### PR TITLE
fix(update): resolve utilities.sh from INSTALL_DIR after self-reload

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -62,6 +62,11 @@ ensure_homebrain_user() {
         chmod 700 "${HOMEBRAIN_HOME}/.ssh"
         chown -R "${HOMEBRAIN_USER}:${HOMEBRAIN_USER}" "${HOMEBRAIN_HOME}/.ssh"
     fi
+    # On modern Ubuntu, useradd -m creates $HOME with mode 0700, which blocks
+    # other UIDs (notably www-data UID 33 inside the Nextcloud container) from
+    # traversing into bind-mounted subdirs like ${HOME}/nextcloud-data. 0755
+    # exposes only directory traversal; .ssh stays 0700 by its own perms.
+    chmod 0755 "${HOMEBRAIN_HOME}" 2>/dev/null || true
     for grp in docker render video; do
         if getent group "$grp" >/dev/null 2>&1; then
             usermod -aG "$grp" "${HOMEBRAIN_USER}" 2>/dev/null || true

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -148,14 +148,22 @@ fi
 # Runs AFTER rsync (so the latest migrate_to_consolidated_layout is in place)
 # and BEFORE docker compose pull/up (so any data move + .env rewrite is
 # reflected in the next mount).
-if [[ -x "$SCRIPT_DIR/utilities.sh" ]]; then
+#
+# Resolve from INSTALL_DIR, not SCRIPT_DIR: when self-reload exec'd the new
+# update.sh from /tmp/homebrain_self_update, $SCRIPT_DIR points there — and
+# only update.sh + common.sh are downloaded into that dir, so utilities.sh
+# would be missing and migration would silently skip.
+INSTALLED_UTILS="$INSTALL_DIR/scripts/utilities.sh"
+if [[ -x "$INSTALLED_UTILS" ]]; then
     log_info "Running directory consolidation migration..."
-    if ! bash "$SCRIPT_DIR/utilities.sh" migrate; then
+    if ! bash "$INSTALLED_UTILS" migrate; then
         log_warn "Migration reported issues; continuing — see /var/log/homebrain for details."
     fi
     # Migration may have rewritten NEXTCLOUD_DATA_DIR; reload so the
     # docker compose step below sees the canonical path.
     load_env
+else
+    log_warn "utilities.sh missing at $INSTALLED_UTILS — skipping migration."
 fi
 
 # 6. Docker Stack Update

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1298,6 +1298,10 @@ migrate_to_consolidated_layout() {
     unset -f _detect_migration_work
 
     # --- 1. Create canonical target directories (idempotent, harmless) ---
+    # Legacy non-AI ARM installs may still be on the 'admin' user with no
+    # 'homebrain' user yet. Phase 1's `install -d -o homebrain` would fail
+    # with "invalid user" — ensure the user exists first.
+    ensure_homebrain_user
     install -d -o "${HOMEBRAIN_USER}" -g "${HOMEBRAIN_USER}" -m 0755 \
         "${ai_dir}" "${ai_dir}/llama-server" "${ai_dir}/whisper-server" \
         "${ai_dir}/whisper-proxy" "${models_dir}" "${nc_dir}"

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1546,10 +1546,15 @@ migrate_to_consolidated_layout() {
                 # also do `docker compose up -d` later, but starting here means
                 # standalone callers (utilities.sh migrate, dashboard manual
                 # migrate) leave the system healthy without a follow-up step.
+                #
+                # --force-recreate is required: a bare `up -d` reuses the
+                # existing container's bind-mount config and ignores the
+                # rewritten NEXTCLOUD_DATA_DIR, leaving the container mounted
+                # on the now-empty old path.
                 if [[ "$nc_container_was_running" == "true" ]]; then
-                    log_info "  Restarting homebrain-nextcloud-1 with new mount..."
-                    ( cd "${INSTALL_DIR}" && docker compose --env-file "${ENV_FILE}" $(get_compose_args) up -d nextcloud ) \
-                        >/dev/null 2>&1 || log_warn "  Nextcloud restart failed; next 'docker compose up' will recover."
+                    log_info "  Recreating homebrain-nextcloud-1 with new mount..."
+                    ( cd "${INSTALL_DIR}" && docker compose --env-file "${ENV_FILE}" $(get_compose_args) up -d --force-recreate nextcloud ) \
+                        >/dev/null 2>&1 || log_warn "  Nextcloud recreate failed; next 'docker compose up --force-recreate' will recover."
                 fi
             fi
         fi


### PR DESCRIPTION
## Summary
Three bugs surfaced by running the dashboard "beta update" on a real ARM target (`homebrain.local`, 83 GB Nextcloud data at `/home/admin/nextcloud`):

### 1. update.sh self-reload silently skips migration
`exec "$SELF_TMP_DIR/update.sh"` (line 50) makes `$SCRIPT_DIR` resolve to `/tmp/homebrain_self_update`, where only `update.sh`+`common.sh` exist. The migration gate `[[ -x "$SCRIPT_DIR/utilities.sh" ]]` therefore failed silently — Phase E never ran. **Fix:** resolve from `$INSTALL_DIR/scripts` and warn if still missing.

### 2. migrate Phase 1 fails on legacy ARM (no `homebrain` user)
Phase 1 calls `install -d -o homebrain -g homebrain`, which exits non-zero with "invalid user" on devices still running as `admin`. **Fix:** call `ensure_homebrain_user` (idempotent) before Phase 1.

### 3. Phase E `up -d` keeps stale bind mount
After rewriting `NEXTCLOUD_DATA_DIR`, plain `docker compose up -d nextcloud` reused the existing container's mount config and silently kept the now-empty old path. **Fix:** add `--force-recreate`.

### 4. `useradd -m` home dir is mode 0700, blocks www-data traversal
Container's www-data (UID 33) couldn't traverse to `${HOME}/nextcloud-data`. **Fix:** chmod 0755 on `$HOMEBRAIN_HOME` in `ensure_homebrain_user` (.ssh perms unaffected — they're set 0700 explicitly right after).

## E2E Verification
- [x] Pre-state: `homebrain.local` updated to `b12ab1e`, `NEXTCLOUD_DATA_DIR=/home/admin/nextcloud`, no `homebrain` user, dashboard 401 OK.
- [x] Ran fixed `utilities.sh migrate`: created homebrain user, Phase E moved 83 GB atomically, .env rewritten, `--force-recreate` rebuilt the mount.
- [x] `docker exec ... occ status` → `installed: true, maintenance: false`.
- [x] `occ user:list` → `admin`, `OliAidana` (data integrity preserved).
- [x] Re-run idempotency: `_detect_migration_work` returns false, "Layout already consolidated".
- [x] Dashboard `/` returns 401 (login redirect), no template error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)