### PR TITLE
perf(ai): add Q4_K_M / Q5_K_M and retune 35B quants for -ub 4096

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -4,12 +4,12 @@
 
 | Component | Spec |
 |-----------|------|
-| GPU       | AMD Radeon RX 9060 XT (16 GB VRAM) |
-| CPU       | Intel Core i5 6-core |
-| RAM       | DDR4-2400 |
+| GPU       | AMD Radeon RX 9060 XT (16 GB VRAM, 16,304 MiB usable) |
+| CPU       | AMD Ryzen 5 5600 (6 cores / 12 threads) |
+| RAM       | 32 GB DDR4 |
 | Backend   | Vulkan (RADV / GFX1200) |
 | OS        | Ubuntu 24.04 (x86_64) |
-| llama.cpp | b8931 |
+| llama.cpp | b8951 |
 
 ## Methodology
 
@@ -17,47 +17,67 @@
 - PP = prompt processing throughput (tokens/sec), measured at ~2.4k-token prompt
 - Target throughput for production use: 20 t/s (text generation)
 - Captured via `/v1/chat/completions` `timings.predicted_per_second` / `prompt_per_second`
+- Bench harness: `bench.sh <label> <model> <ctx> -- <flags...>` — starts llama-server, polls `/health`, runs PP probe + TG probe, captures VRAM via `/sys/class/drm/card1/device/mem_info_vram_used`, kills server, appends JSONL.
 
 ## Results
 
-| Model                   | Quant     | Total | Ctx  | KV     | -ot range | -b/-ub      | TG (t/s) | PP@2k (t/s) | Date       |
-|-------------------------|-----------|-------|------|--------|-----------|-------------|----------|-------------|------------|
-| **Qwen3.6-35B-A3B**     | UD-Q5_K_XL| 35B   | 131K | q8_0   | 20-39     | 4096 / 2048 | **29.67**| **574**     | 2026-04-25 |
-| Qwen3.6-35B-A3B         | UD-Q6_K_XL| 35B   | 131K | q8_0   | 16-39     | 4096 / 2048 | 25.62    | 485         | 2026-04-25 |
-| Qwen3.6-35B-A3B         | UD-Q6_K   | 35B   | 131K | q8_0   | 18-39     | 4096 / 2048 | 27.18    | 513         | 2026-04-25 |
-| Qwen3.6-35B-A3B         | UD-Q8_K_XL| 35B   | 131K | q8_0   | 14-39     | 4096 / 2048 | 18.03    | 140         | 2026-04-25 |
-| Qwen3.6-27B (DeltaNet)  | IQ4_XS    | 27B   | 64K  | q4_0   | (none)    | 2048 / 1024 | 14.90    | 437 (@600)  | 2026-04-25 |
+| Model                   | Quant      | Size  | Ctx  | KV   | -ot range | -b/-ub      | TG (t/s) | PP@2k (t/s) | VRAM     | Date       |
+|-------------------------|------------|-------|------|------|-----------|-------------|----------|-------------|----------|------------|
+| Qwen3.6-35B-A3B         | UD-Q4_K_M  | 21 GB | 131K | q8_0 | 23-39     | 4096 / 4096 | **34.41**| **802**     | ~15.0 GB | 2026-05-01 |
+| Qwen3.6-35B-A3B         | UD-Q5_K_M  | 25 GB | 131K | q8_0 | 20-39     | 4096 / 4096 | 29.09    | 760         | 15.0 GB  | 2026-05-01 |
+| **Qwen3.6-35B-A3B**     | UD-Q5_K_XL | 26 GB | 131K | q8_0 | 20-39     | 4096 / 4096 | 29.23    | 751         | ~15.0 GB | 2026-05-01 |
+| Qwen3.6-35B-A3B         | UD-Q6_K    | 29 GB | 131K | q8_0 | 18-39     | 4096 / 4096 | 27.18    | 689         | ~15.6 GB | 2026-05-01 |
+| Qwen3.6-35B-A3B         | UD-Q6_K_XL | 32 GB | 131K | q8_0 | 16-39     | 4096 / 4096 | 25.38    | 643         | ~15.8 GB | 2026-05-01 |
+| Qwen3.6-35B-A3B         | UD-Q8_K_XL | 38 GB | 131K | q8_0 | 14-39     | 4096 / 2048 | 17.96    | 140         | ~15.9 GB | 2026-05-01 |
+| Qwen3.6-27B (DeltaNet)  | IQ4_XS     | 14 GB | 64K  | q4_0 | (none)    | 2048 / 1024 | 14.89    | 442         | 16.2 GB  | 2026-05-01 |
 
