### PR TITLE
fix(update): run directory consolidation migration on every dashboard update

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -143,6 +143,21 @@ else
 fi
 
 
+# 6b. Layout Migration (idempotent — _detect_migration_work probes first;
+# no-op on already-consolidated targets, so this is safe to run every update).
+# Runs AFTER rsync (so the latest migrate_to_consolidated_layout is in place)
+# and BEFORE docker compose pull/up (so any data move + .env rewrite is
+# reflected in the next mount).
+if [[ -x "$SCRIPT_DIR/utilities.sh" ]]; then
+    log_info "Running directory consolidation migration..."
+    if ! bash "$SCRIPT_DIR/utilities.sh" migrate; then
+        log_warn "Migration reported issues; continuing — see /var/log/homebrain for details."
+    fi
+    # Migration may have rewritten NEXTCLOUD_DATA_DIR; reload so the
+    # docker compose step below sees the canonical path.
+    load_env
+fi
+
 # 6. Docker Stack Update
 log_info "Updating Docker Stack..."
 cd "${INSTALL_DIR}" || die "Failed to cd to ${INSTALL_DIR}"

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1282,6 +1282,16 @@ migrate_to_consolidated_layout() {
             && [[ -z "$(ls -A "${nc_dir}" 2>/dev/null || true)" ]]; then
             return 0
         fi
+        # Phase E: NEXTCLOUD_DATA_DIR pointing to a non-canonical, populated
+        # path (e.g. legacy /home/admin/nextcloud on non-AI ARM installs, or
+        # any custom location set by an earlier provision).
+        if [[ -n "${NEXTCLOUD_DATA_DIR:-}" ]] \
+            && [[ "${NEXTCLOUD_DATA_DIR}" != "${nc_dir}" ]] \
+            && [[ -d "${NEXTCLOUD_DATA_DIR}" ]] \
+            && [[ -n "$(ls -A "${NEXTCLOUD_DATA_DIR}" 2>/dev/null)" ]] \
+            && [[ -z "$(ls -A "${nc_dir}" 2>/dev/null || true)" ]]; then
+            return 0
+        fi
         return 1
     }
     if _detect_migration_work; then needs_data_move=true; fi
