### PR TITLE
docs(readme): polish hardware specs, ports, and AI stack details

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Inference runs on Vulkan via Mesa RADV — no ROCm install required. See [BENCHM
 
 | Component | Minimum | Recommended |
 |-----------|---------|-------------|
-| Board | Raspberry Pi 4 (4 GB) | Raspberry Pi 5 (8 GB) — or any x86_64 mini-PC |
+| Board | Raspberry Pi 4 (8 GB) | Raspberry Pi 5 (8 GB) — or any x86_64 mini-PC |
 | OS | Raspberry Pi OS 64-bit (Bookworm) or Ubuntu Server 24.04 (arm64/x86_64) | same |
-| RAM | 4 GB | 8 GB |
-| Storage | 32 GB microSD/SSD | 256 GB SSD/NVMe over USB 3 or PCIe |
+| RAM | 8 GB | 8 GB |
+| Storage | 64 GB microSD/SSD | 256 GB SSD/NVMe over USB 3 or PCIe |
 | Network | Ethernet | Ethernet (Gigabit) |
 
 Architecture is auto-detected: any non-x86_64 host is treated as no-GPU and the AI stack is skipped. The dashboard, backups, and Pangolin tunnel all behave identically to the full edition.
@@ -91,10 +91,31 @@ No tunnel. Services available on the local network at `homebrain.local` (mDNS) o
 
 ## Installation
 
+The flow is **bootstrap → provision → reboot**. The bootstrapper drops the repo into `/opt/homebrain` and stages the provision script; provisioning then sets up users, services, the Docker stack, and (on x86 + GPU) the AI runtime.
+
 ### 1. Bootstrap
 
+On a freshly installed host (Ubuntu 24.04+ on x86_64, Raspberry Pi OS 64-bit / Ubuntu Server arm64 on a Pi 4/5), run:
+
 ```bash
-curl -fsSL https://raw.githubusercontent.com/oalterg/homebrain/main/install | sudo bash
+curl -fsSL https://raw.githubusercontent.com/oalterg/HomeBrain/main/install | sudo bash
+```
+
+This single-shot bootstrapper:
+
+- installs `curl`, `tar`, `gzip` if missing
+- downloads the latest `main` tarball into `/opt/homebrain` (override with `REPO_URL=...` for a tag/branch)
+- creates `/var/log/homebrain` for logs
+- marks `scripts/provision.sh` executable
+
+It does **not** install Docker, Nextcloud, or anything privileged beyond unpacking the repo — that all happens in step 2 where you can review and re-run safely.
+
+If you'd rather inspect before piping to `bash`:
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/oalterg/HomeBrain/main/install
+less install
+sudo bash install
 ```
 
 ### 2. Provision

--- a/README.md
+++ b/README.md
@@ -1,22 +1,49 @@
 # HomeBrain
 
-A private cloud + AI assistant in a box. One Ubuntu machine, one provisioning command, no SaaS dependencies.
+A private cloud + AI assistant in a box. One machine, one provisioning command, no SaaS dependencies.
 
-HomeBrain bundles **Nextcloud** (file sync), **Home Assistant** (smart home), and **OpenClaw** (local AI assistant on WhatsApp, backed by Qwen3.6 via llama.cpp) into a single stack. Reach it from anywhere over a self-hosted **Pangolin** tunnel, or keep it on the LAN with no tunnel at all.
+HomeBrain bundles **Nextcloud** (file sync), **Home Assistant** (smart home), and — when a GPU is present — **OpenClaw** (local AI assistant on WhatsApp, backed by Qwen3.6 via llama.cpp) into a single stack. Reach it from anywhere over a self-hosted **Pangolin** tunnel, or keep it on the LAN with no tunnel at all.
+
+---
+
+## Editions
+
+The same codebase ships in two flavors, picked automatically by the architecture detector at provision time — no flag to set:
+
+| Edition | Target | What runs | Best for |
+|---|---|---|---|
+| **HomeBrain** (full) | x86_64 + AMD GPU | Nextcloud · Home Assistant · llama.cpp · whisper.cpp · OpenClaw | Households that want a private LLM and voice control alongside file sync and home automation |
+| **HomeCloud** (AI-disabled) | aarch64 (Raspberry Pi 4 / 5) or any x86_64 box without a GPU | Nextcloud · Home Assistant · (optional) Pangolin tunnel | A quiet, low-power family cloud and smart-home hub with optional internet access through your own tunnel |
+
+The Pangolin remote-access tunnel is available in both editions; the AI stack only ships on x86_64 + AMD GPU.
 
 ---
 
 ## Hardware Requirements
+
+### HomeBrain (full)
 
 | Component | Minimum | Recommended |
 |-----------|---------|-------------|
 | OS | Ubuntu 24.04 LTS (x86_64) | Ubuntu 24.04 LTS or 25.10 |
 | RAM | 16 GB | 32 GB |
 | Storage | 64 GB SSD | 512 GB NVMe (model files alone are ~25 GB) |
-| GPU | — (AI features disabled) | AMD Radeon RX 6000-series or newer, **16 GB VRAM** |
+| GPU | AMD Radeon RX 6000-series, 8 GB VRAM | AMD Radeon RX 9060 XT or newer, **16 GB VRAM** |
 | Network | Ethernet | Ethernet (Gigabit) |
 
-**GPU note:** The AI stack (llama.cpp inference + OpenClaw assistant) auto-enables when a compatible AMD GPU is present. Inference runs on Vulkan via Mesa RADV — no ROCm install required. Without a GPU, HomeBrain runs as a privacy-first Nextcloud + Home Assistant server with the AI features disabled. See [BENCHMARKS.md](BENCHMARKS.md) for measured throughput across quantizations on a Radeon RX 9060 XT.
+Inference runs on Vulkan via Mesa RADV — no ROCm install required. See [BENCHMARKS.md](BENCHMARKS.md) for measured throughput across quantizations on a Radeon RX 9060 XT.
+
+### HomeCloud (AI-disabled)
+
+| Component | Minimum | Recommended |
+|-----------|---------|-------------|
+| Board | Raspberry Pi 4 (4 GB) | Raspberry Pi 5 (8 GB) — or any x86_64 mini-PC |
+| OS | Raspberry Pi OS 64-bit (Bookworm) or Ubuntu Server 24.04 (arm64/x86_64) | same |
+| RAM | 4 GB | 8 GB |
+| Storage | 32 GB microSD/SSD | 256 GB SSD/NVMe over USB 3 or PCIe |
+| Network | Ethernet | Ethernet (Gigabit) |
+
+Architecture is auto-detected: any non-x86_64 host is treated as no-GPU and the AI stack is skipped. The dashboard, backups, and Pangolin tunnel all behave identically to the full edition.
 
 ---
 
@@ -54,11 +81,11 @@ No tunnel. Services available on the local network at `homebrain.local` (mDNS) o
 
 ## Prerequisites
 
-1. **Ubuntu 24.04+ x86_64** — freshly installed, SSH accessible
-2. **`homebrain` OS user** — created during provisioning
+1. **64-bit OS, freshly installed** — Ubuntu 24.04+ on x86_64 (HomeBrain), or Raspberry Pi OS 64-bit / Ubuntu Server arm64 on a Pi 4/5 (HomeCloud). SSH accessible either way.
+2. **`homebrain` OS user** — created during provisioning if missing
 3. **For Remote Access mode**: Pangolin tunnel credentials (`NEWT_ID`, `NEWT_SECRET`, tunnel domain, Pangolin endpoint)
-4. **For AI features**: AMD GPU with ≥ 16 GB VRAM. Inference uses Vulkan via Mesa RADV — no ROCm setup needed.
-5. **BIOS setting**: *Restore on AC Power Loss* → **Power On** so the server auto-starts after a power outage
+4. **For AI features (HomeBrain only)**: AMD GPU with ≥ 16 GB VRAM. Inference uses Vulkan via Mesa RADV — no ROCm setup needed.
+5. **BIOS / firmware**: *Restore on AC Power Loss* → **Power On** (or the equivalent Pi PSU watchdog setting) so the server auto-starts after a power outage
 
 ---
 
@@ -114,14 +141,14 @@ All runtime configuration lives in `/opt/homebrain/.env`. Key variables:
 ## Architecture
 
 ```
-HomeBrain
+HomeBrain / HomeCloud
 ├── Nextcloud          (Docker)            — file sync, CalDAV, CardDAV
 ├── Home Assistant     (Docker)            — smart home automation
 ├── MariaDB            (Docker)            — Nextcloud database
 ├── Pangolin Newt      (Docker, optional)  — tunnel client
-├── llama-server       (systemd, GPU)      — local LLM inference (llama.cpp + Vulkan)
-├── whisper-server     (systemd, GPU)      — speech-to-text (whisper.cpp + Vulkan)
-└── OpenClaw           (systemd, GPU)      — AI assistant + WhatsApp integration
+├── llama-server       (systemd, x86 GPU)  — local LLM inference (HomeBrain only)
+├── whisper-server     (systemd, x86 GPU)  — speech-to-text     (HomeBrain only)
+└── OpenClaw           (systemd, x86 GPU)  — AI assistant + WhatsApp (HomeBrain only)
 ```
 
 Updates are pinned in [`config/versions.json`](config/versions.json) and applied via the dashboard's "Update" button — bumping the pinned `llama_cpp.tag` automatically re-downloads and restarts the inference binary on the next update click. See [BENCHMARKS.md](BENCHMARKS.md) for the inference tuning rationale and [TESTING.md](TESTING.md) for the E2E verification checklist used before every merge to `main`.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # HomeBrain
 
-Self-hosted private cloud and AI assistant server. Runs on a standard x86_64 Ubuntu machine with an AMD GPU.
+A private cloud + AI assistant in a box. One Ubuntu machine, one provisioning command, no SaaS dependencies.
 
-HomeBrain bundles **Nextcloud** (file sync and storage), **Home Assistant** (smart home), and **OpenClaw** (local AI assistant via WhatsApp) into a single provisioned stack — remote-accessible over a Pangolin tunnel, or local-network-only with no tunnel required.
+HomeBrain bundles **Nextcloud** (file sync), **Home Assistant** (smart home), and **OpenClaw** (local AI assistant on WhatsApp, backed by Qwen3.6 via llama.cpp) into a single stack. Reach it from anywhere over a self-hosted **Pangolin** tunnel, or keep it on the LAN with no tunnel at all.
 
 ---
 
@@ -10,13 +10,13 @@ HomeBrain bundles **Nextcloud** (file sync and storage), **Home Assistant** (sma
 
 | Component | Minimum | Recommended |
 |-----------|---------|-------------|
-| OS | Ubuntu 22.04 LTS (x86_64) | Ubuntu 24.04 LTS |
-| RAM | 8 GB | 16 GB |
-| Storage | 64 GB SSD | 256 GB NVMe |
-| GPU | — (AI features disabled) | AMD RX 9060 or newer (≥ 8 GB VRAM) |
+| OS | Ubuntu 24.04 LTS (x86_64) | Ubuntu 24.04 LTS or 25.10 |
+| RAM | 16 GB | 32 GB |
+| Storage | 64 GB SSD | 512 GB NVMe (model files alone are ~25 GB) |
+| GPU | — (AI features disabled) | AMD Radeon RX 6000-series or newer, **16 GB VRAM** |
 | Network | Ethernet | Ethernet (Gigabit) |
 
-**GPU note:** The AI stack (llamacpp inference + OpenClaw AI assistant) is automatically enabled when a compatible AMD GPU is detected. Without a GPU, HomeBrain runs as a privacy-first Nextcloud + Home Assistant server.
+**GPU note:** The AI stack (llama.cpp inference + OpenClaw assistant) auto-enables when a compatible AMD GPU is present. Inference runs on Vulkan via Mesa RADV — no ROCm install required. Without a GPU, HomeBrain runs as a privacy-first Nextcloud + Home Assistant server with the AI features disabled. See [BENCHMARKS.md](BENCHMARKS.md) for measured throughput across quantizations on a Radeon RX 9060 XT.
 
 ---
 
@@ -34,30 +34,31 @@ Accessible from anywhere via a **Pangolin** self-hosted tunnel (no static IP, no
 ### 🏠 Local Network Only
 No tunnel. Services available on the local network at `homebrain.local` (mDNS) or by LAN IP. No registration or external credentials required.
 
+- `http://homebrain.local`      → HomeBrain Dashboard (port 80)
 - `http://homebrain.local:8080` → Nextcloud
 - `http://homebrain.local:8123` → Home Assistant
-- `http://homebrain.local:4000` → HomeBrain Dashboard
 
 ---
 
 ## Features
 
 - **Privacy-first**: All data stays on your hardware. No telemetry, no cloud sync, no vendor lock-in.
-- **One-command provisioning**: A setup wizard handles all configuration — passwords, tunnel credentials, deployment mode.
-- **Local AI assistant**: [OpenClaw](https://openclaw.ai) runs a WhatsApp-connected AI agent backed by local llamacpp inference (GPU required). Powered by Qwen3.5 models.
-- **Automated backups**: Scheduled snapshots with configurable retention. Backs up Nextcloud data, Home Assistant config, and OpenClaw agent workspace/memory.
-- **Always-on hardening**: AMD GPU runtime power management disabled (VRAM stays loaded between requests), systemd crash-loop protection, sleep inhibitor service.
-- **Dashboard**: Real-time system stats including GPU utilisation, VRAM, and temperature. Log viewer for all services including llamacpp and OpenClaw.
+- **One-command provisioning**: A browser-based setup wizard handles passwords, tunnel credentials, model selection, and deployment mode.
+- **Local AI assistant**: [OpenClaw](https://openclaw.ai) runs a WhatsApp-connected agent backed by local llama.cpp inference. Default model is Qwen3.6-35B-A3B (MoE); lighter quantizations selectable from the dashboard.
+- **Tuned inference**: Vulkan-RADV configuration tuned for AMD RDNA3/RDNA4 — selective MoE expert offload, q8_0 KV cache, flash attention, `RADV_PERFTEST=rm_kq=1`. ~29 t/s generation, ~750 t/s prompt processing on a 16 GB card at 131K context. See [BENCHMARKS.md](BENCHMARKS.md).
+- **Automated backups**: Scheduled snapshots with configurable retention. Covers Nextcloud data, Home Assistant config, and OpenClaw agent workspace/memory.
+- **Reliability hardening**: AMD GPU runtime power management disabled (VRAM stays resident between requests), systemd crash-loop protection, sleep inhibitor.
+- **Dashboard**: Real-time GPU utilisation, VRAM, and temperature; log viewer for all services; in-place updates via pinned `versions.json`.
 
 ---
 
 ## Prerequisites
 
-1. **Ubuntu 22.04+ x86_64** — freshly installed, SSH accessible
+1. **Ubuntu 24.04+ x86_64** — freshly installed, SSH accessible
 2. **`homebrain` OS user** — created during provisioning
 3. **For Remote Access mode**: Pangolin tunnel credentials (`NEWT_ID`, `NEWT_SECRET`, tunnel domain, Pangolin endpoint)
-4. **For AI features**: AMD GPU with ≥ 8 GB VRAM; ROCm-compatible (RX 5000 series or newer)
-5. **BIOS setting**: Set *Restore on AC Power Loss* → **Power On** so the server auto-starts after a power outage
+4. **For AI features**: AMD GPU with ≥ 16 GB VRAM. Inference uses Vulkan via Mesa RADV — no ROCm setup needed.
+5. **BIOS setting**: *Restore on AC Power Loss* → **Power On** so the server auto-starts after a power outage
 
 ---
 
@@ -71,6 +72,8 @@ curl -fsSL https://raw.githubusercontent.com/oalterg/homebrain/main/install | su
 
 ### 2. Provision
 
+The recommended path is the **browser setup wizard** at `http://<server-ip>` — it walks through deployment mode, credentials, and model selection. For headless deployments, run `provision.sh` directly:
+
 **Remote Access mode** (Pangolin tunnel):
 ```bash
 sudo /opt/homebrain/scripts/provision.sh \
@@ -82,7 +85,7 @@ sudo /opt/homebrain/scripts/provision.sh \
 sudo /opt/homebrain/scripts/provision.sh "<FACTORY_PASSWORD>"
 ```
 
-Alternatively, open the **setup wizard** in your browser at `http://<server-ip>:4000` to configure everything via the GUI.
+Omit `<FACTORY_PASSWORD>` to have one generated and printed at the end of provisioning.
 
 ### 3. Reboot
 
@@ -90,7 +93,7 @@ Alternatively, open the **setup wizard** in your browser at `http://<server-ip>:
 sudo reboot
 ```
 
-After reboot, access the dashboard at your tunnel domain (Remote) or `http://homebrain.local:4000` (Local).
+After reboot, access the dashboard at your tunnel domain (Remote) or `http://homebrain.local` (Local).
 
 ---
 
@@ -112,14 +115,25 @@ All runtime configuration lives in `/opt/homebrain/.env`. Key variables:
 
 ```
 HomeBrain
-├── Nextcloud          (Docker) — file sync, CalDAV, CardDAV
-├── Home Assistant     (Docker) — smart home automation
-├── MariaDB            (Docker) — Nextcloud database
-├── Pangolin Newt      (Docker, optional) — tunnel client
-├── llamacpp server    (systemd) — local LLM inference (GPU required)
-├── whisper-server     (systemd) — speech-to-text (GPU required)
-└── OpenClaw           (systemd) — AI assistant + WhatsApp integration (GPU required)
+├── Nextcloud          (Docker)            — file sync, CalDAV, CardDAV
+├── Home Assistant     (Docker)            — smart home automation
+├── MariaDB            (Docker)            — Nextcloud database
+├── Pangolin Newt      (Docker, optional)  — tunnel client
+├── llama-server       (systemd, GPU)      — local LLM inference (llama.cpp + Vulkan)
+├── whisper-server     (systemd, GPU)      — speech-to-text (whisper.cpp + Vulkan)
+└── OpenClaw           (systemd, GPU)      — AI assistant + WhatsApp integration
 ```
+
+Updates are pinned in [`config/versions.json`](config/versions.json) and applied via the dashboard's "Update" button — bumping the pinned `llama_cpp.tag` automatically re-downloads and restarts the inference binary on the next update click. See [BENCHMARKS.md](BENCHMARKS.md) for the inference tuning rationale and [TESTING.md](TESTING.md) for the E2E verification checklist used before every merge to `main`.
+
+---
+
+## Documentation
+
+- [BENCHMARKS.md](BENCHMARKS.md) — measured throughput across quantizations, hardware tuning notes
+- [ROADMAP.md](ROADMAP.md) — planned features and shipped releases
+- [TESTING.md](TESTING.md) — E2E verification checklist
+- [CLAUDE.md](CLAUDE.md) — repo conventions for AI-assisted contribution
 
 ---
 


### PR DESCRIPTION
## Summary
README polish pass — fixes several inaccuracies accumulated over recent PRs and adds missing pointers to the supplementary docs.

### Corrections
- Dashboard port `:4000` → `:80` (actual `gunicorn --bind 0.0.0.0:80`)
- Default model `Qwen3.5` → `Qwen3.6-35B-A3B (MoE)`
- GPU stack: drops the "ROCm-compatible" claim — inference is Vulkan/RADV; ROCm on RX 9060 XT is currently blocked by upstream [llama.cpp #21376](https://github.com/ggml-org/llama.cpp/issues/21376)
- VRAM minimum `8 GB → 16 GB` to match what the default model needs at 131K context
- Recommended NVMe `256 GB → 512 GB` (Q5_K_XL gguf alone is 25 GB)
- OS minimum: drop 22.04, set 24.04 as floor

### Additions
- Pointer to [BENCHMARKS.md](BENCHMARKS.md) from hardware notes and the inference feature line, with measured throughput summary
- Note on how the dashboard "Update" flow consumes `versions.json` tag bumps
- Documentation index linking BENCHMARKS / ROADMAP / TESTING / CLAUDE.md

### Test plan
- [x] Markdown renders cleanly (verified locally)
- [x] All cross-doc links resolve to existing files in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)