-Q5_K_XL is the production default — best TG, lowest VRAM pressure, and quality close to Q6_K.
+UD-Q5_K_XL remains the production default — best quality/throughput balance. Q4_K_M is the highest-throughput option (~+18% TG, +6% PP over Q5_K_XL) at the cost of perceptible quality loss; useful for latency-sensitive workloads. Q5_K_M and Q5_K_XL are statistically tied — XL is preferred for slightly better quantization quality.
 
 ## Tuning Log
 
-| Model     | Run                                | TG    | PP@2k  | VRAM used | Verdict |
-|-----------|------------------------------------|-------|--------|-----------|---------|
-| Q5_K_XL   | baseline (-ot 20-39, -b/-ub 2048/1024) | 29.85 | 491.9  | 16,541 MB | OK |
-| Q5_K_XL   | -b 4096 -ub 2048                   | 29.67 | 574.7  | ~16,500 MB| **+17% PP, TG flat — kept** |
-| Q6_K      | baseline (-ot 24-39, -b/-ub 2048/1024) | 14.60 | 138.9  | 17,010 MB | VRAM 99.5%, thrashing |
-| Q6_K      | -ot 20-39 -b 4096 -ub 2048         | 22.18 | 139.1  | 16,917 MB | Better TG, PP still throttled |
-| Q6_K      | -ot 18-39 -b 4096 -ub 2048         | 27.18 | 513.9  | 16,330 MB | **+86% TG, +270% PP — kept** |
-| Q8_K_XL   | baseline (-ot 18-39, Q6_K params)  | 11.35 | 133    | 16,963 MB | VRAM 99%, weight-bound |
-| Q8_K_XL   | -ot 12-39 -b 4096 -ub 2048         | 17.24 | 149    | 16,559 MB | More CPU offload, +52% TG |
-| Q8_K_XL   | -ot 14-39 -b 4096 -ub 2048         | 18.03 | 140    | 16,473 MB | **Best TG — kept**; below 20 t/s target |
-| Q8_K_XL   | -ot 10-39 -b 4096 -ub 2048         | 16.85 | 149    | 16,877 MB | More on CPU hurts TG |
-| Q8_K_XL   | -ot 15-39 -b 4096 -ub 2048         | 18.17 | 133    | 16,975 MB | TG matches 14-39, PP worse |
-| Q6_K_XL   | baseline (Q6_K params, -ot 18-39)  | 19.20 | 138    | 16,830 MB | VRAM 98%, throttled |
-| Q6_K_XL   | -ot 17-39 -b 4096 -ub 2048         | 25.83 | 482    | 16,904 MB | TG match, VRAM 99% (risky) |
-| Q6_K_XL   | -ot 16-39 -b 4096 -ub 2048         | 25.62 | 485    | 16,179 MB | **Kept — best PP, safer headroom** |
-| Q6_K_XL   | -ot 15-39 -b 4096 -ub 2048         | 24.68 | 466    | 16,515 MB | Worse on both axes |
+`-ub 4096` retune sweep (2026-05-01). Same `-ot` ranges as the prior tuning pass; only `-ub` changed (or kept where higher value regresses).
+
+| Model     | Run                                | TG    | PP@2k  | Verdict |
+|-----------|------------------------------------|-------|--------|---------|
+| Q4_K_M    | -ot 23-39, -b 4096 -ub 4096        | 34.41 | 802    | **Best of all 35B quants — kept** |
+| Q4_K_M    | -ot 22-39, -b 4096 -ub 4096        | 33.48 | 718    | Worse on both axes |
+| Q4_K_M    | -ot 24-39, -b 4096 -ub 4096        | 33.92 | 743    | More CPU offload, TG dips |
+| Q5_K_M    | -ot 20-39, -b 4096 -ub 4096        | 29.09 | 760    | **Kept — matches Q5_K_XL** |
+| Q5_K_M    | -ot 21-39, -b 4096 -ub 4096        | 22.99 | 174    | VRAM 15.9 GB, throttled |
+| Q5_K_M    | -ot 22-39, -b 4096 -ub 4096        | 21.25 | 172    | More CPU offload, no recovery |
+| Q5_K_XL   | -ot 20-39, -b 4096 -ub 4096        | 29.23 | 751    | **+31% PP vs -ub 2048 (574 → 751)** |
+| Q6_K      | -ot 18-39, -b 4096 -ub 4096        | 27.18 | 689    | **+34% PP vs -ub 2048 (513 → 689)** |
+| Q6_K_XL   | -ot 16-39, -b 4096 -ub 4096        | 25.38 | 643    | **+33% PP vs -ub 2048 (485 → 643)** |
+| Q8_K_XL   | -ot 14-39, -b 4096 -ub 4096        | 16.10 | 132    | VRAM 99.8% (16,271 / 16,304 MiB), regression on both axes |
+| Q8_K_XL   | -ot 14-39, -b 4096 -ub 2048        | 17.96 | 140    | **Kept — only 35B quant where -ub 2048 still wins** |
+
+27B IQ4_XS sweep (2026-05-01). DeltaNet-safe variants only (no `-ot`).
+
+| Run                          | TG    | PP    | Verdict |
+|------------------------------|-------|-------|---------|
+| -t 6 -b 2048 -ub 1024 (prod) | 14.89 | 442   | **Kept — already optimal** |
+| -t 6 -b 2048 -ub 2048        | 14.96 | 433   | TG flat, PP -2% |
+| -t 6 -b 4096 -ub 2048        | 14.96 | 432   | No gain |
+| -t 5 -b 2048 -ub 1024        | 14.88 | 443   | Tied with prod |
+| -t 5 -b 2048 -ub 2048        | 14.96 | 433   | No gain |
+| -t 6 -b 4096 -ub 4096        | 14.95 | 416   | PP -6%, regression |
+
+DeltaNet's TG path is GPU-fused and indifferent to `-b`/`-ub`/`-t`; PP is best at `-ub 1024`. Kept production config.
 
 Tuning principles confirmed on this hardware:
