### PR TITLE
fix(ui): hide AI surfaces on non-GPU hardware + correct GPU detection

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -25,15 +25,29 @@ app = Flask(__name__)
 
 # --- GPU Detection ---
 def has_gpu() -> bool:
-    """Check if a GPU is available. Reads HAS_GPU from env, falls back to /dev/dri probe."""
+    """Check if an AI-capable compute GPU is available.
+
+    Reads HAS_GPU from env when set explicitly. Otherwise probes
+    /sys/class/drm/renderD*/device/driver and only accepts compute-capable
+    drivers (amdgpu / nvidia / i915 / xe). Display-only GPUs like the
+    Raspberry Pi VideoCore (v3d/vc4) are rejected — they expose a render
+    node but cannot run llama.cpp inference, and treating them as a GPU
+    leaves the dashboard's AI cards stuck in skeleton state.
+    """
     val = os.environ.get("HAS_GPU", "").lower()
     if val in ("true", "1", "yes"):
         return True
     if val in ("false", "0", "no"):
         return False
-    # Fallback: probe /dev/dri directly (for existing installs without HAS_GPU in .env)
     import glob
-    return bool(glob.glob("/dev/dri/renderD*"))
+    ai_drivers = {"amdgpu", "nvidia", "i915", "xe"}
+    for path in glob.glob("/sys/class/drm/renderD*/device/driver"):
+        try:
+            if os.path.basename(os.readlink(path)) in ai_drivers:
+                return True
+        except OSError:
+            continue
+    return False
 
 # Cache for delta-based GPU compute utilisation (avoids relying on gpu_busy_percent,
 # which reports spurious 92-100 % on GFX12/RDNA4/Navi44 hardware regardless of load).

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -833,6 +833,7 @@
     <div id="settings" class="tab-content">
         <div class="grid">
 
+            {% if has_gpu %}
             <div class="card" id="integrations-card" style="grid-column: 1 / -1;">
                 <h3>Agent integrations</h3>
                 <p style="margin-bottom:14px; color:var(--text-dim); font-size:0.9em;">
@@ -912,12 +913,10 @@
                 </details>
             </div>
 
+            <div class="card">
+                <h3>Personal AI Assistant</h3>
+                <p style="margin-bottom:18px;">Run a fully private AI assistant on your device. Inference and chat stay entirely local. Live status appears on the Status tab.</p>
 
-            <div class="card" {% if not has_gpu %}style="opacity:0.55; pointer-events:none;"{% endif %}>
-                <h3>Personal AI Assistant{% if not has_gpu %} <span class="status-badge status-unknown">GPU Required</span>{% endif %}</h3>
-                <p style="margin-bottom:18px;">Run a fully private AI assistant on your device. Inference and chat stay entirely local.{% if has_gpu %} Live status appears on the Status tab.{% endif %}</p>
-
-                {% if has_gpu %}
                 <div id="ai-model-selector" style="display:none;">
                     <label>AI model</label>
                     <select id="ai-model-select" onchange="onModelSelectChange()" style="margin-bottom:10px;"></select>
@@ -928,12 +927,8 @@
                     <a id="openclaw-link-anchor" href="#" target="_blank" style="display:none; color:var(--accent); text-decoration:none; font-size:0.92em;">Open OpenClaw &rarr;</a>
                     <button id="btn-ai-toggle" class="btn-primary" onclick="toggleSystem('openclaw')" disabled style="margin-left:auto; opacity:0.6;">Loading…</button>
                 </div>
-                {% else %}
-                <p style="color:var(--text-dim); font-size:0.9em;">
-                    This device does not have a compatible GPU. AI features require a discrete graphics processor (AMD, NVIDIA, or Intel integrated GPU with DRM support).
-                </p>
-                {% endif %}
             </div>
+            {% endif %}
 
             <div class="card" id="vault-config-card" style="grid-column: 1 / -1;">
                 <h3>HomeBrain Vault</h3>
@@ -1119,10 +1114,12 @@
                         <option value="cloudflared-nc">Cloudflare (NC) Container</option>
                         <option value="cloudflared-ha">Cloudflare (HA) Container</option>
                     </optgroup>
+                    {% if has_gpu %}
                     <optgroup label="AI Services">
                         <option value="llama-server">llama-server (AI Inference)</option>
                         <option value="openclaw">OpenClaw Agent</option>
                     </optgroup>
+                    {% endif %}
                 </select>
                 <button onclick="pollLogs()">Refresh Now</button>
             </div>
@@ -1829,6 +1826,10 @@
         }
 
         function updateAIStatus(llamaStatus, openclawStatus, currentModelId, waStatus, whisperStatus) {
+            // No-op on hardware without an AI-capable GPU — the AI Assistant card
+            // and its DOM nodes don't exist there.
+            if (!document.getElementById('sys-llama-status')) return;
+
             const badgeMap = {
                 running:       ['status-running',  'RUNNING'],
                 starting:      ['status-starting', 'LOADING MODEL...'],


### PR DESCRIPTION
## Summary

Reported on an RPi5 install: the Status-tab **GPU** card rendered skeletons that never resolved into stats. Two bugs:

1. **`has_gpu()` false-positives on display-only GPUs.** The fallback probe `/dev/dri/renderD*` matches the Pi's VideoCore display node (`v3d` driver), so `has_gpu` returned True. The backend's GPU stats endpoint correctly reports `gpu.available = false` (no compute device), but by then the dashboard's gated cards have already rendered as skeletons that nothing will ever fill.
2. **Two AI surfaces leaked through into Settings/Logs** even on non-GPU: the *Personal AI Assistant* card had a "GPU Required" disabled-state placeholder, *Agent integrations* was rendered regardless of GPU, and the Logs tab kept its AI Services optgroup.

Both are fixed.

## Changes

- **`src/app.py`** — `has_gpu()` now reads `/sys/class/drm/renderD*/device/driver` and only accepts `amdgpu`, `nvidia`, `i915`, `xe`. Display-only drivers (`v3d`, `vc4`) are rejected. The explicit `HAS_GPU` env override is unchanged.
- **`src/templates/dashboard.html`** — Settings *Agent integrations* + *Personal AI Assistant* cards gated by `{% if has_gpu %}`; the "GPU Required" disabled-state branch removed (per "non-GPU users see no AI surfaces"). Logs tab AI optgroup gated. `updateAIStatus()` early-returns when `sys-llama-status` is absent so the rest of `fetchStatus` doesn't NPE on non-GPU.

## Rendered surface comparison (statically verified)

|  | has_gpu=True | has_gpu=False |
|---|---|---|
| **Status** | Services · Vault · System Resources · GPU · AI Assistant | Services · Vault · System Resources |
| **Backup** | Drives · Schedule · Restore · OpenClaw | Drives · Schedule · Restore |
| **Settings** | Agent integrations · Personal AI · Vault · Maintenance · System Config · FTP · HA Hardware | Vault · Maintenance · System Config · FTP · HA Hardware |
| **Logs** | System Logs + AI Services optgroup | System Logs (no AI options) |

## Test plan

- [x] `python3 -m py_compile src/app.py` — clean.
- [x] Jinja balance preserved (19/19).
- [x] Surface audit (above) at both `has_gpu` values.
- [ ] **Reproduce on RPi5**: re-deploy, confirm Status tab no longer shows GPU/AI cards, Settings tab no longer shows Personal AI Assistant/Agent integrations, Logs tab has no AI optgroup, and no JS error in console from `updateAIStatus`.
- [ ] **Verify on existing AMD-GPU target (.58)** when reachable: no regression — all AI surfaces still render as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)