### PR TITLE
fix(ai): add presence_penalty=1.5 and reasoning_budget for Qwen3.6 A3B

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -103,6 +103,15 @@ Findings:
 
 ROCm backend was investigated but not benchmarked: llama.cpp issue [#21376](https://github.com/ggml-org/llama.cpp/issues/21376) (open) reproduces a hard OOM on RX 9060 XT when KV cache approaches the VRAM ceiling — exactly our 35B + q8_0 KV + `-ub 4096` regime. Comparative benchmarks on RDNA4 (RX 9070 XT, gfx1201) currently show Vulkan ~30% ahead of ROCm for dense Qwen3. Re-evaluate after #21376 fixes and ROCm 7.1+ gfx1200 tuning lands.
 
+## Sampler tuning — `presence_penalty` and `reasoning_budget` for A3B
+
+All 35B-A3B entries in `platform_models.json` carry `--presence-penalty 1.5 --reasoning-budget 8192` in addition to the model card's `temp=1.0 / top_p=0.95 / top_k=20 / min_p=0`. Rationale:
+
+- The Qwen3.6-35B-A3B model card explicitly recommends `presence_penalty=1.5` for thinking mode — the dense Qwen3.6-27B card recommends `0`. The A3B MoE variants are documented to fall into infinite `<think>` loops on tool-call failures (HF discussions #19, #20 on `Qwen/Qwen3.6-35B-A3B`; QwenLM/Qwen3.6 #145; ollama #14421/#14493). Without `presence_penalty=1.5` the model can spend its entire context budget retrying the same failed tool call.
+- `--reasoning-budget 8192` is a hard cap on think tokens; on overflow llama-server appends `</think>` and forces the assistant turn. Prevents a single bad turn from burning the 131K context window. Per-request override via `thinking_budget_tokens` in the JSON body.
+- The 27B IQ4_XS entry (DeltaNet hybrid, dense Qwen3.6-27B) is left at `presence_penalty=0` per its own model card.
+- Do not lower `temperature` to fight loops — Qwen explicitly warns greedy / low-temp causes more repetition on these models, not less.
+
 ## Notes
 
 ### AMD Vulkan / GFX1200 constraints

--- a/config/platform_models.json
+++ b/config/platform_models.json
@@ -7,7 +7,7 @@
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
       "min_size_bytes": 21000000000,
       "context_window": 131072,
-      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[3-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
+      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[3-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --presence-penalty 1.5 --reasoning-budget 8192 -b4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
         "tg_ts": 34.13,
         "pp_ts": 866,
@@ -21,7 +21,7 @@
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q5_K_M.gguf",
       "min_size_bytes": 26000000000,
       "context_window": 131072,
-      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
+      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --presence-penalty 1.5 --reasoning-budget 8192 -b4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
         "tg_ts": 29.09,
         "pp_ts": 760,
@@ -35,7 +35,7 @@
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q5_K_XL.gguf",
       "min_size_bytes": 26000000000,
       "context_window": 131072,
-      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
+      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --presence-penalty 1.5 --reasoning-budget 8192 -b4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
         "tg_ts": 29.20,
         "pp_ts": 751,
@@ -49,7 +49,7 @@
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q6_K.gguf",
       "min_size_bytes": 29000000000,
       "context_window": 131072,
-      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(1[8-9]|2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
+      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(1[8-9]|2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --presence-penalty 1.5 --reasoning-budget 8192 -b4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
         "tg_ts": 27.18,
         "pp_ts": 689,
@@ -63,7 +63,7 @@
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q6_K_XL.gguf",
       "min_size_bytes": 31000000000,
       "context_window": 131072,
-      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(1[6-9]|2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
+      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(1[6-9]|2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --presence-penalty 1.5 --reasoning-budget 8192 -b4096 -ub 4096 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
         "tg_ts": 25.38,
         "pp_ts": 643,
@@ -77,7 +77,7 @@
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q8_K_XL.gguf",
       "min_size_bytes": 38000000000,
       "context_window": 131072,
-      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(1[4-9]|2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 -b 4096 -ub 2048 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
+      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(1[4-9]|2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --presence-penalty 1.5 --reasoning-budget 8192 -b4096 -ub 2048 --threads 6 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
         "tg_ts": 17.96,
         "pp_ts": 140,


### PR DESCRIPTION
## Symptom
On Qwen3.6-35B-A3B-UD-Q5_K_XL, the assistant's `<think>` block sometimes loops on tool-call errors — repeating "let me try one more time" structures dozens of times until it hits the token cap. Burns the 131K context budget on a single bad turn.

## Root cause
The Qwen3.6-35B-A3B model card recommends **`presence_penalty=1.5`** for thinking mode specifically as a loop mitigation (the dense Qwen3.6-27B card recommends `0`). We were running the A3B MoE with the dense default, which is the documented failure mode.

## Upstream evidence
- [HF Qwen/Qwen3.6-35B-A3B discussion #19](https://huggingface.co/Qwen/Qwen3.6-35B-A3B/discussions/19) — endless reasoning loops
- [HF Qwen/Qwen3.6-35B-A3B discussion #20](https://huggingface.co/Qwen/Qwen3.6-35B-A3B/discussions/20) — poor tools use + endless reasoning loop
- [QwenLM/Qwen3.6 #145](https://github.com/QwenLM/Qwen3.6/issues/145) — infinite loops with provided sampling params
- [ollama #14421](https://github.com/ollama/ollama/issues/14421), [#14493](https://github.com/ollama/ollama/issues/14493) — same pattern, repetition penalties silently ignored

## Changes
- All six 35B-A3B entries in `config/platform_models.json` now carry `--presence-penalty 1.5 --reasoning-budget 8192` in `extra_flags`. Sampler order: `... --min-p 0.0 --presence-penalty 1.5 --reasoning-budget 8192 -b 4096 ...`
- 27B IQ4_XS (dense DeltaNet) is **unchanged** — its model card recommends `presence_penalty=0`.
- `BENCHMARKS.md` gains a "Sampler tuning" section explaining the rationale and explicitly warning against the tempting-but-wrong fix of lowering temperature (Qwen's docs flag greedy/low-temp as a *cause* of repetition on these models).
- Both flags verified present in llama.cpp b8996 (`--help` output).

## Test plan
- [x] `python3 -c "json.load(...)"` validates
- [x] grep confirms all 6 A3B entries patched, 27B untouched
- [ ] Reviewer: switch to a 35B-A3B model on .58 via dashboard (which regenerates the systemd unit from `platform_models.json`) and exercise an OpenClaw turn that previously looped on a tool-call error
- [ ] If still looping after this lands, follow-up: verify the rendered chat-template closes `</think>` before `tool_calls` (HF discussion #4 is a separate template bug we may also be hitting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)