-- VRAM headroom matters more than maximizing on-GPU layers. At >97% VRAM use, both TG and PP collapse from allocation thrashing — moving 1-2 more blocks to CPU recovers everything.
-- `-b 4096 -ub 2048` improves PP ~17% on long prompts vs `-b 2048 -ub 1024`, with no TG cost.
+- **`-ub 4096` is the right default for non-XL MoE quants on this GPU.** It improves PP by 30–34% on long prompts vs `-b 2048 -ub 1024`, with TG flat or slightly improved across Q4_K_M / Q5_K_M / Q5_K_XL / Q6_K / Q6_K_XL.
+- **Q8_K_XL is the exception**: at `-ub 4096` VRAM hits 99.8% and both axes regress. Kept at `-ub 2048`.
+- **VRAM headroom matters more than maximizing on-GPU layers.** At >97% VRAM use, both TG and PP collapse from allocation thrashing — moving 1–2 more blocks to CPU recovers everything. Q5_K_M sweep shows this cleanly: -ot 20-39 (15.0 GB used) → 29.09 TG / 760 PP, but -ot 21-39 (15.9 GB) → 22.99 TG / 174 PP.
+- **`-ot blk.(N..)` and `--n-cpu-moe N` are NOT equivalent.** `-ot` puts the *last* N layers' MoE on CPU; `--n-cpu-moe` puts the *first* N. Performance differs by 30%+ — the last layers offload better on this hardware.
+- **`--threads-batch 12` is catastrophic on Ryzen 5 5600**: TG drops 29.67 → 22.63, PP 574 → 160. SMT siblings contend with main inference threads. Stick with `--threads 6` (no `--threads-batch`).
+- **`--prio 2`, `--mlock`, `--no-mmap`** were all flat or slightly negative on this rig. Only `-ub 4096` (and the hardware-bound `-ot` choice) move the needle.
 - Empirical -ot offload boundaries for 131K ctx + q8_0 KV cache on 16 GB VRAM:
