### PR TITLE
fix(ui): gate OpenClaw quick-launch anchor on has_gpu

### DIFF
--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -495,7 +495,9 @@
                     <a href="{{ nc_url }}" target="_blank" class="link-out">Nextcloud<span aria-hidden="true">↗</span></a>
                     <a href="{{ ha_url }}" target="_blank" class="link-out">Home Assistant<span aria-hidden="true">↗</span></a>
                     <a id="vault-launch" href="#" target="_blank" class="link-out" style="display:none;">Vault<span aria-hidden="true">↗</span></a>
+                    {% if has_gpu %}
                     <a id="openclaw-launch" href="#" target="_blank" class="link-out" style="display:none;">OpenClaw<span aria-hidden="true">↗</span></a>
+                    {% endif %}
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- The Services card's link-row rendered a hidden `#openclaw-launch` anchor unconditionally.
- On non-GPU hosts the anchor is never revealed by `updateAIStatus`, so it's invisible — but it stays in the DOM, violating the rule that non-GPU installs see zero AI surfaces.
- Wrap the anchor in `{% if has_gpu %}`; JS already null-guards `launchAnchor`, so GPU-enabled rendering is unchanged.

Found during the post-PR-#17 E2E on the AMD-GPU target (.58). All other AI-gating surfaces verified clean (Status / Settings / Backup / Logs).

## Test plan
- [x] Live AMD-GPU target (`192.168.178.58`): Status/Settings render unchanged after pull + manager restart
- [x] Static non-GPU render simulation: no `openclaw-launch` anchor in HTML
- [x] `updateAIStatus` still works (null-guarded JS path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)