### PR TITLE
fix(dashboard): detect USB backup drives when lsblk reports rm as bool

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1022,8 +1022,10 @@ def list_drives():
                 continue
 
             # Layer 2: Skip non-removable drives (RM=0) — internal NVMe/SATA are never removable.
-            rm = str(dev.get("rm", "0")).strip()
-            if rm != "1":
+            # lsblk -J emits `rm` as a JSON bool (true/false) on util-linux >= 2.37
+            # and as a string ("0"/"1") on older versions; accept both.
+            rm = dev.get("rm")
+            if rm not in (True, 1, "1"):
                 continue
 
             # Layer 1 (continued): Skip the disk that contains the root filesystem.


### PR DESCRIPTION
## Summary
- Accept both JSON-bool (`true`) and string (`"1"`) representations of the `rm` field from `lsblk -J`. util-linux ≥ 2.37 changed the encoding, and the old `str(rm) != "1"` check was silently filtering out every removable drive on newer hosts.

## Repro
On Ubuntu 24.04 x86_64 with a SanDisk USB drive plugged in, `lsblk -J` reports `"rm": true`. The dashboard's "Backup Drive Management" panel shows no candidate. Verified on the AI test target (192.168.178.58): `sda` is removable, USB-connected, ext4-formatted whole disk, but never appears.

## Test plan
- [ ] Plug a USB drive into the AI test target, hit `/api/drives`, confirm the device is now listed with `model`, `size`, `is_backup=false`.
- [ ] Format it via the dashboard, mount it at `/mnt/backup`, confirm `is_backup=true` on subsequent calls.
- [ ] Run a full backup → wipe target → re-provision → restore from this drive (covers the broader E2E flow blocked by this bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)