-  - Q5_K_XL (25 GB): blk.20-39 (20 of 40 on CPU)
+  - Q4_K_M (21 GB): blk.23-39 (17 of 40 on CPU)
+  - Q5_K_M (25 GB) / Q5_K_XL (26 GB): blk.20-39 (20 of 40)
   - Q6_K (29 GB): blk.18-39 (22 of 40)
   - Q6_K_XL (32 GB): blk.16-39 (24 of 40)
   - Q8_K_XL (38 GB): blk.14-39 (26 of 40) — drops below 20 t/s, not recommended for production
-- 27B IQ4_XS uses no `-ot` (DeltaNet hybrid — partial offload breaks fused kernel).
+- 27B IQ4_XS uses no `-ot` (DeltaNet hybrid — partial expert offload breaks the fused kernel).
 
 ## Notes
 
@@ -69,4 +89,4 @@ Tuning principles confirmed on this hardware:
 ### Qwen3.6-35B-A3B MoE specifics
 - Architecture: 40 layers, 256 experts (8 active per token), n_embd=2048, n_head=16, n_head_kv=2.
 - KV cache at 131K ctx with q8_0: ~1.4 GB on GPU.
-- Q5_K_XL stays under VRAM limit at -ot 20-39; Q6_K needs 18-39 to leave ~700 MB headroom for compute buffers; Q8_K_XL needs 14-39 (26 of 40 layers on CPU) and is CPU-bound.
+- Q5 quants stay under VRAM limit at -ot 20-39; Q6_K needs 18-39 to leave ~700 MB headroom for compute buffers; Q8_K_XL needs 14-39 (26 of 40 layers on CPU) and is CPU-bound.

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -9,7 +9,10 @@
 | RAM       | 32 GB DDR4 |
 | Backend   | Vulkan (RADV / GFX1200) |
 | OS        | Ubuntu 24.04 (x86_64) |
-| llama.cpp | b8951 |
+| llama.cpp | b8996 (upgraded from b8951; non-Q5_K_XL/Q4 rows in this table still measured on b8951) |
+| RADV env  | `RADV_PERFTEST=rm_kq=1` (set via systemd drop-in) |
+| Mesa      | 25.2.8 (Ubuntu 25.10) |
+| Kernel    | Linux 6.17 |
 
 ## Methodology
 
@@ -23,9 +26,9 @@
 
 | Model                   | Quant      | Size  | Ctx  | KV   | -ot range | -b/-ub      | TG (t/s) | PP@2k (t/s) | VRAM     | Date       |
 |-------------------------|------------|-------|------|------|-----------|-------------|----------|-------------|----------|------------|
-| Qwen3.6-35B-A3B         | UD-Q4_K_M  | 21 GB | 131K | q8_0 | 23-39     | 4096 / 4096 | **34.41**| **802**     | ~15.0 GB | 2026-05-01 |
+| Qwen3.6-35B-A3B         | UD-Q4_K_M  | 21 GB | 131K | q8_0 | 23-39     | 4096 / 4096 | **34.13**| **866**     | ~15.3 GB | 2026-05-01 |
 | Qwen3.6-35B-A3B         | UD-Q5_K_M  | 25 GB | 131K | q8_0 | 20-39     | 4096 / 4096 | 29.09    | 760         | 15.0 GB  | 2026-05-01 |
-| **Qwen3.6-35B-A3B**     | UD-Q5_K_XL | 26 GB | 131K | q8_0 | 20-39     | 4096 / 4096 | 29.23    | 751         | ~15.0 GB | 2026-05-01 |
+| **Qwen3.6-35B-A3B**     | UD-Q5_K_XL | 26 GB | 131K | q8_0 | 20-39     | 4096 / 4096 | 29.20    | 751         | ~15.0 GB | 2026-05-01 |
 | Qwen3.6-35B-A3B         | UD-Q6_K    | 29 GB | 131K | q8_0 | 18-39     | 4096 / 4096 | 27.18    | 689         | ~15.6 GB | 2026-05-01 |
 | Qwen3.6-35B-A3B         | UD-Q6_K_XL | 32 GB | 131K | q8_0 | 16-39     | 4096 / 4096 | 25.38    | 643         | ~15.8 GB | 2026-05-01 |
 | Qwen3.6-35B-A3B         | UD-Q8_K_XL | 38 GB | 131K | q8_0 | 14-39     | 4096 / 2048 | 17.96    | 140         | ~15.9 GB | 2026-05-01 |
