### PR TITLE
chore(deps): pin llama.cpp b8996, whisper.cpp v1.8.4, ship RADV drop-in

### DIFF
--- a/config/llama-server.service
+++ b/config/llama-server.service
@@ -11,6 +11,10 @@ Group=__HOMEBRAIN_USER__
 WorkingDirectory=__WORKDIR__
 Environment="LD_LIBRARY_PATH=__WORKDIR__"
 Environment="GGML_VK_DEVICE=0"
+# RADV fast KQ matmul path. Required for llama.cpp b8996+ on RADV/GFX1200 to
+# avoid a -7.9% PP regression; also nets +8% PP on Q4_K_M MoE quants. See
+# BENCHMARKS.md upgrade sweep (2026-05-01).
+Environment="RADV_PERFTEST=rm_kq=1"
 
 # Wait for GPU device node before starting inference (30 second timeout)
 ExecStartPre=/bin/sh -c 'i=0; until [ -e /dev/dri/renderD128 ] || [ -e /dev/dri/card0 ]; do sleep 1; i=$((i+1)); [ $i -ge 30 ] && exit 1; done'

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,10 @@
 {
   "llama_cpp": {
-    "tag": "b8931",
-    "url": "https://github.com/ggml-org/llama.cpp/releases/download/b8931/llama-b8931-bin-ubuntu-vulkan-x64.tar.gz"
+    "tag": "b8996",
+    "url": "https://github.com/ggml-org/llama.cpp/releases/download/b8996/llama-b8996-bin-ubuntu-vulkan-x64.tar.gz"
+  },
+  "whisper_cpp": {
+    "git_ref": "v1.8.4"
   },
   "openclaw": {
     "version": "2026.4.24"

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -17,8 +17,9 @@ load_versions() {
     [[ -f "$versions_file" ]] || die "versions.json not found at $versions_file"
     LLAMA_TAG=$(jq -r '.llama_cpp.tag' "$versions_file")
     LLAMA_URL=$(jq -r '.llama_cpp.url' "$versions_file")
+    WHISPER_GIT_REF=$(jq -r '.whisper_cpp.git_ref // "master"' "$versions_file")
     OPENCLAW_VERSION=$(jq -r '.openclaw.version' "$versions_file")
-    export LLAMA_TAG LLAMA_URL OPENCLAW_VERSION
+    export LLAMA_TAG LLAMA_URL WHISPER_GIT_REF OPENCLAW_VERSION
 }
 
 get_installed_versions_file() {
@@ -538,6 +539,11 @@ install_llamacpp() {
         installed_tag=$(jq -r '.llama_cpp.tag // empty' "$installed_file" 2>/dev/null || echo "")
     fi
 
+    # Always (re)apply the RADV drop-in so existing devices pick it up on the
+    # first dashboard update after this change, even when the binary itself is
+    # already current and the install short-circuits below.
+    _install_llama_radv_dropin
+
     if [[ "$installed_tag" == "$LLAMA_TAG" ]] && [[ -x "$bin_path" ]]; then
         log_info "llama.cpp already at ${LLAMA_TAG}, skipping."
         return 0
@@ -560,6 +566,22 @@ install_llamacpp() {
 
     update_installed_version '.llama_cpp.tag' "$LLAMA_TAG"
     log_info "Installed llama.cpp ${LLAMA_TAG} at ${bin_path}"
+}
+
+# Apply RADV_PERFTEST=rm_kq=1 via systemd drop-in. b8996+ on RADV/GFX1200
+# regresses prompt-processing -7.9% without this; with it, +8% on Q4_K_M.
+# Idempotent: overwrite each upgrade; daemon-reload picks up changes for
+# the next restart performed by the caller (update.sh).
+_install_llama_radv_dropin() {
+    local dropin_dir="/etc/systemd/system/llama-server.service.d"
+    local dropin_file="${dropin_dir}/10-radv-perftest.conf"
+    mkdir -p "$dropin_dir"
+    cat > "$dropin_file" <<'EOF'
+[Service]
+Environment="RADV_PERFTEST=rm_kq=1"
+EOF
+    chmod 644 "$dropin_file"
+    systemctl daemon-reload 2>/dev/null || true
 }
 
 # Generate the systemd service file at runtime from model/platform config.
@@ -797,7 +819,14 @@ install_whisper_server() {
         return 0
     fi
 
-    # whisper.cpp has no prebuilt Linux binaries — build from source
+    # Pin to a known-good whisper.cpp tag from versions.json. Build is from
+    # source (upstream ships no Linux prebuilts) and runs only at provision
+    # time — not on dashboard update — to keep updates fast and avoid
+    # compile-time failures (apt drift, header skew) breaking voice control
+    # on existing devices. Bumping git_ref affects fresh installs only.
+    load_versions
+    local whisper_ref="${WHISPER_GIT_REF:-master}"
+
     log_info "Installing build dependencies for whisper.cpp..."
     wait_for_apt_lock
     export DEBIAN_FRONTEND=noninteractive
@@ -808,13 +837,15 @@ install_whisper_server() {
 
     local src_dir="/tmp/whisper.cpp"
     if [[ -d "$src_dir/.git" ]]; then
-        log_info "Updating existing whisper.cpp source..."
-        git -C "$src_dir" pull --ff-only 2>/dev/null || true
+        log_info "Updating existing whisper.cpp source to ${whisper_ref}..."
+        git -C "$src_dir" fetch --depth 1 origin "$whisper_ref" 2>/dev/null || true
+        git -C "$src_dir" checkout -q "$whisper_ref" 2>/dev/null || true
     else
-        log_info "Cloning whisper.cpp..."
+        log_info "Cloning whisper.cpp at ${whisper_ref}..."
         rm -rf "$src_dir"
-        git clone --depth 1 https://github.com/ggml-org/whisper.cpp.git "$src_dir" \
-            || die "Failed to clone whisper.cpp"
+        git clone --depth 1 --branch "$whisper_ref" \
+            https://github.com/ggml-org/whisper.cpp.git "$src_dir" \
+            || die "Failed to clone whisper.cpp at ${whisper_ref}"
     fi
 
     log_info "Building whisper-server with Vulkan GPU support..."


### PR DESCRIPTION
## Summary
Follow-up to #9. Bumps `versions.json` so the dashboard update flow actually carries the b8996 binary upgrade through the existing `install_llamacpp` → `systemctl restart llama-server` path. Also wires `RADV_PERFTEST=rm_kq=1` into both the canonical service template and a runtime-installed systemd drop-in so existing devices pick it up on the first dashboard update without needing a model switch.

For whisper.cpp: pin the git ref (v1.8.4) for reproducible new installs, but **deliberately do not auto-rebuild on update** — see rationale below.

## Changes
- `config/versions.json`: `llama_cpp.tag b8931 → b8996`, add `whisper_cpp.git_ref: "v1.8.4"`.
- `config/llama-server.service`: `Environment="RADV_PERFTEST=rm_kq=1"` in the canonical template (covers fresh provisions and dashboard model switches that regenerate the unit).
- `scripts/utilities.sh`:
  - `load_versions()` exports `WHISPER_GIT_REF`.
  - `install_llamacpp()` calls a new helper `_install_llama_radv_dropin()` **before** the early-return so the drop-in lands on every invocation, even when the binary is already current. Helper writes `/etc/systemd/system/llama-server.service.d/10-radv-perftest.conf` and `daemon-reload`s; the caller (`update.sh`) handles the restart.
  - `install_whisper_server()` clones at `WHISPER_GIT_REF` (default `master`); skipped on existing devices so we don't risk a compile failure during dashboard update.

## Why no auto-rebuild for whisper

| Aspect | llama.cpp | whisper.cpp |
|---|---|---|
| Upstream prebuilt | yes (Ubuntu Vulkan tarball) | no — source build required |
| Update cost | seconds (extract tarball) | ~5 min compile, needs cmake + g++ + glslc + libvulkan-dev |
| Failure modes during update | network (idempotent retry) | apt drift, header skew, kernel/Vulkan SDK mismatch — can leave a broken binary |
| Criticality | core LLM service | voice control (degrades gracefully if absent) |

A failed in-place rebuild on a live device would silently break voice control until the user notices. Pinning `git_ref` gives reproducibility for fresh installs (the actual stability win); existing devices keep their working binary until rebuilt manually. Revisit if/when whisper.cpp ships prebuilt Linux artifacts.

## E2E verification (homebrain@192.168.178.58)
1. Staged patched scripts at `/tmp/e2e/`.
2. Ran `update-deps.sh llama_cpp` with `b8996` already installed and the drop-in deleted:
   - Output: `[INFO] llama.cpp already at b8996, skipping.`
   - Drop-in recreated correctly.
3. Live `llama-server` process (`/proc/$PID/environ`) carries `RADV_PERFTEST=rm_kq=1`. Service active. Health 200.

## Test plan
- [x] JSON validates, bash syntax clean (`bash -n scripts/utilities.sh`)
- [x] E2E on .58: short-circuit + drop-in idempotency verified
- [ ] Reviewer: confirm whisper-no-auto-rebuild stance for the project's stability target
- [ ] Optional: cut a release after merge so existing devices clicking "Update" pick up the bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)