@@ -1472,6 +1482,72 @@ migrate_to_consolidated_layout() {
             rmdir "$legacy_nc" 2>/dev/null || true
         else
             log_warn "Migration D: ${nc_dir} already non-empty; leaving ${legacy_nc} in place. Investigate manually."
+        fi
+    fi
+
+    # --- 5b. Phase E: any non-canonical NEXTCLOUD_DATA_DIR → ${nc_dir} ---
+    # Catches non-AI/legacy deployments where NEXTCLOUD_DATA_DIR points to
+    # /home/admin/nextcloud or any other path. After move: rewrites .env so
+    # docker-compose remounts the canonical path on the next 'up'.
+    #
+    # Idempotent: if .env already points to ${nc_dir}, or source==target, or
+    # source is empty, the block no-ops. If target is non-empty we refuse to
+    # merge and log a warning rather than risk masking data.
+    local current_nc_path="${NEXTCLOUD_DATA_DIR:-}"
+    if [[ -n "$current_nc_path" ]] \
+        && [[ "$current_nc_path" != "$nc_dir" ]] \
+        && [[ -d "$current_nc_path" ]] \
+        && [[ -n "$(ls -A "$current_nc_path" 2>/dev/null)" ]]; then
+        if [[ -n "$(ls -A "$nc_dir" 2>/dev/null || true)" ]]; then
+            log_warn "Migration E: ${nc_dir} already non-empty; leaving ${current_nc_path} in place. Investigate manually."
+        else
+            # Same-filesystem check — only same-FS guarantees atomic mv. A
+            # cross-FS copy would be slow and could leave partial state.
+            local src_dev tgt_dev
+            src_dev=$(stat -c %d "$current_nc_path" 2>/dev/null || echo "")
+            tgt_dev=$(stat -c %d "$(dirname "$nc_dir")" 2>/dev/null || echo "")
+            if [[ -n "$src_dev" ]] && [[ -n "$tgt_dev" ]] && [[ "$src_dev" != "$tgt_dev" ]]; then
+                log_warn "Migration E: ${current_nc_path} and ${nc_dir} are on different filesystems. Skipping auto-move; manual migration required."
+            else
+                log_info "Migration E: Nextcloud data ${current_nc_path} → ${nc_dir}"
+
+                # Stop the container so no in-flight writes occur during move.
+                local nc_container_was_running=false
+                if docker ps --format '{{.Names}}' 2>/dev/null | grep -qx 'homebrain-nextcloud-1'; then
+                    nc_container_was_running=true
+                    log_info "  Stopping homebrain-nextcloud-1 for safe data move..."
+                    docker stop homebrain-nextcloud-1 >/dev/null 2>&1 \
+                        || log_warn "  docker stop failed; mv on same FS is still atomic, continuing."
+                fi
+
+                # Atomic same-FS move of contents into pre-created target dir
+                # (Phase 1 created it; Phase 6 will chown it 33:33).
+                if ! ( shopt -s dotglob nullglob; mv "$current_nc_path"/* "$nc_dir"/ ); then
+                    log_error "  Nextcloud data move failed. NEXTCLOUD_DATA_DIR=${current_nc_path} unchanged."
+                    if [[ "$nc_container_was_running" == "true" ]]; then
+                        docker start homebrain-nextcloud-1 >/dev/null 2>&1 || true
+                    fi
+                    return 1
+                fi
+                rmdir "$current_nc_path" 2>/dev/null || true
+
+                # Persist new path to .env so docker-compose picks it up.
+                update_env_var "NEXTCLOUD_DATA_DIR" "${nc_dir}"
+                log_info "  .env updated: NEXTCLOUD_DATA_DIR=${nc_dir}"
+
+                # Match container UID immediately so a quick restart doesn't EACCES.
+                chown 33:33 "${nc_dir}" 2>/dev/null || true
+
+                # Bring the container back with the new mount. Update.sh will
+                # also do `docker compose up -d` later, but starting here means
+                # standalone callers (utilities.sh migrate, dashboard manual
+                # migrate) leave the system healthy without a follow-up step.
+                if [[ "$nc_container_was_running" == "true" ]]; then
+                    log_info "  Restarting homebrain-nextcloud-1 with new mount..."
+                    ( cd "${INSTALL_DIR}" && docker compose --env-file "${ENV_FILE}" $(get_compose_args) up -d nextcloud ) \
+                        >/dev/null 2>&1 || log_warn "  Nextcloud restart failed; next 'docker compose up' will recover."
+                fi
+            fi
         fi
     fi
 


### PR DESCRIPTION
## Summary
- Wire `bash utilities.sh migrate` into `update.sh` between rsync and the docker compose stack step. The dashboard beta-update path previously skipped migration entirely, so existing deployments never converged on the canonical `/home/homebrain` layout.
- Add **Phase E** to `migrate_to_consolidated_layout`: when `NEXTCLOUD_DATA_DIR` points to a non-canonical, populated path (e.g. `/home/admin/nextcloud` on legacy non-AI ARM installs), stop the Nextcloud container, move data atomically (same-FS only), rewrite `.env`, chown to www-data (33:33), and restart the container.
- Extend `_detect_migration_work` so already-consolidated targets remain a true no-op — no service churn on every deploy.

## Why
Discovered during the RPi5 production beta update: `update.sh` never invoked the migration, so the device kept its pre-existing `/home/admin/nextcloud` layout. Data was preserved (thanks to `.env` preservation in 3fae0f2), but the layout never consolidated. This PR closes that gap for both AI and non-AI devices.

## Robustness
- **Same-FS check** before `mv` — refuses cross-FS rather than risk a slow, interruptible copy.
- **Container stopped** before move — no in-flight writes.
- **Refuses to merge** if the target dir is already populated (warns instead of clobbering).
- **Failure path:** container restarts at OLD path, `.env` unchanged, function returns 1.
- Existing concurrency lock (`/tmp/.hb_migration.lock`) protects against overlapping invocations.

## Test plan
- [ ] Provision fresh x86 AI target → migration runs as no-op (already consolidated).
- [ ] Trigger dashboard beta update on RPi5 (non-AI ARM, `NEXTCLOUD_DATA_DIR=/home/admin/nextcloud`) → Phase E moves data, rewrites `.env`, restarts Nextcloud, container healthy with new mount.
- [ ] Re-run update on the same RPi5 → migration probe returns false, no service churn, no log noise beyond "Layout already consolidated".
- [ ] Verify `status.php` reports `installed:true, maintenance:false` post-migration; spot-check user data integrity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)