### PR TITLE
feat(ui): light-mode-default theme with dark toggle and Status/Settings split

### DIFF
--- a/config/platform_models.json
+++ b/config/platform_models.json
@@ -2,16 +2,44 @@
   "default": "Qwen3.6-35B-A3B-UD-Q5_K_XL",
   "models": [
     {
+      "id": "Qwen3.6-35B-A3B-UD-Q4_K_M",
+      "filename": "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+      "min_size_bytes": 21000000000,
+      "context_window": 131072,
+      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[3-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
+      "benchmark": {
+        "tg_ts": 34.41,
+        "pp_ts": 802,
+        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan, llama.cpp b8951"
+      },
+      "default": false
+    },
+    {
+      "id": "Qwen3.6-35B-A3B-UD-Q5_K_M",
+      "filename": "Qwen3.6-35B-A3B-UD-Q5_K_M.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q5_K_M.gguf",
+      "min_size_bytes": 26000000000,
+      "context_window": 131072,
+      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
+      "benchmark": {
+        "tg_ts": null,
+        "pp_ts": null,
+        "measured_on": "pending"
+      },
+      "default": false
+    },
+    {
       "id": "Qwen3.6-35B-A3B-UD-Q5_K_XL",
       "filename": "Qwen3.6-35B-A3B-UD-Q5_K_XL.gguf",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q5_K_XL.gguf",
       "min_size_bytes": 26000000000,
       "context_window": 131072,
-      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 2048 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
+      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
-        "tg_ts": 29.67,
-        "pp_ts": 574,
-        "measured_on": "AMD RX 9060 XT, i5 6-core, Vulkan, llama.cpp b8931"
+        "tg_ts": 29.23,
+        "pp_ts": 751,
+        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan, llama.cpp b8951"
       },
       "default": true
     },
@@ -21,11 +49,11 @@
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q6_K.gguf",
       "min_size_bytes": 29000000000,
       "context_window": 131072,
-      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(1[8-9]|2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 2048 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
+      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(1[8-9]|2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
         "tg_ts": 27.18,
-        "pp_ts": 513,
-        "measured_on": "AMD RX 9060 XT, i5 6-core, Vulkan, llama.cpp b8931"
+        "pp_ts": 689,
+        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan, llama.cpp b8951"
       },
       "default": false
     },
@@ -35,11 +63,11 @@
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q6_K_XL.gguf",
       "min_size_bytes": 31000000000,
       "context_window": 131072,
-      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(1[6-9]|2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 2048 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
+      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(1[6-9]|2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
-        "tg_ts": 25.62,
-        "pp_ts": 485,
-        "measured_on": "AMD RX 9060 XT, i5 6-core, Vulkan, llama.cpp b8931"
+        "tg_ts": 25.38,
+        "pp_ts": 643,
+        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan, llama.cpp b8951"
       },
       "default": false
     },
@@ -51,9 +79,10 @@
       "context_window": 131072,
       "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(1[4-9]|2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 2048 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
-        "tg_ts": 18.03,
+        "tg_ts": 17.96,
         "pp_ts": 140,
-        "measured_on": "AMD RX 9060 XT, i5 6-core, Vulkan, llama.cpp b8931"
+        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan, llama.cpp b8951",
+        "notes": "Keeps -ub 2048; -ub 4096 pushes VRAM to 99.8% and regresses both TG and PP."
       },
       "default": false
     },
@@ -67,8 +96,8 @@
       "benchmark": {
         "tg128_ts": 14.2,
         "pp512_ts": 385,
-        "measured_on": "AMD RX 9060 XT, i5 6-core, DDR4-2400, Vulkan, ngl=99",
-        "notes": "Hybrid DeltaNet SSM+attn (16/64 standard attn layers, 48 DeltaNet). RS must stay GPU-local \u2014 nkvo breaks DeltaNet fused kernel (garbage output). ngl<99 drops to ~2 t/s; partial offload defeats DeltaNet GPU fusion. fa=on + ctk/ctv q8_0 (Group C): tg128 +6.5% (13.33\u219214.20 t/s), pp halved at ub=128 vs fa-only but still fast at ub=512 production setting. ctv q8_0 saves 640 MiB VRAM enabling ctx=65536 vs the 40960 cap without it. ctv q8_0 without fa fails context creation on AMD Vulkan. Real overflow errors at 53966 and 51804 tokens observed; ctx=65536 with Group C loads cleanly."
+        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, DDR4, Vulkan, ngl=99",
+        "notes": "Hybrid DeltaNet SSM+attn (16/64 standard attn layers, 48 DeltaNet). RS must stay GPU-local — nkvo breaks DeltaNet fused kernel (garbage output). ngl<99 drops to ~2 t/s; partial offload defeats DeltaNet GPU fusion. fa=on + ctk/ctv q8_0 (Group C): tg128 +6.5% (13.33→14.20 t/s), pp halved at ub=128 vs fa-only but still fast at ub=512 production setting. ctv q8_0 saves 640 MiB VRAM enabling ctx=65536 vs the 40960 cap without it. ctv q8_0 without fa fails context creation on AMD Vulkan. Real overflow errors at 53966 and 51804 tokens observed; ctx=65536 with Group C loads cleanly."
       },
       "default": false
     }