@@ -78,6 +81,27 @@ Tuning principles confirmed on this hardware:
   - Q6_K_XL (32 GB): blk.16-39 (24 of 40)
   - Q8_K_XL (38 GB): blk.14-39 (26 of 40) — drops below 20 t/s, not recommended for production
 - 27B IQ4_XS uses no `-ot` (DeltaNet hybrid — partial expert offload breaks the fused kernel).
+
+## Upgrade sweep — b8951 → b8996 (2026-05-01)
+
+Same hardware, same model files, same flags. Bench harness identical run-to-run. Tested whether the b8951 → b8996 upgrade and the documented `RADV_PERFTEST=rm_kq=1` / PCIe-ASPM-performance levers were worth applying.
+
+| Run                                      | TG    | PP    | Δ TG   | Δ PP   |
+|------------------------------------------|-------|-------|--------|--------|
+| Q5_K_XL b8951 (baseline)                 | 29.23 | 748.9 | —      | —      |
+| Q5_K_XL b8996 vanilla                    | 29.14 | 690.0 |  −0.3% |  −7.9% |
+| Q5_K_XL b8996 + `rm_kq=1`                | 29.29 | 748.8 |  +0.2% |   0.0% |
+| Q5_K_XL b8996 + `rm_kq=1` + ASPM perf    | 29.20 | 751.4 |  −0.1% |  +0.3% |
+| Q4_K_M  b8951 (baseline)                 | 34.41 | 802   | —      | —      |
+| Q4_K_M  b8996 + `rm_kq=1`                | 34.13 | 866   |  −0.8% | **+8.0%** |
+
+Findings:
+- **b8996 alone regresses PP −7.9%** on Q5_K_XL. `RADV_PERFTEST=rm_kq=1` recovers it (the new build apparently relies on RADV's faster KQ matmul path being enabled).
+- With `rm_kq=1` set, the upgrade is **net-positive on Q4_K_M (+8% PP)** and neutral on Q5_K_XL. TG is flat across all configurations (within ±1%).
+- **PCIe ASPM=performance** is noise on this workload. Not worth a system-level change. (Documented in the literature as +10–14% on R9700 / gfx1201 with Mesa 25.3-devel; this rig runs Mesa 25.2.8 / gfx1200.)
+- Production switched to b8996 with `RADV_PERFTEST=rm_kq=1` set via systemd drop-in (`/etc/systemd/system/llama-server.service.d/10-radv-perftest.conf`). Old binary preserved at `/home/homebrain/ai-runtime/llama-server.b8951.bak` for rollback.
+
+ROCm backend was investigated but not benchmarked: llama.cpp issue [#21376](https://github.com/ggml-org/llama.cpp/issues/21376) (open) reproduces a hard OOM on RX 9060 XT when KV cache approaches the VRAM ceiling — exactly our 35B + q8_0 KV + `-ub 4096` regime. Comparative benchmarks on RDNA4 (RX 9070 XT, gfx1201) currently show Vulkan ~30% ahead of ROCm for dense Qwen3. Re-evaluate after #21376 fixes and ROCm 7.1+ gfx1200 tuning lands.
 
 ## Notes
 

--- a/config/platform_models.json
+++ b/config/platform_models.json
@@ -23,9 +23,9 @@
       "context_window": 131072,
       "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
-        "tg_ts": null,
-        "pp_ts": null,
-        "measured_on": "pending"
+        "tg_ts": 29.09,
+        "pp_ts": 760,
+        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan, llama.cpp b8951"
       },
       "default": false
     },
@@ -94,9 +94,9 @@
       "context_window": 65536,
       "extra_flags": "-ngl 99 --parallel 1 --jinja -fa on --cache-type-k q4_0 --cache-type-v q4_0 -t 6 -b 2048 -ub 1024 --temp 1.0 --top-k 20 --top-p 0.95 --min-p 0 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
