### PR TITLE
fix(registrar): verify init-email send and recover from already-exists

### DIFF
--- a/registrar/worker.js
+++ b/registrar/worker.js
@@ -27,8 +27,8 @@ export default {
       // 2. Security Check
       const authHeader = request.headers.get("Authorization");
       if (!authHeader || authHeader.trim() !== `Bearer ${env.REGISTRAR_SECRET}`) {
-         return new Response(JSON.stringify({ error: "Unauthorized: Invalid Secret" }), { 
-           status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } 
+         return new Response(JSON.stringify({ error: "Unauthorized: Invalid Secret" }), {
+           status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" }
          });
       }
 
@@ -46,16 +46,40 @@ export default {
         return new Response(JSON.stringify({ error: "Invalid email format" }), { status: 400, headers: corsHeaders });
       }
 
-      if (!email || !email.includes("@")) {
-        return new Response(JSON.stringify({ error: "Invalid email format" }), { status: 400, headers: corsHeaders });
-      }
-
       // Helper: Robust Base64 (Handles Unicode to prevent 500 errors on special chars)
       const safeBtoa = (str) => btoa(unescape(encodeURIComponent(str || "")));
 
       // 3. Robust Domain Handling
-      let zDomain = env.ZITADEL_DOMAIN.replace(/^https?:\/\//, "").replace(/\/$/, "");
-      const zitadelUrl = `https://${zDomain}/v2/users/human`;
+      const zDomain = env.ZITADEL_DOMAIN.replace(/^https?:\/\//, "").replace(/\/$/, "");
+      const zHeaders = {
+        "Authorization": `Bearer ${env.ZITADEL_PAT}`,
+        "Content-Type": "application/json",
+        "x-zitadel-orgid": env.ZITADEL_ORG_ID
+      };
+
+      // Wrap fetch with an 8s timeout via AbortController (broader compat than
+      // AbortSignal.timeout). Each call gets its own controller.
+      const zFetch = async (url, init) => {
+        const controller = new AbortController();
+        const t = setTimeout(() => controller.abort(), 8000);
+        try {
+          return await fetch(url, { ...init, signal: controller.signal });
+        } finally {
+          clearTimeout(t);
+        }
+      };
+
+      // Send the password-setup link to the freshly created user. Returns an
+      // {ok, error} object; callers decide whether to surface failures or
+      // treat them as soft.
+      const sendInitEmail = async (userId) => {
+        const initUrl = `https://${zDomain}/management/v1/users/${userId}/initialization_email`;
+        const r = await zFetch(initUrl, { method: "POST", headers: zHeaders, body: JSON.stringify({}) });
+        if (r.ok) return { ok: true };
+        const text = await r.text().catch(() => "");
+        console.error(`initialization_email failed for ${userId}: ${r.status} ${text}`);
+        return { ok: false, status: r.status, error: text };
+      };
 
       // 4. Create User in Zitadel
       const payload = {
@@ -67,22 +91,9 @@ export default {
         ]
       };
 
-      // ROBUSTNESS: Use AbortController instead of AbortSignal.timeout (compatibility)
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 8000);
-
-      const zResponse = await fetch(zitadelUrl, {
-        method: "POST",
-        headers: {
-          "Authorization": `Bearer ${env.ZITADEL_PAT}`,
-          "Content-Type": "application/json",
-          "x-zitadel-orgid": env.ZITADEL_ORG_ID
-        },
-        body: JSON.stringify(payload),
-        signal: controller.signal
+      const zResponse = await zFetch(`https://${zDomain}/v2/users/human`, {
+        method: "POST", headers: zHeaders, body: JSON.stringify(payload)
       });
-
-      clearTimeout(timeoutId); // Clear timeout immediately after fetch
 
       if (zResponse.ok) {
         const userData = await zResponse.json();
@@ -91,52 +102,79 @@ export default {
         // --- User Grant ---
         // Use /grants instead of /members. 'Members' implies admin/management rights on the project.
         // 'Grants' implies "permission to use the application".
-        const grantUrl = `https://${zDomain}/management/v1/users/${userId}/grants`;
-
-        const grantResponse = await fetch(grantUrl, {
-            method: "POST",
-            headers: {
-                "Authorization": `Bearer ${env.ZITADEL_PAT}`,
-                "Content-Type": "application/json",
-                "x-zitadel-orgid": env.ZITADEL_ORG_ID
-            },
-            body: JSON.stringify({
-                projectId: env.ZITADEL_PROJECT_ID,
-                roleKeys: [env.ZITADEL_PROJECT_ROLE || "user"] 
-            })
+        const grantResponse = await zFetch(`https://${zDomain}/management/v1/users/${userId}/grants`, {
+          method: "POST", headers: zHeaders,
+          body: JSON.stringify({
+            projectId: env.ZITADEL_PROJECT_ID,
+            roleKeys: [env.ZITADEL_PROJECT_ROLE || "user"]
+          })
         });
-
-        // --- Trigger Initialization Email ---
-        // Essential: Since we verify the email implicitly, we must send this link
-        // so the user can set their password.
-        const initUrl = `https://${zDomain}/management/v1/users/${userId}/initialization_email`;
-        await fetch(initUrl, {
-            method: "POST",
-            headers: {
-                "Authorization": `Bearer ${env.ZITADEL_PAT}`,
-                "Content-Type": "application/json",
-                "x-zitadel-orgid": env.ZITADEL_ORG_ID
-            },
-            body: JSON.stringify({}) 
-        });
-
         if (!grantResponse.ok) {
-            // Log error but don't fail the whole request since user is created
-            const errText = await grantResponse.text();
-            console.error("Failed to assign project grant:", errText);
+          // Log error but don't fail the whole request since user is created
+          const errText = await grantResponse.text().catch(() => "");
+          console.error(`Failed to assign project grant for ${userId}: ${errText}`);
         }
 
+        // --- Trigger Initialization Email ---
+        // Required: we marked the address as verified above, so Zitadel will
+        // not auto-send a verification mail. The user gets the password-setup
+        // link only from this call — if it fails (SMTP down, mailbox blocks,
+        // etc.) the user is silently stranded. Surface it to the caller.
+        const initResult = await sendInitEmail(userId);
+        if (!initResult.ok) {
+          return new Response(JSON.stringify({
+            error: `User created but invitation email could not be sent: ${initResult.error || "unknown error"}`,
+            user_created: true
+          }), { status: 502, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+        }
+
+        console.log(`Registered new user ${userId} (${email}) for device ${device_id || "unknown"}`);
         return new Response(JSON.stringify({ status: "success", message: "Invitation sent" }), {
           status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" }
         });
       } else {
-        const zText = await zResponse.text();
+        const zText = await zResponse.text().catch(() => "");
         let zError;
         try { zError = JSON.parse(zText); } catch(e) { zError = { message: zText }; }
 
-        // Code 6 = Already Exists
+        // Code 6 = Already Exists. Re-trigger the init email so a user who
+        // missed the first one (typo in address fixed via Zitadel admin,
+        // greylisted message, lost-in-spam, etc.) can request a fresh link
+        // by re-submitting on the device. Without this branch the worker
+        // would silently return success without sending anything — exactly
+        // the failure mode that masked the protomail/protonmail typo above.
         if (zResponse.status === 409 || (zError.code === 6)) {
-           return new Response(JSON.stringify({ status: "success", message: "User already registered" }), {
+          const lookup = await zFetch(`https://${zDomain}/v2/users`, {
+            method: "POST", headers: zHeaders,
+            body: JSON.stringify({
+              queries: [{ emailQuery: { emailAddress: email, method: "TEXT_QUERY_METHOD_EQUALS" } }]
+            })
+          });
+          if (!lookup.ok) {
+            const errText = await lookup.text().catch(() => "");
+            console.error(`Lookup failed for existing user ${email}: ${lookup.status} ${errText}`);
+            // Fall through to the old success-without-resend shape — the user
+            // does exist, we just couldn't re-trigger. Better than 500.
+            return new Response(JSON.stringify({ status: "success", message: "User already registered" }), {
+              status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" }
+            });
+          }
+          const lookupBody = await lookup.json().catch(() => ({}));
+          const existingId = (lookupBody.result || [])[0]?.userId;
+          if (!existingId) {
+            console.error(`Existing user search returned no result for ${email}`);
+            return new Response(JSON.stringify({ status: "success", message: "User already registered" }), {
+              status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" }
+            });
+          }
+          const resend = await sendInitEmail(existingId);
+          if (!resend.ok) {
+            return new Response(JSON.stringify({
+              error: `User exists but resending invitation failed: ${resend.error || "unknown error"}`
+            }), { status: 502, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+          }
+          console.log(`Re-sent invitation to existing user ${existingId} (${email})`);
+          return new Response(JSON.stringify({ status: "success", message: "Invitation re-sent" }), {
             status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" }
           });
         }


### PR DESCRIPTION
## Summary
The worker was reporting `"Invitation sent"` even when the underlying Zitadel `initialization_email` POST silently failed. Two real failure modes were hidden:

1. **On user-create success**, the init-email response was discarded — any SMTP/Zitadel error left the user stranded with no way to diagnose from the device side.
2. **On Zitadel 409 "user already exists"** (typoed address, lost-in-spam first email, etc.), the worker returned success without resending. Repeated registration attempts on the device were silent no-ops.

Both bit me during today's E2E: I sent a registration to `protomail.com` (mistyping `protonmail.com`), got `success`, no email arrived. Retrying with the same typo also got `success` — because the typoed user was already in Zitadel from the first attempt, and the worker silently took the already-exists path.

## Changes
- Factor the init-email POST into `sendInitEmail()` and **check its response**. Return `502` with a useful error if it fails.
- **On 409:** look up the existing user via `/v2/users` search and re-trigger `initialization_email`. Users can now self-recover from a missed mail by re-submitting on the device.
- Single shared `zFetch()` helper with per-call 8s timeout (was duplicated inline).
- `console.log` on success / `console.error` on failure so CF Worker logs trace the flow.
- Drop the duplicated email-format check (lines 45 & 49 in the old file).

## Test plan
- [x] Live: original (typo) request returned silent success → exactly the bug
- [x] Corrected request (`@protonmail.com`) delivered email to inbox after worker accepted via old code
- [ ] Deploy new worker → verify retry-with-existing-address resends email (needs CF Worker deploy)
- [ ] Verify a forced Zitadel SMTP failure now surfaces as a 502 from the worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)