--- a/src/templates/_theme.html
+++ b/src/templates/_theme.html
@@ -1,0 +1,341 @@
+{# HomeBrain shared theme — light (default) + dark mode tokens.
+   Include in <head> of every page. Provides:
+     - FOUC-safe inline init script that reads localStorage('hb-theme')
+     - Semantic CSS custom properties for both modes
+     - Backwards-compat aliases for the legacy --hb-* names
+     - Polished theme toggle (rendered via theme_toggle macro below)
+#}
+<script>
+  // FOUC-safe theme bootstrap. Runs before stylesheet to set data-theme.
+  (function () {
+    try {
+      var stored = localStorage.getItem('hb-theme');
+      var theme = (stored === 'dark' || stored === 'light') ? stored : 'light';
+      document.documentElement.setAttribute('data-theme', theme);
+    } catch (e) {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
+
+<style>
+  /* =====================================================================
+     HomeBrain Theme Tokens
+     Light = default, Dark = opt-in via [data-theme="dark"]
+     ===================================================================== */
+
+  :root,
+  :root[data-theme="light"] {
+    /* Surfaces */
+    --bg:            #f4f6f3;       /* page background, warm off-white */
+    --bg-grid:       rgba(15, 24, 19, 0.04);  /* subtle scanline overlay */
+    --surface:       #ffffff;       /* card surface */
+    --surface-2:     #f1f4ee;       /* nested panel (preview boxes, drive rows) */
+    --surface-sunken:#fbfcf9;       /* inputs, selects */
+    --console-bg:    #0c100e;       /* log/console — stays dark for techy vibe */
+    --console-fg:    #7eebab;       /* phosphor green */
+    --console-border:#1d2522;
+    --console-shadow:inset 0 0 18px rgba(0, 0, 0, 0.65);
+
+    /* Text */
+    --text:          #0f1813;
+    --text-strong:   #000000;
+    --text-dim:      #5b6660;
+    --text-faint:    #8a948e;
+    --text-on-accent:#08130d;
+
+    /* Lines */
+    --border:        #d6dbd3;
+    --border-strong: #b9c0b6;
+    --border-soft:   #e3e7df;
+    --hairline:      rgba(15, 24, 19, 0.08);
+
+    /* Accent (HomeBrain green) */
+    --accent:        #16a34a;
+    --accent-hover:  #128039;
+    --accent-soft:   rgba(22, 163, 74, 0.10);
+    --accent-ring:   rgba(22, 163, 74, 0.28);
+    --accent-glow:   0 4px 18px rgba(22, 163, 74, 0.18);
+
+    /* Status palette */
+    --danger:        #b91c1c;
+    --danger-fg:     #ffffff;
+    --danger-soft:   rgba(185, 28, 28, 0.10);
+    --warning:       #b45309;
+    --warning-soft:  rgba(180, 83, 9, 0.12);
+    --info:          #1d4ed8;
+    --info-soft:     rgba(29, 78, 216, 0.10);
+    --neutral:       #5b6660;
+    --neutral-soft:  rgba(91, 102, 96, 0.12);
+
+    /* Buttons */
+    --btn-bg:        #ffffff;
+    --btn-bg-hover:  #f1f3ee;
+    --btn-border:    #c8cdc3;
+    --btn-fg:        #1a221d;
+
+    /* Effects */
+    --shadow-card:   0 1px 0 rgba(15,24,19,0.02), 0 6px 24px rgba(15,24,19,0.06);
+    --shadow-pop:    0 1px 0 rgba(15,24,19,0.04), 0 12px 36px rgba(15,24,19,0.10);
+    --radius-card:   12px;
+    --radius-input:  8px;
+    --radius-pill:   999px;
+
+    /* Fonts */
+    --font-ui:       'Inter', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    --font-mono:     'JetBrains Mono', 'SF Mono', 'Consolas', 'Monaco', ui-monospace, monospace;
+
+    color-scheme: light;
+  }
+
+  :root[data-theme="dark"] {
+    --bg:            #0e1311;
+    --bg-grid:       rgba(255, 255, 255, 0.025);
+    --surface:       #181d1a;
+    --surface-2:     #202622;
+    --surface-sunken:#262d29;
+    --console-bg:    #05080a;
+    --console-fg:    #8df0b0;
+    --console-border:#1b211e;
+    --console-shadow:inset 0 0 18px rgba(0, 0, 0, 0.85);
+
+    --text:          #e8ede9;
+    --text-strong:   #ffffff;
+    --text-dim:      #9aa39d;
+    --text-faint:    #6e7872;
+    --text-on-accent:#06120a;
+
+    --border:        #2a3128;
+    --border-strong: #3b433f;
+    --border-soft:   #232a27;
+    --hairline:      rgba(255, 255, 255, 0.06);
+
+    --accent:        #2ecc71;
+    --accent-hover:  #27b765;
+    --accent-soft:   rgba(46, 204, 113, 0.12);
+    --accent-ring:   rgba(46, 204, 113, 0.32);
+    --accent-glow:   0 4px 22px rgba(46, 204, 113, 0.22);
+
+    --danger:        #ef4444;
+    --danger-fg:     #ffffff;
+    --danger-soft:   rgba(239, 68, 68, 0.12);
+    --warning:       #f59e0b;
+    --warning-soft:  rgba(245, 158, 11, 0.14);
+    --info:          #60a5fa;
+    --info-soft:     rgba(96, 165, 250, 0.14);
+    --neutral:       #9aa39d;
+    --neutral-soft:  rgba(154, 163, 157, 0.14);
+
+    --btn-bg:        #232925;
+    --btn-bg-hover:  #2c332e;
+    --btn-border:    #3a423d;
+    --btn-fg:        #e8ede9;
+
+    --shadow-card:   0 1px 0 rgba(0,0,0,0.20), 0 8px 28px rgba(0,0,0,0.45);
+    --shadow-pop:    0 1px 0 rgba(0,0,0,0.30), 0 16px 48px rgba(0,0,0,0.55);
+
+    color-scheme: dark;
+  }
+
+  /* ---- Legacy aliases (preserve --hb-* references already in templates) ---- */
+  :root {
+    --hb-green:        var(--accent);
+    --hb-green-hover:  var(--accent-hover);
+    --hb-bg:           var(--bg);
+    --hb-card:         var(--surface);
+    --hb-card-bg:      var(--surface);
+    --hb-border:       var(--border);
+    --hb-text:         var(--text);
+    --hb-text-main:    var(--text);
+    --hb-text-dim:     var(--text-dim);
+    --hb-danger:       var(--danger);
+    --hb-danger-hover: var(--danger);
+    --hb-warning:      var(--warning);
+    --text-muted:      var(--text-dim);
+
+    /* Pin water.css variables so the OS prefers-color-scheme cannot bleed in */
+    --background-body: var(--bg);
+    --background:      var(--surface);
+    --background-alt:  var(--surface-2);
+    --text-main:       var(--text);
+    --text-bright:     var(--text-strong);
+    --links:           var(--accent);
+    --focus:           var(--accent-ring);
+    --border:          var(--border);
+    --code:            var(--accent);
+    --button-base:     var(--btn-bg);
+    --button-hover:    var(--btn-bg-hover);
+    --form-placeholder:var(--text-faint);
+    --form-text:       var(--text);
+    --variable:        var(--accent);
+    --highlight:       var(--warning-soft);
+    --select-text:     var(--text-strong);
+    --select-bg:       var(--accent-soft);
+    --scrollbar-thumb: var(--border-strong);
+    --scrollbar-thumb-hover: var(--text-faint);
+  }
+
+  /* =====================================================================
+     Global base
+     ===================================================================== */
+  html, body {
+    background: var(--bg);
+    color: var(--text);
+  }
+
+  body {
+    font-family: var(--font-ui);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    transition: background-color 220ms ease, color 220ms ease;
+  }
+
+  /* Smooth-but-snappy theme cross-fade on token-driven elements */
+  body, .card, .surface, .drive-row, button, input, select, textarea, .status-badge, .log-box, .progress-bg {
+    transition: background-color 220ms ease, color 220ms ease, border-color 220ms ease, box-shadow 220ms ease;
+  }
+
+  ::selection { background: var(--accent-soft); color: var(--text-strong); }
+
+  /* =====================================================================
+     Theme toggle (pill switch in headers)
+     ===================================================================== */
+  .theme-toggle {
+    --t-h: 30px;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    height: var(--t-h);
+    padding: 0 4px 0 4px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill);
+    cursor: pointer;
+    box-shadow: var(--shadow-card);
+    color: var(--text-dim);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    user-select: none;
+    transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+  }
+  .theme-toggle:hover { border-color: var(--accent); box-shadow: var(--accent-glow); }
+  .theme-toggle:focus-visible { outline: 2px solid var(--accent-ring); outline-offset: 2px; }
+
+  .theme-toggle .tt-icon {
+    width: 22px; height: 22px;
+    display: inline-flex; align-items: center; justify-content: center;
+    border-radius: 999px;
+    color: var(--text-faint);
+    transition: color 200ms ease, background 200ms ease, transform 300ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+  .theme-toggle .tt-icon svg { width: 14px; height: 14px; }
+  :root[data-theme="light"] .theme-toggle .tt-sun { color: var(--accent); background: var(--accent-soft); }
+  :root[data-theme="dark"]  .theme-toggle .tt-moon { color: var(--accent); background: var(--accent-soft); }
+  :root[data-theme="dark"]  .theme-toggle .tt-sun  { transform: rotate(-30deg); }
+  :root[data-theme="light"] .theme-toggle .tt-moon { transform: rotate( 30deg); }
+
+  /* Floating variant — used on welcome/installing where there's no header */
+  .theme-toggle.floating {
+    position: fixed;
+    top: 16px;
+    right: 16px;
+    z-index: 100;
+  }
+
+  /* =====================================================================
+     Form controls in light mode look correct
+     ===================================================================== */
+  input, select, textarea {
+    background: var(--surface-sunken);
+    color: var(--text);
+    border-color: var(--border-strong);
+  }
+  input::placeholder, textarea::placeholder { color: var(--text-faint); }
+  input:focus, select:focus, textarea:focus {
+    border-color: var(--accent);
+    outline: 0;
+    box-shadow: 0 0 0 3px var(--accent-ring);
+  }
+
+  /* Override water.css link/heading colors for both modes */
+  a { color: var(--accent); }
+  a:hover { color: var(--accent-hover); }
+  h1, h2, h3, h4, h5, h6 { color: var(--text-strong); }
+  hr { border: 0; height: 1px; background: var(--border); }
+
+  /* Code-ish */
+  code, pre, kbd, samp { font-family: var(--font-mono); }
+
+  /* Custom checkbox accent */
+  input[type="checkbox"], input[type="radio"] { accent-color: var(--accent); }
+
+  /* =====================================================================
+     Skeleton loaders — replace literal "..." placeholders
+     ===================================================================== */
+  @keyframes hb-shimmer {
+    0%   { background-position: -200px 0; }
+    100% { background-position: 200px 0; }
+  }
+  .skeleton {
+    display: inline-block;
+    height: 0.9em;
+    width: 64px;
+    border-radius: 4px;
+    vertical-align: middle;
+    background: linear-gradient(90deg, var(--surface-sunken) 0%, var(--surface-2) 50%, var(--surface-sunken) 100%);
+    background-size: 400px 100%;
+    animation: hb-shimmer 1.4s ease-in-out infinite;
+  }
+  .skeleton.sk-wide  { width: 110px; }
+  .skeleton.sk-mid   { width: 80px; }
+  .skeleton.sk-small { width: 48px; height: 0.8em; }
+
+  /* =====================================================================
+     Empty state — used for inactive sections
+     ===================================================================== */
+  .empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 36px 20px;
+    color: var(--text-dim);
+    border: 1px dashed var(--border-strong);
+    border-radius: var(--radius-input);
+    background: var(--surface-2);
+    gap: 10px;
+  }
+  .empty-state .empty-icon {
+    width: 38px; height: 38px;
+    display: inline-flex; align-items: center; justify-content: center;
+    border-radius: 999px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--text-faint);
+  }
+  .empty-state .empty-icon svg { width: 20px; height: 20px; }
+  .empty-state h4 {
+    margin: 0;
+    color: var(--text-strong);
+    font-weight: 600;
+    font-size: 1em;
+  }
+  .empty-state p {
+    margin: 0;
+    font-size: 0.9em;
+    max-width: 38ch;
+  }
+</style>
+
+<script>
+  function hbToggleTheme() {
+    var cur = document.documentElement.getAttribute('data-theme') || 'light';
+    var next = cur === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    try { localStorage.setItem('hb-theme', next); } catch (e) {}
+  }
+</script>

--- a/src/templates/_theme_toggle.html
+++ b/src/templates/_theme_toggle.html
@@ -1,0 +1,18 @@
+{# Theme toggle button. Pass `floating=True` for fixed-position variant. #}
+<button type="button"
+        class="theme-toggle{% if floating|default(false) %} floating{% endif %}"
+        onclick="hbToggleTheme()"
+        aria-label="Toggle light / dark theme"
+        title="Toggle theme">
+  <span class="tt-icon tt-sun" aria-hidden="true">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="4"/>
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
+    </svg>
+  </span>
+  <span class="tt-icon tt-moon" aria-hidden="true">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z"/>
+    </svg>
+  </span>
+</button>

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -1,30 +1,15 @@
 <!DOCTYPE html>
-<html>
+<html data-theme="light">
 <head>
     <title>{{ platform.product_name }} Dashboard</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
+    {% include '_theme.html' %}
     <style>
-        :root {
-            --hb-green: #2ecc71;
-            --hb-green-hover: #27ae60;
-            --hb-bg: #121212;
-            --hb-card: #1e1e1e;
-            --hb-border: #333;
-            --hb-text-main: #eee;
-            --hb-text-dim: #aaa;
-            --hb-danger: #c0392b;
-            --hb-danger-hover: #e74c3c;
-            --hb-warning: #f39c12;
-        }
-
         body {
             max-width: 1100px;
             margin: 0 auto;
             padding: 20px;
-            background-color: var(--hb-bg);
-            color: var(--hb-text-main);
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
             line-height: 1.6;
         }
 
@@ -33,32 +18,60 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
-            border-bottom: 1px solid var(--hb-border);
+            border-bottom: 1px solid var(--border);
             padding-bottom: 20px;
             margin-bottom: 30px;
+            gap: 16px;
         }
 
         .logo {
             font-size: 2em;
             font-weight: 300;
             letter-spacing: -1px;
-            color: #fff;
+            color: var(--text-strong);
             margin: 0;
             line-height: 1;
         }
-        .logo span { color: var(--hb-green); font-weight: 700; }
-        .logo small { font-size: 0.4em; color: var(--hb-text-dim); font-weight: 400; letter-spacing: 0; display: block; margin-top: 4px; }
+        .logo span { color: var(--accent); font-weight: 700; }
+        .logo small {
+            font-size: 0.4em;
+            color: var(--text-dim);
+            font-weight: 400;
+            letter-spacing: 1px;
+            display: block;
+            margin-top: 4px;
+            font-family: var(--font-mono);
+            text-transform: uppercase;
+        }
 
-        .header-status { text-align: right; }
-        .global-status { font-weight: bold; color: var(--hb-green); font-size: 1.1em; }
-        .provider-mode { font-size: 0.85em; color: var(--hb-text-dim); margin-top: 4px; }
+        .header-status { text-align: right; display: flex; flex-direction: column; align-items: flex-end; gap: 6px; }
+        .header-actions { display: flex; align-items: center; gap: 12px; }
+        .global-status {
+            font-weight: 500;
+            color: var(--text-dim);
+            font-size: 0.9em;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+        }
+        .global-status::before {
+            content: "";
+            width: 8px; height: 8px;
+            border-radius: 999px;
+            background: var(--accent);
+            box-shadow: 0 0 0 3px var(--accent-soft);
+        }
+        .global-status[data-state="busy"]::before { background: var(--warning); box-shadow: 0 0 0 3px var(--warning-soft); animation: hb-pulse 1.4s ease-in-out infinite; }
+        .global-status[data-state="error"]::before { background: var(--danger);  box-shadow: 0 0 0 3px var(--danger-soft); }
+        @keyframes hb-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
+        .provider-mode { font-size: 0.8em; color: var(--text-faint); }
 
         /* --- Navigation Tabs --- */
         .tabs {
             display: flex;
-            gap: 15px;
+            gap: 6px;
             margin-bottom: 25px;
-            border-bottom: 1px solid var(--hb-border);
+            border-bottom: 1px solid var(--border);
             padding-bottom: 0;
             flex-wrap: wrap;
         }
@@ -66,23 +79,23 @@
         .tab-btn {
             background: transparent;
             border: none;
-            padding: 12px 20px;
+            padding: 12px 18px;
             cursor: pointer;
-            color: var(--hb-text-dim);
-            font-weight: 600;
-            font-size: 1em;
-            transition: all 0.2s ease;
+            color: var(--text-dim);
+            font-weight: 500;
+            font-size: 0.95em;
+            transition: color 0.18s ease, border-color 0.18s ease;
             position: relative;
             top: 1px;
-            border-bottom: 3px solid transparent;
-            border-radius: 4px 4px 0 0;
+            border-bottom: 2px solid transparent;
+            font-family: var(--font-ui);
         }
 
-        .tab-btn:hover { color: #fff; background: rgba(255,255,255,0.05); }
+        .tab-btn:hover { color: var(--text-strong); }
         .tab-btn.active {
-            color: var(--hb-green);
-            border-bottom: 3px solid var(--hb-green);
-            background: linear-gradient(to top, rgba(46, 204, 113, 0.1), transparent);
+            color: var(--text-strong);
+            border-bottom: 2px solid var(--accent);
+            font-weight: 600;
         }
 
         .tab-content { display: none; animation: fadeIn 0.4s ease-out; }
@@ -92,180 +105,345 @@
         /* --- Cards & Grid --- */
         .grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
-            gap: 25px;
+            grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+            gap: 22px;
         }
 
         .card {
-            background: var(--hb-card);
+            background: var(--surface);
             padding: 25px;
-            border-radius: 12px;
-            border: 1px solid #2a2a2a;
-            box-shadow: 0 4px 20px rgba(0,0,0,0.2);
-            transition: transform 0.2s;
+            border-radius: var(--radius-card);
+            border: 1px solid var(--border);
+            box-shadow: var(--shadow-card);
+            transition: transform 0.2s, border-color 0.2s, box-shadow 0.2s;
         }
-        .card:hover { border-color: #444; }
+        .card:hover { border-color: var(--border-strong); }
 
         .card h3 {
             margin-top: 0;
-            margin-bottom: 20px;
-            font-size: 1.3em;
-            color: #fff;
+            margin-bottom: 18px;
+            font-size: 1.05em;
+            color: var(--text-strong);
             font-weight: 600;
-            border-bottom: 1px solid #333;
-            padding-bottom: 12px;
+            padding-bottom: 0;
             display: flex;
             align-items: center;
             justify-content: space-between;
+            gap: 10px;
+            font-family: var(--font-ui);
+            letter-spacing: -0.1px;
         }
 
-        .card p { font-size: 0.95em; color: #ccc; margin-bottom: 15px; }
+        .card p { font-size: 0.95em; color: var(--text); margin-bottom: 15px; }
 
         /* --- Buttons & Inputs --- */
         button {
-            background-color: #333;
-            color: #fff;
-            border: 1px solid #444;
-            padding: 10px 18px;
-            border-radius: 6px;
+            background-color: var(--btn-bg);
+            color: var(--btn-fg);
+            border: 1px solid var(--btn-border);
+            padding: 9px 16px;
+            border-radius: var(--radius-input);
             cursor: pointer;
             font-weight: 500;
-            transition: all 0.2s;
+            transition: background-color 0.18s, border-color 0.18s, transform 0.18s, box-shadow 0.18s, color 0.18s;
             font-size: 0.9em;
+            font-family: var(--font-ui);
         }
-        button:hover { background-color: #444; border-color: #666; transform: translateY(-1px); }
+        button:hover { background-color: var(--btn-bg-hover); border-color: var(--accent); transform: translateY(-1px); }
         button:active { transform: translateY(0); }
-        button:disabled { opacity: 0.6; cursor: not-allowed; transform: none; }
+        button:disabled { opacity: 0.55; cursor: not-allowed; transform: none; }
 
         .btn-primary {
-            background-color: var(--hb-green);
-            color: #000;
+            background-color: var(--accent);
+            color: var(--text-on-accent);
             font-weight: 700;
-            border: none;
-            box-shadow: 0 2px 10px rgba(46, 204, 113, 0.2);
+            border: 1px solid var(--accent);
+            box-shadow: var(--accent-glow);
         }
-        .btn-primary:hover { background-color: var(--hb-green-hover); box-shadow: 0 4px 15px rgba(46, 204, 113, 0.3); }
+        .btn-primary:hover { background-color: var(--accent-hover); border-color: var(--accent-hover); color: var(--text-on-accent); box-shadow: 0 6px 22px var(--accent-ring); }
 
-        .btn-danger { background-color: var(--hb-danger); color: white; border: none; }
-        .btn-danger:hover { background-color: var(--hb-danger-hover); }
+        .btn-danger { background-color: var(--danger); color: var(--danger-fg); border: 1px solid var(--danger); }
+        .btn-danger:hover { background-color: var(--danger); filter: brightness(1.1); border-color: var(--danger); color: var(--danger-fg); }
 
-        .btn-warning { background-color: rgba(243, 156, 18, 0.2); color: var(--hb-warning); border: 1px solid var(--hb-warning); }
-        .btn-warning:hover { background-color: var(--hb-warning); color: #121212; }
+        .btn-warning { background-color: var(--warning-soft); color: var(--warning); border: 1px solid var(--warning); }
+        .btn-warning:hover { background-color: var(--warning); color: #fff; border-color: var(--warning); }
 
-        input, select {
-            background: #2a2a2a;
-            color: #fff;
-            border: 1px solid #444;
-            padding: 10px;
-            border-radius: 6px;
+        input, select, textarea {
+            padding: 10px 12px;
+            border-radius: var(--radius-input);
             width: 100%;
             margin-bottom: 15px;
             font-size: 0.95em;
-            box-sizing: border-box; /* Fix width issues */
+            box-sizing: border-box;
+            border: 1px solid var(--border-strong);
+            font-family: var(--font-ui);
         }
-        input:focus, select:focus { border-color: var(--hb-green); outline: none; }
 
         label {
-            color: var(--hb-text-dim);
+            color: var(--text-dim);
             font-size: 0.85em;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
+            font-weight: 500;
             margin-bottom: 6px;
             display: block;
+            font-family: var(--font-ui);
         }
 
         /* --- Specific UI Elements --- */
         .status-badge {
-            padding: 4px 10px;
-            border-radius: 50px;
-            font-weight: 700;
-            text-transform: uppercase;
-            font-size: 0.7em;
-            letter-spacing: 1px;
+            padding: 3px 10px;
+            border-radius: var(--radius-pill);
+            font-weight: 500;
+            font-size: 0.78em;
             display: inline-block;
+            font-family: var(--font-ui);
         }
-        .status-running { background: rgba(46, 204, 113, 0.15); color: var(--hb-green); border: 1px solid rgba(46, 204, 113, 0.3); }
-        .status-stopped { background: rgba(231, 76, 60, 0.15); color: #e74c3c; border: 1px solid rgba(231, 76, 60, 0.3); }
-        .status-unknown { background: #333; color: #aaa; border: 1px solid #444; }
-        .status-starting { background: rgba(243, 156, 18, 0.15); color: var(--hb-warning); border: 1px solid rgba(243, 156, 18, 0.3); }
+        .status-running  { background: var(--accent-soft);  color: var(--accent);  border: 1px solid var(--accent-ring); }
+        .status-stopped  { background: var(--danger-soft);  color: var(--danger);  border: 1px solid var(--danger); }
+        .status-unknown  { background: var(--neutral-soft); color: var(--text-dim);border: 1px solid var(--border-strong); }
+        .status-starting { background: var(--warning-soft); color: var(--warning); border: 1px solid var(--warning); }
 
         .progress-bg {
-            background: #2a2a2a;
-            height: 24px;
+            background: var(--surface-sunken);
+            height: 22px;
             border-radius: 12px;
             overflow: hidden;
             margin-top: 8px;
             position: relative;
-            box-shadow: inset 0 1px 3px rgba(0,0,0,0.3);
+            border: 1px solid var(--hairline);
+            box-shadow: inset 0 1px 2px rgba(0,0,0,0.06);
         }
         .progress-fill {
-            background: var(--hb-green);
+            background: linear-gradient(90deg, var(--accent), var(--accent-hover));
             height: 100%;
             width: 0%;
-            transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+            transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1), background-color 0.3s;
         }
         .progress-text {
             position: absolute;
             width: 100%;
             text-align: center;
             top: 0;
-            font-size: 0.8em;
-            font-weight: bold;
-            line-height: 24px;
-            color: #fff;
-            text-shadow: 0 1px 2px rgba(0,0,0,0.8);
+            font-size: 0.78em;
+            font-weight: 700;
+            line-height: 22px;
+            color: var(--text-strong);
+            text-shadow:
+                0 0 2px var(--surface),
+                0 0 6px var(--surface);
             z-index: 2;
+            font-family: var(--font-mono);
+            letter-spacing: 0.5px;
         }
 
         .log-box {
-            background: #000;
-            color: #aaddaa;
-            font-family: 'Consolas', 'Monaco', monospace;
+            background: var(--console-bg);
+            color: var(--console-fg);
+            font-family: var(--font-mono);
             height: 400px;
             overflow-y: scroll;
             padding: 15px;
-            border-radius: 8px;
+            border-radius: var(--radius-card);
             font-size: 13px;
-            border: 1px solid #333;
-            box-shadow: inset 0 0 15px rgba(0,0,0,0.5);
-            line-height: 1.4;
+            border: 1px solid var(--console-border);
+            box-shadow: var(--console-shadow);
+            line-height: 1.45;
         }
 
         .log-line { margin-bottom: 2px; }
-        .log-error { color: #ff6b6b; font-weight: bold; }
-        .log-warning { color: #feca57; }
-        .log-info { color: #aaddaa; }
-        .log-debug { color: #54a0ff; }
+        .log-error { color: #ff8a8a; font-weight: bold; }
+        .log-warning { color: #f5d76e; }
+        .log-info { color: var(--console-fg); }
+        .log-debug { color: #82b6ff; }
 
         .stat-item {
             display: flex;
             justify-content: space-between;
             align-items: center;
             padding: 8px 0;
-            border-bottom: 1px solid rgba(255,255,255,0.05);
+            border-bottom: 1px solid var(--hairline);
         }
         .stat-item:last-child { border-bottom: none; }
-        .stat-item span:first-child { color: var(--hb-text-dim); }
-        .stat-item span:last-child { font-family: 'Consolas', monospace; color: #fff; }
+        .stat-item span:first-child { color: var(--text-dim); }
+        .stat-item span:last-child { font-family: var(--font-mono); color: var(--text-strong); font-size: 0.95em; }
 
-        table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
-        th { text-align: left; padding: 10px; color: var(--hb-text-dim); border-bottom: 2px solid #333; font-weight: 600; text-transform: uppercase; font-size: 0.8em;}
-        td { padding: 12px 10px; border-bottom: 1px solid #333; vertical-align: middle; }
+        table { width: 100%; border-collapse: collapse; font-size: 0.9em; background: transparent; }
+        tr, thead, tbody { background: transparent; }
+        th { text-align: left; padding: 10px; color: var(--text-dim); border-bottom: 1px solid var(--border); font-weight: 500; font-size: 0.85em; background: transparent; }
+        td { padding: 12px 10px; border-bottom: 1px solid var(--hairline); vertical-align: middle; color: var(--text); background: transparent; }
         tr:last-child td { border-bottom: none; }
-        tr:hover td { background: rgba(255,255,255,0.02); }
+        tr:hover td { background: var(--accent-soft); }
 
-        hr { border: 0; height: 1px; background: #333; margin: 20px 0; }
+        hr { border: 0; height: 1px; background: var(--border); margin: 20px 0; }
 
         .drive-row {
             display: flex;
             justify-content: space-between;
             align-items: center;
-            background: #2a2a2a;
-            padding: 15px;
+            background: var(--surface-2);
+            padding: 14px 16px;
             margin-bottom: 10px;
-            border-radius: 8px;
-            border: 1px solid #333;
+            border-radius: var(--radius-input);
+            border: 1px solid var(--border);
+        }
+
+        /* Inline notices */
+        .notice {
+            padding: 12px 14px;
+            border-radius: var(--radius-input);
+            font-size: 0.92em;
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
+            color: var(--text);
+        }
+        .notice-danger { border-left-color: var(--danger); background: var(--danger-soft); }
+        .notice-danger strong { color: var(--danger); }
+        .notice-warning { border-left-color: var(--warning); background: var(--warning-soft); }
+        .notice-warning strong { color: var(--warning); }
+
+        /* Tunnel/preview info panel */
+        .info-panel {
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
+            padding: 14px 16px;
+            border-radius: var(--radius-input);
+            font-family: var(--font-mono);
+            font-size: 0.86em;
+            color: var(--text);
+        }
+
+        /* Provider/active mode chips reused via inline style — keep CSS classes too */
+        .chip {
+            display: inline-block;
+            padding: 3px 10px;
+            border-radius: var(--radius-pill);
+            font-size: 0.78em;
+            font-family: var(--font-mono);
+            letter-spacing: 0.5px;
+            white-space: nowrap;
+        }
+        .chip-local { background: var(--accent-soft); border: 1px solid var(--accent); color: var(--accent); }
+        .chip-remote{ background: var(--info-soft);   border: 1px solid var(--info);   color: var(--info); }
+
+        /* Side-by-side rows inside a wide card */
+        .updates-row {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 22px;
+        }
+        @media (max-width: 720px) {
+            .updates-row { grid-template-columns: 1fr; }
+        }
+
+        .ftp-row {
+            display: grid;
+            grid-template-columns: 1.3fr 1fr;
+            gap: 30px;
+            align-items: start;
+        }
+        @media (max-width: 880px) {
+            .ftp-row { grid-template-columns: 1fr; }
+        }
+
+        /* Compact list rows used in cards (replaces 2-col tables for status lists) */
+        .row-list { display: flex; flex-direction: column; }
+        .row-item {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 14px;
+            padding: 12px 0;
+            border-bottom: 1px solid var(--hairline);
+        }
+        .row-item:last-child { border-bottom: none; }
+        .row-main {
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+            min-width: 0;
+        }
+        .row-main strong {
+            color: var(--text-strong);
+            font-weight: 600;
+            font-size: 0.95em;
+        }
+        .row-meta {
+            font-size: 0.82em;
+            color: var(--text-dim);
+            font-family: var(--font-mono);
+        }
+
+        /* External-launch link buttons (low emphasis vs .btn-primary) */
+        .link-row {
+            display: flex;
+            gap: 10px;
+            margin-top: 18px;
+            flex-wrap: wrap;
+        }
+        .link-out {
+            flex: 1 1 0;
+            min-width: 0;
+            display: inline-flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 10px;
+            padding: 10px 14px;
+            background: var(--surface-2);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-input);
+            color: var(--text-strong);
+            font-weight: 500;
+            font-size: 0.92em;
+            text-decoration: none;
+            transition: border-color 0.18s, color 0.18s, transform 0.18s, background 0.18s;
+        }
+        .link-out:hover {
+            border-color: var(--accent);
+            color: var(--accent);
+            background: var(--accent-soft);
+            transform: translateY(-1px);
+        }
+        .link-out span { color: var(--text-faint); transition: color 0.18s, transform 0.18s; font-size: 1.1em; }
+        .link-out:hover span { color: var(--accent); transform: translate(2px, -2px); }
+
+        /* Generic badge classes used by OpenClaw card */
+        .badge {
+            display: inline-block;
+            padding: 3px 10px;
+            border-radius: var(--radius-pill);
+            font-size: 0.78em;
+            font-weight: 500;
+        }
+        .badge-muted   { background: var(--neutral-soft); color: var(--text-dim); border: 1px solid var(--border-strong); }
+        .badge-success { background: var(--accent-soft);  color: var(--accent);   border: 1px solid var(--accent); }
+        .badge-danger  { background: var(--danger-soft);  color: var(--danger);   border: 1px solid var(--danger); }
+        .stat-row { display: flex; justify-content: space-between; align-items: center; padding: 6px 0; }
+        .stat-label { color: var(--text-dim); }
+        .card-header { margin-bottom: 12px; }
+        .card-title { margin: 0; color: var(--text-strong); font-size: 1.1em; }
+
+        /* WhatsApp modal */
+        .modal-backdrop {
+            display: none;
+            position: fixed;
+            top: 0; left: 0;
+            width: 100%; height: 100%;
+            background: rgba(0, 0, 0, 0.55);
+            backdrop-filter: blur(4px);
+            z-index: 1000;
+            align-items: center;
+            justify-content: center;
+        }
+        .modal-card {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-card);
+            padding: 26px;
+            max-width: 420px;
+            text-align: center;
+            box-shadow: var(--shadow-pop);
+            color: var(--text);
         }
     </style>
 </head>
@@ -274,13 +452,12 @@
     <div class="header">
         <h1 class="logo">Home<span>{{ platform.product_suffix }}</span><small>Private Cloud Manager</small></h1>
         <div class="header-status">
-            <div id="global-status" class="global-status">System Active</div>
+            <div class="header-actions">
+                <div id="global-status" class="global-status">System Active</div>
+                {% include '_theme_toggle.html' with context %}
+            </div>
             <div class="provider-mode">
-                {% if deployment_mode == 'local' %}
-                <span style="background:rgba(46,204,113,0.12); border:1px solid var(--hb-green); color:var(--hb-green); padding:2px 10px; border-radius:20px; font-size:0.85em; white-space:nowrap;">Local Network</span>
-                {% else %}
-                <span style="background:rgba(52,152,219,0.12); border:1px solid #3498db; color:#3498db; padding:2px 10px; border-radius:20px; font-size:0.85em; white-space:nowrap;">Remote Access</span>
-                {% endif %}
+                {% if deployment_mode == 'local' %}Local Network{% else %}Remote Access{% endif %}
             </div>
         </div>
     </div>
@@ -297,21 +474,22 @@
         <div class="grid">
             <div class="card">
                 <h3>Services</h3>
-                <div class="stat-item"><span>Nextcloud</span> <span id="st-nc" class="status-badge status-unknown">...</span></div>
-                <div class="stat-item"><span>Database</span> <span id="st-db" class="status-badge status-unknown">...</span></div>
-                <div class="stat-item"><span>Home Assistant</span> <span id="st-ha" class="status-badge status-unknown">...</span></div>
-                <div class="stat-item"><span>Tunnel</span> <span id="st-tunnel" class="status-badge status-unknown">...</span></div>
+                <div class="stat-item"><span>Nextcloud</span> <span id="st-nc" class="skeleton sk-mid"></span></div>
+                <div class="stat-item"><span>Database</span> <span id="st-db" class="skeleton sk-mid"></span></div>
+                <div class="stat-item"><span>Home Assistant</span> <span id="st-ha" class="skeleton sk-mid"></span></div>
+                <div class="stat-item"><span>Tunnel</span> <span id="st-tunnel" class="skeleton sk-mid"></span></div>
                 
-                <div style="margin-top:25px; display:flex; gap:15px;">
-                    <a href="{{ nc_url }}" target="_blank" style="flex:1"><button class="btn-primary" style="width:100%">Open Nextcloud</button></a>
-                    <a href="{{ ha_url }}" target="_blank" style="flex:1"><button class="btn-primary" style="width:100%">Open Home Assistant</button></a>
+                <div class="link-row">
+                    <a href="{{ nc_url }}" target="_blank" class="link-out">Nextcloud<span aria-hidden="true">↗</span></a>
+                    <a href="{{ ha_url }}" target="_blank" class="link-out">Home Assistant<span aria-hidden="true">↗</span></a>
+                    <a id="openclaw-launch" href="#" target="_blank" class="link-out" style="display:none;">OpenClaw<span aria-hidden="true">↗</span></a>
                 </div>
             </div>
 
             <div class="card">
                 <h3>System Resources</h3>
-                <div class="stat-item"><span>CPU Load</span> <span id="sys-cpu">...</span></div>
-                <div class="stat-item"><span>RAM Usage</span> <span id="sys-ram">...</span></div>
+                <div class="stat-item"><span>CPU Load</span> <span id="sys-cpu" class="skeleton sk-small"></span></div>
+                <div class="stat-item"><span>RAM Usage</span> <span id="sys-ram" class="skeleton sk-wide"></span></div>
 
                 <div style="margin-top: 20px;">
                     <label>Root Filesystem</label>
@@ -323,10 +501,10 @@
             </div>
 
             {% if has_gpu %}
-            <div class="card" style="border-left: 4px solid #e74c3c;">
-                <h3>🎮 GPU</h3>
-                <div class="stat-item"><span>Utilisation</span> <span id="gpu-util">—</span></div>
-                <div class="stat-item"><span>Temperature</span> <span id="gpu-temp">—</span></div>
+            <div class="card">
+                <h3>GPU</h3>
+                <div class="stat-item"><span>Utilisation</span> <span id="gpu-util" class="skeleton sk-small"></span></div>
+                <div class="stat-item"><span>Temperature</span> <span id="gpu-temp" class="skeleton sk-small"></span></div>
                 <div class="stat-item" style="margin-top: 10px;"><span>VRAM</span></div>
                 <div style="margin-top: 0px;">
                     <div class="progress-bg">
@@ -335,31 +513,66 @@
                     </div>
                 </div>
             </div>
+
+            <div class="card">
+                <h3>AI Assistant</h3>
+                <div class="row-list">
+                    <div class="row-item">
+                        <div class="row-main"><strong>Inference Engine</strong><span class="row-meta">llama-server · :8001</span></div>
+                        <span id="sys-llama-status" class="skeleton sk-mid"></span>
+                    </div>
+                    <div class="row-item">
+                        <div class="row-main"><strong>AI Agent</strong><span class="row-meta">OpenClaw</span></div>
+                        <span id="sys-openclaw-status" class="skeleton sk-mid"></span>
+                    </div>
+                    <div class="row-item" id="whatsapp-row" style="display:none;">
+                        <div class="row-main">
+                            <strong>WhatsApp</strong><span class="row-meta">Chat channel</span>
+                            <small id="whatsapp-link-action" style="display:none; margin-top:4px;">
+                                <a href="#" onclick="startWhatsAppLink(); return false;" style="color:var(--accent);">Link WhatsApp &rarr;</a>
+                            </small>
+                        </div>
+                        <span id="sys-whatsapp-status" class="skeleton sk-mid"></span>
+                    </div>
+                    <div class="row-item" id="whisper-row" style="display:none;">
+                        <div class="row-main"><strong>Speech-to-Text</strong><span class="row-meta">Whisper</span></div>
+                        <span id="sys-whisper-status" class="skeleton sk-mid"></span>
+                    </div>
+                </div>
+            </div>
             {% endif %}
 
             <div class="card">
-                <h3>Maintenance & Updates</h3>
-                <div class="stat-item"><span>Maintenance Mode</span> <span id="st-maint">Checking...</span></div>
-                <div style="display:flex; gap:10px; margin-top:10px;">
+                <h3>Maintenance Mode</h3>
+                <p style="margin-bottom:14px;">Pause services to perform safe maintenance. Reversible at any time.</p>
+                <div class="stat-item" style="margin-bottom:14px;"><span>Status</span> <span id="st-maint" class="skeleton sk-mid"></span></div>
+                <div style="display:flex; gap:10px;">
                     <button onclick="toggleMaintenance('on')" style="flex:1">Enable</button>
                     <button onclick="toggleMaintenance('off')" style="flex:1">Disable</button>
                 </div>
-                
-                <hr>
-                
-                <label>System Update Channel</label>
-                <div style="display:flex; gap:10px;">
-                    <select id="update-channel" onchange="resetUpdateUI()" style="margin-bottom:0; flex:2;">
-                        <option value="stable">Stable (Releases)</option>
-                        <option value="beta">Beta (Main Branch)</option>
-                    </select>
-                    <button onclick="triggerAction('/api/upgrade', 'System Upgrade')" style="flex:1;">OS Upgrade</button>
-                </div>
+            </div>
 
-                <div style="margin-top: 15px; display:flex; align-items:center; gap:10px;">
-                    <button id="btn-check-update" onclick="checkManagerUpdate()">Check App Update</button>
-                    <button id="btn-do-update" class="btn-primary" onclick="doManagerUpdate()" style="display:none;">Update Now</button>
-                    <span id="update-msg" style="font-size: 0.85em; color:var(--hb-text-dim);"></span>
+            <div class="card" style="grid-column: 1 / -1;">
+                <h3>Updates</h3>
+                <div class="updates-row">
+                    <div>
+                        <label>App update</label>
+                        <div style="display:flex; align-items:center; gap:10px;">
+                            <button id="btn-check-update" onclick="checkManagerUpdate()" style="flex-shrink:0;">Check now</button>
+                            <button id="btn-do-update" class="btn-primary" onclick="doManagerUpdate()" style="display:none;">Install update</button>
+                            <span id="update-msg" style="font-size: 0.88em; color:var(--text-dim);"></span>
+                        </div>
+                    </div>
+                    <div>
+                        <label>System update channel</label>
+                        <div style="display:flex; gap:10px;">
+                            <select id="update-channel" onchange="resetUpdateUI()" style="margin-bottom:0; flex:2;">
+                                <option value="stable">Stable (Releases)</option>
+                                <option value="beta">Beta (Main Branch)</option>
+                            </select>
+                            <button onclick="triggerAction('/api/upgrade', 'System Upgrade')" style="flex:1;">Run OS upgrade</button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -435,19 +648,21 @@
             </div>
         </div>
 
-        <div class="card" style="margin-top:25px;">
-            <h3>Restore Data</h3>
-            <p>Select a backup file to restore. <strong style="color:var(--hb-danger)">Warning: This overwrites current data!</strong></p>
+        <div class="card" style="margin-top:22px;">
+            <h3>Restore from backup</h3>
+            <div class="notice notice-danger" style="margin-bottom:16px;">
+                <strong>Heads up:</strong> Restoring overwrites all current data with the selected snapshot. This cannot be undone.
+            </div>
             <div style="display:flex; gap:10px; align-items:center;">
                 <select id="backup-list" style="margin-bottom:0; flex-grow:1;"></select>
-                <button class="btn-danger" onclick="confirmRestore()">Restore Selected</button>
+                <button class="btn-danger" onclick="confirmRestore()">Restore</button>
             </div>
         </div>
 
         {% if has_gpu %}
         <div class="card" style="margin-top: 16px;">
           <div class="card-header">
-            <h3 class="card-title">🤖 OpenClaw AI Assistant</h3>
+            <h3 class="card-title">OpenClaw AI Assistant</h3>
           </div>
           <div class="card-body">
             <div class="stat-row">
@@ -457,7 +672,7 @@
             <div class="stat-row" style="margin-top: 8px;">
               <span class="stat-label">Workspace size</span>
               <span id="oc-backup-workspace-size">—</span>
-              <span id="oc-backup-size-warning" style="display:none; color:#e74c3c; margin-left:8px;">⚠ Large workspace</span>
+              <span id="oc-backup-size-warning" style="display:none; color:var(--danger); margin-left:8px;">⚠ Large workspace</span>
             </div>
             <div style="margin-top: 14px; display: flex; flex-direction: column; gap: 10px;">
               <label style="display:flex; align-items:center; gap:10px; cursor:pointer;">
@@ -471,8 +686,8 @@
                 <span>Exclude model caches (reduces backup size)</span>
               </label>
             </div>
-            <p style="margin-top: 12px; font-size: 0.8em; color: var(--text-muted, #888);">
-              ⚠ Workspace contains conversation history and agent memory. Backups are stored unencrypted.
+            <p style="margin-top: 12px; font-size: 0.85em; color: var(--text-dim);">
+              Workspace contains conversation history and agent memory. Backups are stored unencrypted.
             </p>
           </div>
         </div>
@@ -480,45 +695,50 @@
     </div>
 
     <div id="connectivity" class="tab-content">
-        <div class="card" style="border-left: 4px solid var(--hb-green);">
-             <h3 style="border-bottom:none; margin-bottom:10px;">Authentication</h3>
-             <p style="margin-bottom:0;">The <strong>Master Admin Password</strong> controls access to {{ platform.product_name }} Manager, Nextcloud, and Home Assistant.</p>
+        <div class="notice" style="margin-bottom:22px;">
+             <strong>Authentication.</strong> The Master Admin Password controls access to {{ platform.product_name }} Manager, Nextcloud, and Home Assistant.
         </div>
 
         {% if cloud_enabled %}
         <div class="card">
              <h3>Cloud Account</h3>
              {% if cloud_account.email %}
-             <div style="display:flex; justify-content:space-between; border-bottom:1px solid #333; padding-bottom:10px; margin-bottom:10px;">
-                <span style="color:var(--hb-text-dim);">Registered Email</span>
+             <div style="display:flex; justify-content:space-between; border-bottom:1px solid var(--hairline); padding-bottom:10px; margin-bottom:10px;">
+                <span style="color:var(--text-dim);">Registered Email</span>
                 <div style="text-align:right;">
-                    <span style="color:#fff; font-weight:bold; display:block;">{{ cloud_account.email }}</span>
-                    <a href="#" onclick="changeCloudEmail('{{ cloud_account.email }}')" style="font-size:0.8em; color:var(--hb-green);">Update Email</a>
+                    <span style="color:var(--text-strong); font-weight:bold; display:block;">{{ cloud_account.email }}</span>
+                    <a href="#" onclick="changeCloudEmail('{{ cloud_account.email }}')" style="font-size:0.8em; color:var(--accent);">Update Email</a>
                 </div>
              </div>
              <div style="display:flex; justify-content:space-between;">
-                <span style="color:var(--hb-text-dim);">Subscription Plan</span>
+                <span style="color:var(--text-dim);">Subscription Plan</span>
                 <span class="status-badge status-running">{{ cloud_account.tier }}</span>
              </div>
              {% else %}
-             <p style="color:#888; margin-bottom:15px;">No cloud account registered locally.</p>
+             <p style="color:var(--text-dim); margin-bottom:15px;">No cloud account registered locally.</p>
              <button onclick="changeCloudEmail('')">Register Account</button>
              {% endif %}
         </div>
         {% endif %}
 
-        <div class="card" {% if deployment_mode == 'local' %}style="opacity:0.45; pointer-events:none;" title="Tunnel configuration is not available in Local Network mode"{% endif %}>
-            <h3>Tunnel Configuration
-                {% if deployment_mode == 'local' %}
-                <span style="font-size:0.6em; font-weight:400; color:var(--hb-text-dim); margin-left:8px;">— not used in Local Network mode</span>
-                {% endif %}
+        <div class="card">
+            <h3>
+                <span>Tunnel Configuration{% if deployment_mode != 'local' %}{% if tunnel.mode == 'pangolin' %} <span class="status-badge status-running" style="margin-left:6px;">Pangolin{% if tunnel.is_custom_pangolin %} · Custom{% endif %}</span>{% else %} <span class="status-badge status-starting" style="margin-left:6px;">Cloudflare</span>{% endif %}{% endif %}</span>
             </h3>
 
-            {% if tunnel.mode == 'pangolin' %}
-            <div style="background:rgba(46, 204, 113, 0.1); border:1px solid var(--hb-green); padding:15px; border-radius:6px; margin-bottom:20px;">
-                <span style="color:var(--hb-green); font-weight:bold;">Active Provider: Pangolin</span>
-                {% if tunnel.is_custom_pangolin %}<span style="font-size:0.8em; margin-left:10px; opacity:0.7;">(Customized)</span>{% endif %}
+            {% if deployment_mode == 'local' %}
+            <div class="empty-state">
+                <span class="empty-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M9 17H7a5 5 0 0 1 0-10h2"/>
+                        <path d="M15 7h2a5 5 0 0 1 4.546 7.071"/>
+                        <path d="M3 3l18 18"/>
+                    </svg>
+                </span>
+                <h4>Tunnel inactive</h4>
+                <p>This device is in Local Network mode. Switch to Remote Access during setup to expose services through a tunnel.</p>
             </div>
+            {% elif tunnel.mode == 'pangolin' %}
 
             <form onsubmit="updatePangolin(event)">
                 <div class="grid" style="grid-template-columns: 1fr 1fr; gap:15px;">
@@ -532,11 +752,11 @@
                 <label>Main Domain (e.g. myserver.homebrain.com)</label>
                 <input type="text" id="tun-main-domain" value="{{ main_domain }}">
                 
-                <div style="font-size: 0.85em; color: var(--hb-text-dim); padding: 10px; background: #222; border-radius: 4px; margin-bottom:15px;">
-                    <strong>Subdomain Preview:</strong><br>
-                    Manager: <span id="preview-mgr" style="color:#fff">{{ main_domain }}</span><br>
-                    Nextcloud: nc.<span id="preview-nc" style="color:#fff">{{ main_domain }}</span><br>
-                    Home Assistant: ha.<span id="preview-ha" style="color:#fff">{{ main_domain }}</span>
+                <div class="info-panel" style="margin-bottom:15px;">
+                    <strong style="color:var(--text-strong);">Subdomain Preview</strong><br>
+                    Manager: <span id="preview-mgr" style="color:var(--text-strong)">{{ main_domain }}</span><br>
+                    Nextcloud: nc.<span id="preview-nc" style="color:var(--text-strong)">{{ main_domain }}</span><br>
+                    Home Assistant: ha.<span id="preview-ha" style="color:var(--text-strong)">{{ main_domain }}</span>
                 </div>
 
                 <button type="submit">Update Connection Settings</button>
@@ -554,8 +774,8 @@
             <p>You can switch to Cloudflare Tunnel if you have your own domain.</p>
             <button class="btn-warning" onclick="showCloudflareForm()">Switch to Cloudflare</button>
 
-            <div id="cf-form-container" style="display:none; margin-top:20px; background: #222; padding: 20px; border-radius: 8px; border:1px solid #444;">
-                <h4 style="margin-top:0; color:var(--hb-warning)">Cloudflare Setup</h4>
+            <div id="cf-form-container" style="display:none; margin-top:20px; background: var(--surface-2); padding: 20px; border-radius: 8px; border:1px solid var(--border);">
+                <h4 style="margin-top:0; color:var(--warning)">Cloudflare setup</h4>
                 <p style="font-size:0.9em;">Configure public hostnames in Cloudflare Dashboard pointing to <code>http://nextcloud:80</code> and <code>http://homeassistant:8123</code>.</p>
                 <form onsubmit="updateCloudflare(event, 'switch')">
                     <label>Service</label>
@@ -572,20 +792,16 @@
             </div>
 
             {% else %}
-            <div style="background:rgba(243, 156, 18, 0.1); border:1px solid var(--hb-warning); padding:15px; border-radius:6px; margin-bottom:20px;">
-                <span style="color:var(--hb-warning); font-weight:bold;">Active Provider: Cloudflare</span>
-            </div>
-
             <div style="margin-bottom:20px;">
                 <label>Active Tunnels</label>
-                <ul style="list-style:none; padding:0; margin:0; font-size:0.9em; color:#ccc;">
-                    <li style="padding:5px 0; border-bottom:1px solid #333;">
-                        <strong>Nextcloud:</strong> 
-                        {% if tunnel.current.CF_TOKEN_NC %}<span style="color:var(--hb-green)">Configured</span>{% else %}<span style="color:#666">Inactive</span>{% endif %}
+                <ul style="list-style:none; padding:0; margin:0; font-size:0.9em; color:var(--text);">
+                    <li style="padding:5px 0; border-bottom:1px solid var(--hairline);">
+                        <strong>Nextcloud:</strong>
+                        {% if tunnel.current.CF_TOKEN_NC %}<span style="color:var(--accent)">Configured</span>{% else %}<span style="color:var(--text-faint)">Inactive</span>{% endif %}
                     </li>
                     <li style="padding:5px 0;">
-                        <strong>Home Assistant:</strong> 
-                        {% if tunnel.current.CF_TOKEN_HA %}<span style="color:var(--hb-green)">Configured</span>{% else %}<span style="color:#666">Inactive</span>{% endif %}
+                        <strong>Home Assistant:</strong>
+                        {% if tunnel.current.CF_TOKEN_HA %}<span style="color:var(--accent)">Configured</span>{% else %}<span style="color:var(--text-faint)">Inactive</span>{% endif %}
                     </li>
                 </ul>
             </div>
@@ -622,7 +838,7 @@
                             <small style="color:var(--hb-text-dim);">Auto-reboots system if frozen.</small>
                         </td>
                         <td style="text-align:right;">
-                            <span id="sys-wd-status" class="status-badge status-unknown">...</span>
+                            <span id="sys-wd-status" class="skeleton sk-mid"></span>
                             <button onclick="toggleSystem('watchdog')" style="margin-left:10px; padding:4px 10px; font-size:0.8em;">Toggle</button>
                         </td>
                     </tr>
@@ -632,7 +848,7 @@
                             <small style="color:var(--hb-text-dim);">Use system cron (Reliable).</small>
                         </td>
                         <td style="text-align:right;">
-                            <span id="sys-cron-status" class="status-badge status-unknown">...</span>
+                            <span id="sys-cron-status" class="skeleton sk-mid"></span>
                             <button onclick="toggleSystem('cron')" style="margin-left:10px; padding:4px 10px; font-size:0.8em;">Enforce</button>
                         </td>
                     </tr>
@@ -642,7 +858,7 @@
                             <small style="color:var(--hb-text-dim);">Gen 3.0 (Experimental).</small>
                         </td>
                         <td style="text-align:right;">
-                            <span id="sys-pci-status" class="status-badge status-unknown">...</span>
+                            <span id="sys-pci-status" class="skeleton sk-mid"></span>
                             <button onclick="toggleSystem('pci')" style="margin-left:10px; padding:4px 10px; font-size:0.8em;">Toggle</button>
                         </td>
                     </tr>
@@ -652,7 +868,7 @@
                             <small style="color:var(--hb-text-dim);">High-performance memory caching.</small>
                         </td>
                         <td style="text-align:right;">
-                            <span id="sys-redis-status" class="status-badge status-unknown">...</span>
+                            <span id="sys-redis-status" class="skeleton sk-mid"></span>
                             <button id="btn-redis-fix" onclick="configureRedis()" style="margin-left:10px; padding:4px 10px; font-size:0.8em; display:none;" class="btn-warning">Fix Config</button>
                         </td>
                     </tr>
@@ -660,55 +876,24 @@
             </div>
 
             {% if has_gpu %}
-            <div class="card" style="border-left: 4px solid #9b59b6;">
-                <h3>Personal AI Assistant <span class="status-badge status-starting" style="background:#9b59b622; color:#d2b4de; border-color:#9b59b6;">Experimental</span></h3>
-                <p>Run a fully private AI assistant on your device. Inference and chat stay entirely local.</p>
-                <table style="margin-top:10px;">
-                    <tr>
-                        <td><strong>Inference Engine</strong> <small style="color:var(--hb-text-dim);">(llama-server :8001)</small></td>
-                        <td style="text-align:right;"><span id="sys-llama-status" class="status-badge status-unknown">...</span></td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <strong>AI Agent</strong> <small style="color:var(--hb-text-dim);">(OpenClaw)</small><br>
-                            <small id="openclaw-link" style="display:none; margin-top:4px;">
-                                <a id="openclaw-link-anchor" href="#" target="_blank" style="color:var(--hb-green);">Open OpenClaw &rarr;</a>
-                            </small>
-                        </td>
-                        <td style="text-align:right;"><span id="sys-openclaw-status" class="status-badge status-unknown">...</span></td>
-                    </tr>
-                    <tr id="whatsapp-row" style="display:none;">
-                        <td>
-                            <strong>WhatsApp</strong> <small style="color:var(--hb-text-dim);">(Chat Channel)</small><br>
-                            <small id="whatsapp-link-action" style="display:none; margin-top:4px;">
-                                <a href="#" onclick="startWhatsAppLink(); return false;" style="color:var(--hb-green);">Link WhatsApp &rarr;</a>
-                            </small>
-                        </td>
-                        <td style="text-align:right;">
-                            <span id="sys-whatsapp-status" class="status-badge status-unknown">...</span>
-                        </td>
-                    </tr>
-                    <tr id="whisper-row" style="display:none;">
-                        <td>
-                            <strong>Speech-to-Text</strong> <small style="color:var(--hb-text-dim);">(Whisper)</small>
-                        </td>
-                        <td style="text-align:right;">
-                            <span id="sys-whisper-status" class="status-badge status-unknown">...</span>
-                        </td>
-                    </tr>
-                </table>
-                <div id="ai-model-selector" style="margin-top:10px; display:none;">
-                    <label for="ai-model-select" style="font-size:0.85em; color:var(--hb-text-dim);">AI Model:</label>
-                    <select id="ai-model-select" onchange="onModelSelectChange()" style="width:100%; padding:6px; margin-top:4px; font-size:0.85em; background:var(--hb-card-bg); color:var(--hb-text); border:1px solid var(--hb-border); border-radius:4px;"></select>
-                    <button id="btn-switch-model" onclick="switchModel()" style="display:none; margin-top:6px; padding:4px 14px; font-size:0.8em;">Switch Model</button>
+            <div class="card">
+                <h3>Personal AI Assistant</h3>
+                <p style="margin-bottom:18px;">Run a fully private AI assistant on your device. Inference and chat stay entirely local. Live status appears on the Status tab.</p>
+
+                <div id="ai-model-selector" style="display:none;">
+                    <label>AI model</label>
+                    <select id="ai-model-select" onchange="onModelSelectChange()" style="margin-bottom:10px;"></select>
+                    <button id="btn-switch-model" onclick="switchModel()" style="display:none;">Switch model</button>
                 </div>
-                <div style="text-align:right; margin-top:10px;">
-                    <button id="btn-ai-toggle" onclick="toggleSystem('openclaw')" style="padding:6px 18px; font-size:0.9em;">...</button>
+
+                <div style="display:flex; align-items:center; justify-content:space-between; gap:12px; margin-top:18px;">
+                    <a id="openclaw-link-anchor" href="#" target="_blank" style="display:none; color:var(--accent); text-decoration:none; font-size:0.92em;">Open OpenClaw &rarr;</a>
+                    <button id="btn-ai-toggle" class="btn-primary" onclick="toggleSystem('openclaw')" disabled style="margin-left:auto; opacity:0.6;">Loading…</button>
                 </div>
             </div>
             {% else %}
-            <div class="card" style="border-left: 4px solid #9b59b6; opacity: 0.45; pointer-events: none;">
-                <h3>Personal AI Assistant <span class="status-badge" style="background:#95a5a622; color:#bdc3c7; border-color:#95a5a6;">GPU Required</span></h3>
+            <div class="card" style="opacity: 0.55; pointer-events: none;">
+                <h3>Personal AI Assistant <span class="status-badge status-unknown">GPU Required</span></h3>
                 <p>Run a fully private AI assistant on your device. Inference and chat stay entirely local.</p>
                 <p style="color:var(--hb-text-dim); font-size:0.9em; margin-top:10px;">
                     This device does not have a compatible GPU. AI features require a discrete graphics processor (AMD, NVIDIA, or Intel integrated GPU with DRM support).
@@ -716,24 +901,28 @@
             </div>
             {% endif %}
             
-            <div class="card">
-                <h3>FTP Server (Camera Uploads)</h3>
-                <p>Create dedicated FTP accounts mapping to Nextcloud.</p>
-                
-                <form onsubmit="setupFtp(event)">
-                    <div class="grid" style="grid-template-columns: 1fr 1fr; gap:15px;">
-                        <div><label>NC User</label><input type="text" id="ftp-nc-user" placeholder="admin"></div>
-                        <div><label>FTP User</label><input type="text" id="ftp-user" placeholder="camera1"></div>
+            <div class="card" style="grid-column: 1 / -1;">
+                <h3>FTP Server <span style="font-weight:400; color:var(--text-dim); font-size:0.85em;">— for camera uploads</span></h3>
+                <p style="margin-bottom:18px;">Create dedicated FTP accounts that map to Nextcloud users.</p>
+
+                <div class="ftp-row">
+                    <form onsubmit="setupFtp(event)" class="ftp-form">
+                        <div style="display:grid; grid-template-columns: 1fr 1fr 1fr; gap:12px; align-items:end;">
+                            <div><label>NC User</label><input type="text" id="ftp-nc-user" placeholder="admin" style="margin-bottom:0;"></div>
+                            <div><label>FTP User</label><input type="text" id="ftp-user" placeholder="camera1" style="margin-bottom:0;"></div>
+                            <div><label>FTP Password</label><input type="password" id="ftp-pass" style="margin-bottom:0;"></div>
+                        </div>
+                        <button type="submit" class="btn-primary" style="margin-top:14px;">Create or update user</button>
+                    </form>
+
+                    <div class="ftp-list">
+                        <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:8px;">
+                            <label style="margin-bottom:0;">Active users</label>
+                            <button onclick="loadFtpUsers()" style="font-size:0.8em; padding:4px 10px;">Refresh</button>
+                        </div>
+                        <div id="ftp-user-list" style="min-height:50px;">Loading...</div>
                     </div>
-                    <label>FTP Password</label><input type="password" id="ftp-pass">
-                    
-                    <button type="submit" class="btn-primary" style="width:100%; margin-top:5px;">Create / Update User</button>
-                </form>
-        
-                <hr>
-                <label>Active FTP Users</label>
-                <div id="ftp-user-list" style="min-height:50px;">Loading...</div>
-                <button onclick="loadFtpUsers()" style="margin-top:10px; font-size:0.8em; padding:6px 12px;">Refresh List</button>
+                </div>
             </div>
 
             {% if ha_domain %}
@@ -781,14 +970,14 @@
                 <button onclick="pollLogs()">Refresh Now</button>
             </div>
             
-            <div style="display:flex; gap:15px; margin-bottom:10px; font-size:0.9em; align-items:center; background:#111; padding:8px; border-radius:4px; border:1px solid #333;">
-                <span style="color:#888; font-weight:bold;">FILTERS:</span>
-                <label style="display:inline; margin:0; cursor:pointer;"><input type="checkbox" id="chk-error" checked onchange="renderLogs()"> Errors</label>
-                <label style="display:inline; margin:0; cursor:pointer;"><input type="checkbox" id="chk-warn" checked onchange="renderLogs()"> Warnings</label>
-                <label style="display:inline; margin:0; cursor:pointer;"><input type="checkbox" id="chk-info" checked onchange="renderLogs()"> Info</label>
-                <label style="display:inline; margin:0; cursor:pointer;"><input type="checkbox" id="chk-debug" onchange="renderLogs()"> Debug/Raw</label>
+            <div style="display:flex; gap:15px; margin-bottom:10px; font-size:0.85em; align-items:center; background:var(--surface-2); padding:10px 14px; border-radius:var(--radius-input); border:1px solid var(--border); font-family:var(--font-mono);">
+                <span style="color:var(--text-dim); font-weight:bold; letter-spacing:1px; text-transform:uppercase; font-size:0.75em;">Filters</span>
+                <label style="display:inline; margin:0; cursor:pointer; color:var(--text); text-transform:none; letter-spacing:0; font-size:0.92em; font-family:var(--font-ui);"><input type="checkbox" id="chk-error" checked onchange="renderLogs()"> Errors</label>
+                <label style="display:inline; margin:0; cursor:pointer; color:var(--text); text-transform:none; letter-spacing:0; font-size:0.92em; font-family:var(--font-ui);"><input type="checkbox" id="chk-warn" checked onchange="renderLogs()"> Warnings</label>
+                <label style="display:inline; margin:0; cursor:pointer; color:var(--text); text-transform:none; letter-spacing:0; font-size:0.92em; font-family:var(--font-ui);"><input type="checkbox" id="chk-info" checked onchange="renderLogs()"> Info</label>
+                <label style="display:inline; margin:0; cursor:pointer; color:var(--text); text-transform:none; letter-spacing:0; font-size:0.92em; font-family:var(--font-ui);"><input type="checkbox" id="chk-debug" onchange="renderLogs()"> Debug/Raw</label>
                 <div style="flex-grow:1; text-align:right;">
-                    <small style="color:#666;" id="log-status">Ready</small>
+                    <small style="color:var(--text-faint);" id="log-status">Ready</small>
                 </div>
             </div>
 
@@ -890,12 +1079,21 @@
                     if (el) setStatus(el, data[k === 'nc' ? 'nextcloud' : (k === 'tunnel' ? 'tunnel' : (k === 'ha' ? 'homeassistant' : 'db'))]);
                 });
                 
-                if (document.getElementById('st-maint')) 
-                    document.getElementById('st-maint').innerText = (data.maintenance_mode || 'unknown').toUpperCase();
+                if (document.getElementById('st-maint')) {
+                    const mEl = document.getElementById('st-maint');
+                    mEl.classList.remove('skeleton','sk-mid','sk-wide','sk-small');
+                    mEl.innerText = (data.maintenance_mode || 'unknown').toUpperCase();
+                }
 
                 // Stats
-                if (data.cpu_load !== undefined) document.getElementById('sys-cpu').innerText = data.cpu_load + "%";
-                if (data.ram_text !== undefined) document.getElementById('sys-ram').innerText = data.ram_text + " (" + data.ram_percent + "%)";
+                const fillStat = (id, txt) => {
+                    const el = document.getElementById(id);
+                    if (!el) return;
+                    el.classList.remove('skeleton','sk-mid','sk-wide','sk-small');
+                    el.innerText = txt;
+                };
+                if (data.cpu_load !== undefined) fillStat('sys-cpu', data.cpu_load + "%");
+                if (data.ram_text !== undefined) fillStat('sys-ram', data.ram_text + " (" + data.ram_percent + "%)");
 
                 // Root Disk
                 if (data.root_percent !== undefined) {
@@ -911,8 +1109,8 @@
                     const gpuTemp = document.getElementById('gpu-temp');
                     const gpuVramBar = document.getElementById('gpu-vram-bar');
                     const gpuVramText = document.getElementById('gpu-vram-text');
-                    if (gpuUtil) gpuUtil.textContent = data.gpu.util_percent + '%';
-                    if (gpuTemp && data.gpu.temp_c !== undefined) gpuTemp.textContent = data.gpu.temp_c + '°C';
+                    if (gpuUtil) { gpuUtil.classList.remove('skeleton','sk-mid','sk-wide','sk-small'); gpuUtil.textContent = data.gpu.util_percent + '%'; }
+                    if (gpuTemp && data.gpu.temp_c !== undefined) { gpuTemp.classList.remove('skeleton','sk-mid','sk-wide','sk-small'); gpuTemp.textContent = data.gpu.temp_c + '°C'; }
                     if (gpuVramBar) gpuVramBar.style.width = data.gpu.vram_percent + '%';
                     if (gpuVramText) gpuVramText.textContent = data.gpu.vram_used_gb + ' / ' + data.gpu.vram_total_gb + ' GB';
                 }
@@ -934,15 +1132,16 @@
                 
                 if(data.status === 'idle') {
                     banner.innerText = 'System Active';
-                    banner.style.color = 'var(--hb-green)';
+                    banner.removeAttribute('data-state');
                 } else if (data.status === 'running') {
                     banner.innerText = data.message;
-                    banner.style.color = 'var(--hb-warning)';
+                    banner.dataset.state = 'busy';
                 } else if (data.status === 'error') {
                     banner.innerText = 'Error: ' + data.message;
-                    banner.style.color = 'var(--hb-danger)';
+                    banner.dataset.state = 'error';
                 } else {
                     banner.innerText = data.message;
+                    banner.removeAttribute('data-state');
                 }
 
                 // Auto switch log view if setup/update is running
@@ -958,12 +1157,15 @@
             document.getElementById('cf-form-container').style.display = 'block';
         }
 
-        document.getElementById('tun-main-domain').addEventListener('input', function(e) {
-            const val = e.target.value || '...';
-            document.getElementById('preview-mgr').innerText = val;
-            document.getElementById('preview-nc').innerText = val;
-            document.getElementById('preview-ha').innerText = val;
-        });
+        const tunDomainEl = document.getElementById('tun-main-domain');
+        if (tunDomainEl) {
+            tunDomainEl.addEventListener('input', function(e) {
+                const val = e.target.value || '...';
+                document.getElementById('preview-mgr').innerText = val;
+                document.getElementById('preview-nc').innerText = val;
+                document.getElementById('preview-ha').innerText = val;
+            });
+        }
 
         async function updatePangolin(e) {
             e.preventDefault();
@@ -1068,9 +1270,9 @@
             ocEl.innerText = openclawStatus === 'starting' ? 'STARTING' : oTxt;
             ocEl.dataset.val = openclawStatus;
 
-            // OpenClaw link (only when running)
-            const linkWrap = document.getElementById('openclaw-link');
+            // OpenClaw link (only when running) — used in Settings card and Status quick-launch row
             const linkAnchor = document.getElementById('openclaw-link-anchor');
+            const launchAnchor = document.getElementById('openclaw-launch');
             if (openclawStatus === 'running') {
                 // Pre-authenticate the link via URL fragment so the token is never
                 // sent to the server in logs. OpenClaw 2026.3.7+ uses `#token=`.
@@ -1081,15 +1283,20 @@
                     .then(data => {
                         const port = data.port || 18789;
                         const base = `http://${location.hostname}:${port}/`;
-                        linkAnchor.href = data.token ? `${base}#token=${encodeURIComponent(data.token)}` : base;
+                        const href = data.token ? `${base}#token=${encodeURIComponent(data.token)}` : base;
+                        if (linkAnchor) linkAnchor.href = href;
+                        if (launchAnchor) launchAnchor.href = href;
                     })
                     .catch(() => {
-                        linkAnchor.href = `http://${location.hostname}:18789`;
+                        const fallback = `http://${location.hostname}:18789`;
+                        if (linkAnchor) linkAnchor.href = fallback;
+                        if (launchAnchor) launchAnchor.href = fallback;
                     });
-                linkAnchor.innerText = `Open OpenClaw \u2192 :18789`;
-                linkWrap.style.display = 'block';
+                if (linkAnchor) linkAnchor.style.display = '';
+                if (launchAnchor) launchAnchor.style.display = '';
             } else {
-                linkWrap.style.display = 'none';
+                if (linkAnchor) linkAnchor.style.display = 'none';
+                if (launchAnchor) launchAnchor.style.display = 'none';
             }
 
             // Model selector (show when not installed or when running/disabled)
@@ -1107,6 +1314,7 @@
             // Unified button
             const btn = document.getElementById('btn-ai-toggle');
             btn.disabled = false;
+            btn.style.opacity = '';
             if (llamaStatus === 'not_installed' && openclawStatus === 'not_installed') {
                 btn.innerText = 'Install';
             } else if (llamaStatus === 'running' && openclawStatus === 'running') {
@@ -1340,7 +1548,7 @@
                 const users = await res.json();
                 
                 if (users.length === 0) {
-                    el.innerHTML = '<em style="color:#666;">No FTP users configured.</em>';
+                    el.innerHTML = '<em style="color:var(--text-faint);">No FTP users configured.</em>';
                     return;
                 }
                 
@@ -1425,7 +1633,7 @@
                     const div = document.createElement('div');
                     div.className = 'drive-row';
                     
-                    let html = `<div><strong>${d.path}</strong> <span style="color:#aaa">(${d.size})</span> <small>${d.model}</small></div>`;
+                    let html = `<div><strong>${d.path}</strong> <span style="color:var(--text-dim)">(${d.size})</span> <small>${d.model}</small></div>`;
                     
                     if (d.is_backup) {
                         html += '<span class="status-badge status-running">Backup Drive</span>';
@@ -1653,7 +1861,7 @@
                    doBtn.innerText = `Install ${data.target_ref}`;
                } else {
                    msg.innerText = data.message;
-                   msg.style.color = "#ccc";
+                   msg.style.color = "var(--text-dim)";
                }
             } catch (e) {
                 msg.innerText = "Check failed.";
@@ -1884,15 +2092,14 @@
         init();
     </script>
 
-    <div id="whatsapp-qr-modal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%;
-        background:rgba(0,0,0,0.7); z-index:1000; align-items:center; justify-content:center;">
-        <div style="background:var(--hb-card-bg); border:1px solid var(--hb-border); border-radius:8px; padding:24px; max-width:400px; text-align:center;">
-            <h3 style="margin-top:0;">Link WhatsApp</h3>
-            <p id="whatsapp-qr-message" style="color:var(--hb-text-dim); font-size:0.9em;">Connecting...</p>
-            <div id="whatsapp-qr-container" style="margin:16px auto;">
+    <div id="whatsapp-qr-modal" class="modal-backdrop">
+        <div class="modal-card">
+            <h3 style="margin-top:0; color:var(--text-strong);">Link WhatsApp</h3>
+            <p id="whatsapp-qr-message" style="color:var(--text-dim); font-size:0.9em;">Connecting...</p>
+            <div id="whatsapp-qr-container" style="margin:16px auto; padding: 12px; background:#fff; display:inline-block; border-radius:6px;">
                 <img id="whatsapp-qr-img" style="display:none; max-width:280px; border-radius:4px;" />
             </div>
-            <p style="font-size:0.8em; color:var(--hb-text-dim);">
+            <p style="font-size:0.82em; color:var(--text-dim);">
                 Open WhatsApp on your phone &rarr; Settings &rarr; Linked Devices &rarr; Scan QR code
             </p>
             <button onclick="closeWhatsAppModal()" style="margin-top:12px; padding:6px 18px;">Close</button>

--- a/src/templates/installing.html
+++ b/src/templates/installing.html
@@ -1,76 +1,168 @@
 <!DOCTYPE html>
-<html>
+<html data-theme="light">
 <head>
     <title>Installing {{ platform.product_name }}...</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
+    {% include '_theme.html' %}
     <style>
         body {
             max-width: 800px;
             margin: 0 auto;
             padding: 40px 20px;
             text-align: center;
-            background-color: #121212;
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-            color: #eee;
         }
         .logo {
             font-size: 2.5em;
-            font-weight: bold;
-            color: #fff;
-            margin-bottom: 20px;
+            font-weight: 300;
+            color: var(--text-strong);
+            margin-bottom: 16px;
             letter-spacing: -1px;
         }
-        .logo span { color: #2ecc71; }
-        
-        #logs {
-            background: #000;
-            color: #2ecc71;
-            padding: 15px;
-            height: 400px;
-            overflow: auto;
-            font-family: 'Consolas', 'Monaco', monospace;
-            font-size: 13px;
-            border-radius: 8px;
-            border: 1px solid #333;
-            text-align: left;
-            box-shadow: inset 0 0 10px #000;
+        .logo span { color: var(--accent); font-weight: 700; }
+
+        h2 { font-weight: 300; color: var(--text-strong); margin-bottom: 6px; }
+
+        .progress-meta {
+            color: var(--text-dim);
+            font-family: var(--font-mono);
+            font-size: 0.85em;
+            text-transform: uppercase;
+            letter-spacing: 1px;
         }
-        
+        .progress-meta::before { content: "› "; color: var(--accent); }
+
+        #logs {
+            background: var(--console-bg);
+            color: var(--console-fg);
+            padding: 16px 18px;
+            height: 420px;
+            overflow: auto;
+            font-family: var(--font-mono);
+            font-size: 13px;
+            border-radius: var(--radius-card);
+            border: 1px solid var(--console-border);
+            text-align: left;
+            box-shadow: var(--console-shadow);
+            line-height: 1.45;
+            position: relative;
+        }
+        #log-container { margin-top: 24px; position: relative; }
+        #log-container::before {
+            content: "● ● ●";
+            position: absolute;
+            top: -6px; left: 14px;
+            background: var(--surface);
+            color: var(--text-faint);
+            padding: 0 8px;
+            font-family: var(--font-mono);
+            font-size: 0.7em;
+            letter-spacing: 6px;
+            border-radius: 4px;
+            z-index: 1;
+        }
+
         .success-box {
-            background: #1e1e1e;
+            background: var(--surface);
             padding: 30px;
-            border-radius: 12px;
-            border: 2px solid #2ecc71;
-            box-shadow: 0 0 30px rgba(46, 204, 113, 0.15);
+            border-radius: var(--radius-card);
+            border: 1px solid var(--accent);
+            box-shadow: var(--accent-glow), var(--shadow-pop);
             text-align: left;
             animation: fadeIn 0.5s;
         }
         @keyframes fadeIn { from { opacity:0; transform: translateY(20px); } to { opacity:1; transform: translateY(0); } }
 
         button {
-            background-color: #2ecc71;
-            color: #000;
-            font-weight: bold;
-            font-size: 1.1em;
-            padding: 15px 30px;
+            background: var(--accent);
+            color: var(--text-on-accent);
+            font-weight: 700;
+            font-size: 1.05em;
+            padding: 14px 28px;
             border: none;
-            border-radius: 50px;
+            border-radius: var(--radius-pill);
             cursor: pointer;
-            transition: transform 0.2s, background-color 0.2s;
+            transition: transform 0.18s, background-color 0.18s, box-shadow 0.18s;
             width: 100%;
+            box-shadow: var(--accent-glow);
         }
-        button:hover {
-            transform: scale(1.02);
-            background-color: #27ae60;
+        button:hover { transform: translateY(-1px); background: var(--accent-hover); }
+        button:disabled { background: var(--neutral-soft); color: var(--text-faint); box-shadow: none; }
+
+        .creds-block {
+            background: var(--surface-2);
+            padding: 20px;
+            border-radius: var(--radius-input);
+            margin: 25px 0;
+            border: 1px solid var(--border);
         }
+        .creds-label {
+            color: var(--text-dim);
+            display: block;
+            font-size: 0.72em;
+            text-transform: uppercase;
+            letter-spacing: 1.4px;
+            font-family: var(--font-mono);
+        }
+        .creds-value {
+            font-size: 1.2em;
+            color: var(--text-strong);
+        }
+        .creds-password {
+            font-family: var(--font-mono);
+            font-size: 1.55em;
+            color: var(--warning);
+            word-break: break-all;
+            margin-top: 6px;
+            padding: 8px 10px;
+            background: var(--bg);
+            border: 1px dashed var(--border-strong);
+            border-radius: 6px;
+        }
+
+        .activate-card {
+            background: var(--accent-soft);
+            border: 1px solid var(--accent);
+            padding: 20px;
+            border-radius: var(--radius-input);
+            margin-bottom: 25px;
+        }
+        .activate-card h3 {
+            margin-top:0;
+            color: var(--accent);
+            font-size: 1.05em;
+            font-family: var(--font-mono);
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
+        .activate-card input[type=email] {
+            padding: 12px;
+            border-radius: 6px;
+            flex-grow: 1;
+            outline: none;
+        }
+        .activate-card .activate-row { display:flex; gap:10px; align-items: center; }
+        .activate-card button { width:auto; padding:10px 22px; font-size:0.9em; margin:0; }
+        .activate-msg { margin-bottom:0; font-size:0.85em; margin-top:10px; min-height:1.2em; }
+
+        .confirm-gate {
+            display:none;
+            margin-top:15px;
+            background: var(--surface);
+            padding: 12px 14px;
+            border-radius: 6px;
+            border: 1px dashed var(--border-strong);
+        }
+        .confirm-gate label { display:flex; align-items:center; gap:10px; cursor:pointer; color: var(--text); }
     </style>
 </head>
 <body>
+    {% include '_theme_toggle.html' with context %}
+
     <div class="logo">Home<span>{{ platform.product_suffix }}</span></div>
-    <h2 id="status-title" style="font-weight: 300;">System Installation in Progress</h2>
-    <p id="status-sub" style="color:#aaa;">Please do not unplug. This can take about 15 minutes.</p>
-    
+    <h2 id="status-title">System Installation in Progress</h2>
+    <p id="status-sub" class="progress-meta">Please do not unplug. This can take about 15 minutes.</p>
+
     <div id="log-container">
         <pre id="logs">Connecting to log stream...</pre>
     </div>
@@ -83,9 +175,9 @@
             if (finished) return;
 
             fetch('/api/logs/setup').then(r => {
-                if (r.status === 401) { 
-                    console.log("Session refreshed"); 
-                    location.reload(); return null; 
+                if (r.status === 401) {
+                    console.log("Session refreshed");
+                    location.reload(); return null;
                 }
                 return r.text();
             }).then(t => {
@@ -106,7 +198,6 @@
             fetch('/api/setup/credentials', { cache: "no-store" })
                  .then(res => {
                     if (!res.ok && retries > 0) {
-                        // If file isn't ready yet (404), wait and retry
                         console.log("Credentials not ready, retrying...");
                         setTimeout(() => fetchCredentials(retries - 1), 2000);
                         return null;
@@ -115,23 +206,20 @@
                     return res.json();
                 })
                 .then(data => {
-                    if (!data) return; // Retrying...
+                    if (!data) return;
                     showSuccess(data);
-                    // NOTE: We do NOT cleanup here. We wait for user confirmation.
                 })
                 .catch(e => {
                     console.error(e);
                     document.body.innerHTML = `
                         <div class="logo">Home<span>{{ platform.product_suffix }}</span></div>
                         <h1>Installation Finished</h1>
-                        <p><p>System is ready, but credentials could not be loaded.</p>
+                        <p>System is ready, but credentials could not be loaded.</p>
                         <button onclick="location.reload()">Go to Login</button>
                     `;
                 });
         }
 
-        // If the backend tells us the handover is ready (e.g. after a reboot),
-        // skip log polling and fetch credentials immediately.
         if (handoverReady) {
             finished = true;
             logsEl.innerText = "Resuming session... Retrieving credentials...";
@@ -140,43 +228,41 @@
 
         function showSuccess(data) {
             document.body.innerHTML = `
-                <div style="max-width: 500px; margin: 0 auto; padding: 20px;">
+                <div style="max-width: 520px; margin: 0 auto; padding: 20px;">
                     <div class="logo">Home<span>{{ platform.product_suffix }}</span></div>
-                    
+
                     <div class="success-box">
-                        <h2 style="margin-top:0; color: #2ecc71; border-bottom: 1px solid #444; padding-bottom: 15px;">Setup Complete</h2>
-                        <p style="color:#ddd;">Your private cloud is ready. Save these credentials immediately.</p>
-                        
-                        <div style="background: #252525; padding: 20px; border-radius: 8px; margin: 25px 0;">
-                            <div style="margin-bottom: 15px;">
-                                <span style="color:#888; display:block; font-size:0.75em; text-transform:uppercase; letter-spacing:1px;">Master Username</span>
-                                <span style="font-size:1.2em; color:#fff;">admin</span>
+                        <h2 style="margin-top:0; color: var(--accent); border-bottom: 1px solid var(--border); padding-bottom: 15px;">Setup Complete</h2>
+                        <p style="color: var(--text);">Your private cloud is ready. Save these credentials immediately.</p>
+
+                        <div class="creds-block">
+                            <div style="margin-bottom: 16px;">
+                                <span class="creds-label">Master Username</span>
+                                <span class="creds-value">admin</span>
                             </div>
                             <div>
-                                <span style="color:#888; display:block; font-size:0.75em; text-transform:uppercase; letter-spacing:1px;">Master Password</span>
-                                <div style="font-family: 'Consolas', monospace; font-size: 1.6em; color: #f39c12; word-break: break-all; margin-top:5px;">
-                                    ${data.password}
-                                </div>
+                                <span class="creds-label">Master Password</span>
+                                <div class="creds-password">${data.password}</div>
                             </div>
                         </div>
-                        
-                        <p style="font-size: 0.9em; color: #aaa; margin-bottom: 25px;">
+
+                        <p style="font-size: 0.9em; color: var(--text-dim); margin-bottom: 25px;">
                             This password provides full administrative access to your Dashboard, Nextcloud, and Home Assistant.
                         </p>
                         ${data.cloud_enabled ? `
-                        <div style="background: rgba(46, 204, 113, 0.05); border: 1px solid #2ecc71; padding: 20px; border-radius: 8px; margin-bottom: 25px;">
-                            <h3 style="margin-top:0; color: #2ecc71; font-size:1.1em;">Activate Remote Access (Required)</h3>
-                            <p style="font-size:0.9em; color:#ccc; margin-bottom:15px;">
+                        <div class="activate-card">
+                            <h3>// Activate Remote Access (Required)</h3>
+                            <p style="font-size:0.9em; color: var(--text); margin-bottom:15px;">
                                 You must register your device to enable remote access and finish setup.
                             </p>
-                            <div style="display:flex; gap:10px;">
-                                <input type="email" id="cloud-email" placeholder="Enter your email address" style="padding:12px; border-radius:4px; border:1px solid #444; background:#111; color:#fff; flex-grow:1; outline:none;" required>
-                                <button onclick="registerCloud()" id="btn-cloud" style="width:auto; padding:10px 25px; font-size:0.9em; margin:0;">Activate</button>
+                            <div class="activate-row">
+                                <input type="email" id="cloud-email" placeholder="Enter your email address" required>
+                                <button onclick="registerCloud()" id="btn-cloud">Activate</button>
                             </div>
-                            <p id="cloud-msg" style="margin-bottom:0; font-size:0.85em; margin-top:10px; min-height:1.2em;"></p>
-                            
-                            <div id="confirmation-gate" style="display:none; margin-top:15px; background:#1e1e1e; padding:10px; border-radius:4px; border:1px dashed #666;">
-                                <label style="display:flex; align-items:center; gap:10px; cursor:pointer; color:#fff;">
+                            <p id="cloud-msg" class="activate-msg"></p>
+
+                            <div id="confirmation-gate" class="confirm-gate">
+                                <label>
                                     <input type="checkbox" id="chk-confirm" onchange="toggleLoginBtn()">
                                     <span>I have received the email and set my password.</span>
                                 </label>
@@ -197,10 +283,10 @@
             const email = document.getElementById('cloud-email').value;
             const btn = document.getElementById('btn-cloud');
             const msg = document.getElementById('cloud-msg');
-            
+
             if (!email.includes('@')) {
                 msg.innerText = "Please enter a valid email.";
-                msg.style.color = "#e74c3c";
+                msg.style.color = "var(--danger)";
                 return;
             }
 
@@ -218,24 +304,20 @@
             .then(data => {
                 if (data.status === 'success') {
                     msg.innerText = data.message;
-                    msg.style.color = "#2ecc71";
+                    msg.style.color = "var(--accent)";
                     btn.innerText = "Activated";
-                    
-                    // Show Confirmation Checkbox instead of auto-unlocking
                     document.getElementById('login-section').style.display = 'block';
                     document.getElementById('confirmation-gate').style.display = 'block';
-                    // Button remains disabled until checkbox is checked
-                    document.getElementById('login-section').style.display = 'block';
                 } else {
                     msg.innerText = data.error || "Failed to send.";
-                    msg.style.color = "#e74c3c";
+                    msg.style.color = "var(--danger)";
                     btn.disabled = false;
                     btn.innerText = "Send Invite";
                 }
             })
             .catch(e => {
                 msg.innerText = "Connection error.";
-                msg.style.color = "#e74c3c";
+                msg.style.color = "var(--danger)";
                 btn.disabled = false;
                 document.getElementById('cloud-email').disabled = false;
                 btn.innerText = "Send Invite";
@@ -257,16 +339,9 @@
         }
 
         function confirmAndLogin() {
-            // 1. Signal backend to delete the credential file
             fetch('/api/setup/cleanup_credentials', {method: 'POST'})
-                .then(() => {
-                    // 2. Reload page to trigger auth prompt
-                    window.location.href = "/";
-                })
-                .catch(err => {
-                    // Fallback if server unreachable, just reload
-                    window.location.href = "/";
-                });
+                .then(() => { window.location.href = "/"; })
+                .catch(err => { window.location.href = "/"; });
         }
     </script>
 </body>

--- a/src/templates/welcome.html
+++ b/src/templates/welcome.html
@@ -1,41 +1,51 @@
 <!DOCTYPE html>
-<html>
+<html data-theme="light">
 <head>
     <title>{{ platform.product_name }} Setup</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
+    {% include '_theme.html' %}
     <style>
         body {
             max-width: 800px;
             margin: 0 auto;
             padding: 40px 20px;
             text-align: center;
-            background-color: #121212;
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
         }
         .logo {
             font-size: 2.5em;
-            font-weight: bold;
-            color: #fff;
+            font-weight: 300;
+            color: var(--text-strong);
             margin-bottom: 10px;
             letter-spacing: -1px;
         }
-        .logo span { color: #2ecc71; }
+        .logo span { color: var(--accent); font-weight: 700; }
+
+        .tagline {
+            color: var(--text-dim);
+            font-family: var(--font-mono);
+            font-size: 0.85em;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            margin-top: 0;
+        }
+        .tagline::before { content: "// "; color: var(--accent); }
+        .tagline::after  { content: " //"; color: var(--accent); }
 
         .card {
-            background: #1e1e1e;
+            background: var(--surface);
             padding: 30px;
-            border-radius: 12px;
+            border-radius: var(--radius-card);
             text-align: left;
-            margin-top: 30px;
-            box-shadow: 0 4px 15px rgba(0,0,0,0.3);
-            border: 1px solid #333;
+            margin-top: 24px;
+            box-shadow: var(--shadow-card);
+            border: 1px solid var(--border);
         }
 
-        h1 { font-weight: 300; color: #eee; }
+        h1 { font-weight: 300; color: var(--text-strong); margin-bottom: 6px; }
 
         ul { list-style: none; padding: 0; }
-        li { padding: 10px 0; border-bottom: 1px solid #333; color: #ccc; }
+        li { padding: 10px 0; border-bottom: 1px solid var(--hairline); color: var(--text); }
         li:last-child { border-bottom: none; }
 
         /* Mode selector cards */
@@ -46,67 +56,120 @@
             margin: 20px 0;
         }
         .mode-option {
-            border: 2px solid #333;
+            border: 1px solid var(--border);
+            background: var(--surface-2);
             border-radius: 10px;
             padding: 20px;
             cursor: pointer;
-            transition: border-color 0.2s, background 0.2s;
+            transition: border-color 0.18s, background 0.18s, transform 0.18s, box-shadow 0.18s;
             text-align: left;
+            position: relative;
         }
-        .mode-option:hover { border-color: #555; background: #252525; }
+        .mode-option:hover {
+            border-color: var(--border-strong);
+            transform: translateY(-1px);
+            box-shadow: var(--shadow-card);
+        }
         .mode-option.selected {
-            border-color: #2ecc71;
-            background: rgba(46, 204, 113, 0.08);
+            border-color: var(--accent);
+            background: var(--accent-soft);
+            box-shadow: var(--accent-glow);
+        }
+        .mode-option.selected::after {
+            content: "✓";
+            position: absolute;
+            top: 12px; right: 14px;
+            color: var(--accent);
+            font-weight: 700;
         }
         .mode-option input[type=radio] { display: none; }
         .mode-option .mode-title {
             font-size: 1.05em;
             font-weight: 600;
-            color: #fff;
+            color: var(--text-strong);
             margin-bottom: 6px;
         }
         .mode-option .mode-desc {
             font-size: 0.85em;
-            color: #999;
+            color: var(--text-dim);
             line-height: 1.4;
         }
 
         #pangolin-fields { display: none; margin-top: 20px; }
-        #pangolin-fields label { font-size: 0.9em; color: #bbb; display: block; margin-bottom: 4px; margin-top: 14px; }
+        #pangolin-fields label {
+            font-size: 0.85em;
+            color: var(--text-dim);
+            display: block;
+            margin-bottom: 4px;
+            margin-top: 14px;
+            font-family: var(--font-mono);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
         #pangolin-fields input {
             width: 100%;
             box-sizing: border-box;
-            background: #252525;
-            border: 1px solid #444;
-            color: #eee;
-            border-radius: 6px;
+            border-radius: var(--radius-input);
             padding: 9px 12px;
             font-size: 0.95em;
+            font-family: var(--font-mono);
         }
 
         button.btn-main {
-            background-color: #2ecc71;
-            color: #000;
-            font-weight: bold;
-            font-size: 1.1em;
-            padding: 18px 40px;
-            margin-top: 30px;
+            background: var(--accent);
+            color: var(--text-on-accent);
+            font-weight: 700;
+            font-size: 1.05em;
+            padding: 16px 40px;
+            margin-top: 28px;
             border: none;
-            border-radius: 50px;
+            border-radius: var(--radius-pill);
             cursor: pointer;
-            transition: transform 0.2s, background-color 0.2s;
+            box-shadow: var(--accent-glow);
+            transition: transform 0.18s, background-color 0.18s, box-shadow 0.18s;
+            letter-spacing: 0.3px;
         }
-        button.btn-main:hover { transform: scale(1.05); background-color: #27ae60; }
-        button.btn-main:disabled { background-color: #555; color: #888; transform: none; cursor: not-allowed; }
+        button.btn-main:hover { transform: translateY(-1px); background: var(--accent-hover); }
+        button.btn-main:disabled { background: var(--neutral-soft); color: var(--text-faint); transform: none; cursor: not-allowed; box-shadow: none; }
+
+        .notice {
+            margin-top: 16px;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-left: 3px solid var(--accent);
+            border-radius: var(--radius-input);
+            padding: 14px 16px;
+            text-align: left;
+            font-size: 0.92em;
+            color: var(--text);
+        }
+        .notice strong { color: var(--text-strong); }
+
+        .factory-card {
+            border-color: var(--accent);
+            box-shadow: var(--accent-glow);
+        }
+        .factory-card h3 {
+            color: var(--accent);
+            margin-top: 0;
+            font-family: var(--font-mono);
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            font-size: 0.95em;
+        }
+
+        #msg { color: var(--text-dim); margin-top: 18px; font-size: 0.9em; min-height: 1.3em; }
     </style>
 </head>
 <body>
+    {% include '_theme_toggle.html' with context %}
+
     <div class="logo">Home<span>{{ platform.product_suffix }}</span></div>
-    <h1>Private Cloud Setup</h1>
-    <p style="color: #aaa;">Choose how you want to access your {{ platform.product_name }}</p>
+    <p class="tagline">Private Cloud Setup</p>
+    <p style="color: var(--text-dim);">Choose how you want to access your {{ platform.product_name }}</p>
 
     <div class="card">
-        <h3 style="margin-top:0; color:#2ecc71;">Access Mode</h3>
+        <h3 style="margin-top:0; color:var(--accent); font-family:var(--font-mono); text-transform:uppercase; letter-spacing:1px; font-size:0.95em;">Access Mode</h3>
 
         <div class="mode-grid">
             <label class="mode-option selected" id="opt-local" onclick="selectMode('local')">
@@ -134,24 +197,24 @@
     </div>
 
     {% if config.NEWT_ID %}
-    <div class="card" style="border-color:#2ecc71; margin-top:15px;">
-        <h3 style="margin-top:0; color:#2ecc71;">Factory Provisioned Device</h3>
+    <div class="card factory-card">
+        <h3>// Factory Provisioned Device</h3>
         <ul>
             <li><strong>Device ID:</strong> {{ config.NEWT_ID }}</li>
             <li><strong>Main Domain:</strong> {{ config.PANGOLIN_DOMAIN }}</li>
-            <li><strong>Status:</strong> <span style="color:#2ecc71">Online & Ready</span></li>
+            <li><strong>Status:</strong> <span style="color:var(--accent)">Online &amp; Ready</span></li>
         </ul>
-        <p style="font-size:0.85em; color:#888; margin-bottom:0;">Tunnel credentials are pre-provisioned. Select Remote Access to use them.</p>
+        <p style="font-size:0.85em; color:var(--text-dim); margin-bottom:0;">Tunnel credentials are pre-provisioned. Select Remote Access to use them.</p>
     </div>
     {% endif %}
 
-    <div class="notice notice-info" style="margin-top: 16px;">
+    <div class="notice">
       <strong>📋 Hardware checklist</strong>
-      <p style="margin-top: 8px; font-size: 0.9em;">For a true always-on server, set your BIOS to <strong>"Restore on AC Power Loss → Power On"</strong> so HomeBrain restarts automatically after a power outage. This is found in BIOS under Power Management → AC Power Recovery.</p>
+      <p style="margin-top: 8px; font-size: 0.92em;">For a true always-on server, set your BIOS to <strong>"Restore on AC Power Loss → Power On"</strong> so HomeBrain restarts automatically after a power outage. This is found in BIOS under Power Management → AC Power Recovery.</p>
     </div>
 
     <button class="btn-main" onclick="startSetup()" id="btn">Initialize System</button>
-    <p id="msg" style="color: #888; margin-top: 20px; font-size: 0.9em;"></p>
+    <p id="msg"></p>
 
     <script>
         var selectedMode = 'local';


### PR DESCRIPTION
## Summary
- New shared theme partial (`_theme.html` + `_theme_toggle.html`) drives `welcome`, `installing`, and `dashboard`. Light is default; dark is opt-in via a pill toggle, persisted in `localStorage('hb-theme')`. An inline FOUC-safe bootstrap sets `data-theme` before paint.
- water.css custom properties are pinned to our semantic tokens, fixing the OS-dark-mode bleed-through bug (Nextcloud Cron / Redis Caching rows previously rendered with a black background on users whose OS was in dark mode while the app was in light mode).
- Dashboard reclustered around clear separation: **Status** holds live state (new AI Assistant card with rows for Inference Engine, Agent, WhatsApp, Whisper), **Settings** holds config only (model selector, Open OpenClaw quick-launch, unified Install/Enable/Disable button).
- Services card now exposes Nextcloud, Home Assistant, and OpenClaw side-by-side when the AI stack is running.
- Skeleton shimmer loaders replace literal "..." placeholders during fetch.
- "Experimental" badge removed from the AI feature (it is fully tested).
- `platform_models.json`: adds Q4_K_M and Q5_K_M variants, refreshes benchmarks for `ub=4096` / llama.cpp b8951.

## Why
Fresh-install users land on a console-styled dark page that doesn't match their OS or their phone. Light-as-default is friendlier; the toggle preserves the techy console vibe for users who want it. Pinning water.css vars also fixes a real visual bug. Splitting Status vs Settings cleans up a card that had drifted into mixing live state with configuration.

## Test plan
- [x] Provisioned target (192.168.178.58) E2E via Playwright in both modes — welcome → installing → dashboard.
- [x] Verified table rows (Nextcloud Cron, Redis Caching) render on the surface color, not OS-dark, in light mode.
- [x] AI Assistant status card on Status tab updates as services come up; rows hide correctly when WhatsApp/Whisper are absent.
- [x] Settings AI card shows only model selector + OpenClaw link + Install/Enable/Disable button.
- [x] OpenClaw link appears beside Nextcloud / Home Assistant in Services when running.
- [x] Theme toggle persists across navigations; no FOUC on hard reload.
- [ ] Verify on a non-AI device that the GPU-required fallback card still renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)