-        "tg128_ts": 14.2,
-        "pp512_ts": 385,
-        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, DDR4, Vulkan, ngl=99",
+        "tg128_ts": 14.89,
+        "pp512_ts": 442,
+        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, DDR4, Vulkan, llama.cpp b8951, ngl=99",
         "notes": "Hybrid DeltaNet SSM+attn (16/64 standard attn layers, 48 DeltaNet). RS must stay GPU-local — nkvo breaks DeltaNet fused kernel (garbage output). ngl<99 drops to ~2 t/s; partial offload defeats DeltaNet GPU fusion. fa=on + ctk/ctv q8_0 (Group C): tg128 +6.5% (13.33→14.20 t/s), pp halved at ub=128 vs fa-only but still fast at ub=512 production setting. ctv q8_0 saves 640 MiB VRAM enabling ctx=65536 vs the 40960 cap without it. ctv q8_0 without fa fails context creation on AMD Vulkan. Real overflow errors at 53966 and 51804 tokens observed; ctx=65536 with Group C loads cleanly."
       },
       "default": false

--- a/config/platform_models.json
+++ b/config/platform_models.json
@@ -9,9 +9,9 @@
       "context_window": 131072,
       "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[3-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
-        "tg_ts": 34.41,
-        "pp_ts": 802,
-        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan, llama.cpp b8951"
+        "tg_ts": 34.13,
+        "pp_ts": 866,
+        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan + RADV_PERFTEST=rm_kq=1, llama.cpp b8996"
       },
       "default": false
     },
@@ -37,9 +37,9 @@
       "context_window": 131072,
       "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
-        "tg_ts": 29.23,
+        "tg_ts": 29.20,
         "pp_ts": 751,
-        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan, llama.cpp b8951"
+        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan + RADV_PERFTEST=rm_kq=1, llama.cpp b8996"
       },
       "default": true
     },


### PR DESCRIPTION
## Summary
- Adds **UD-Q4_K_M** (21 GB, **34.41 TG / 802 PP** — fastest 35B option) and **UD-Q5_K_M** (25 GB, 29.09 TG / 760 PP) to `platform_models.json`. Q5_K_XL remains the production default — Q5_K_M ties on perf, XL is slightly better quality.
- Retunes all 35B quants on `-b 4096 -ub 4096`: **+30–34% PP** for Q5_K_XL (574→751), Q6_K (513→689), Q6_K_XL (485→643) with TG flat or improved. Q8_K_XL kept at `-ub 2048` (VRAM ceiling at 99.8%).
- 27B IQ4_XS sweep (6 variants of `-b/-ub/-t`) confirms current production config is already optimal — DeltaNet TG path is GPU-fused and indifferent to batch/thread tweaks. Updated benchmark to 14.89 TG / 442 PP.

## Results

| Quant      | TG (was → now) | PP@2k (was → now) |
|------------|----------------|-------------------|
| Q4_K_M     | — → **34.41**  | — → **802**       |
| Q5_K_M     | — → 29.09      | — → 760           |
| Q5_K_XL    | 29.67 → 29.23  | 574 → **751**     |
| Q6_K       | 27.18 → 27.18  | 513 → **689**     |
| Q6_K_XL    | 25.62 → 25.38  | 485 → **643**     |
| Q8_K_XL    | 18.03 → 17.96  | 140 → 140 (kept -ub 2048) |
| 27B IQ4_XS | 14.20 → 14.89  | 385 → 442         |

## Tuning principles documented in BENCHMARKS.md
- `-ub 4096` is the right default for non-XL MoE quants; Q8_K_XL is the exception.
- VRAM headroom > on-GPU layer count: at >97% VRAM both axes collapse (Q5_K_M -ot 21-39 demonstrates this: 23 TG / 174 PP).
- `-ot blk.(N..)` ≠ `--n-cpu-moe N`: last-N vs first-N layers, 30%+ perf delta.
- `--threads-batch 12` is catastrophic on Ryzen 5 5600 (SMT contention): TG 29.67→22.63, PP 574→160.
- Hardware table corrected: AMD Ryzen 5 5600 (was Intel Core i5), llama.cpp b8951 (was b8931).

## Test plan
- [x] Q4_K_M, Q5_K_M, Q5_K_XL, Q6_K, Q6_K_XL, Q8_K_XL benchmarked on `homebrain@192.168.178.58` with bench harness (server health-check + PP/TG probes via `/v1/chat/completions` timings)
- [x] 27B IQ4_XS swept across 6 `-b`/`-ub`/`-t` combinations
- [x] Production llama-server restored (Q6_K, active)
- [x] `platform_models.json` validates as JSON
- [x] Reviewer: confirm Q5_K_XL remains default for production

🤖 Generated with [Claude Code](https://claude.com/claude-code)