### PR TITLE
fix(utilities): clear systemd failed-state before openclaw daemon start

### DIFF
--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1225,6 +1225,14 @@ setup_openclaw() {
     # then exec's whatever path the previous unit pointed at — which silently
     # breaks after an OpenClaw upgrade or a path move.
     run_as_admin openclaw daemon install --force 2>/dev/null || true
+    # The previous (sabotaged or version-mismatched) unit may have crash-
+    # looped its way to systemd's "Start request repeated too quickly"
+    # rate-limit cap before we got here. `--force` rewrites the unit file
+    # but does NOT clear that failed/limited state, and the next start
+    # would then surface as `systemctl restart failed: Job for
+    # openclaw-gateway.service failed`. Reload-and-reset before start.
+    run_as_admin systemctl --user daemon-reload 2>/dev/null || true
+    run_as_admin systemctl --user reset-failed openclaw-gateway 2>/dev/null || true
     run_as_admin openclaw daemon start \
         || { log_error "daemon start failed. Try: sudo -u ${HOMEBRAIN_USER} openclaw daemon install --force"; return 1; }
 


### PR DESCRIPTION
## Summary
PR #24 made `setup_openclaw` pass `--force` to `openclaw daemon install` and verify via TCP probe. The E2E re-test surfaced a missed third step:

`openclaw daemon install --force` rewrites the unit file but does **not** clear the user-systemd's failed-state for it. If the previous (stale or sabotaged) unit had already crash-looped to the "Start request repeated too quickly" rate-limit cap before `setup_openclaw` ran, the next `openclaw daemon start` issues `systemctl --user restart` which honours the cap and fails:

```
Gateway start failed: Error: systemctl restart failed:
Job for openclaw-gateway.service failed because the control process exited with error code.
```

Adding `systemctl --user daemon-reload` + `reset-failed openclaw-gateway` between `install --force` and `start` fixes this. The TCP-probe verify from PR #24 keeps the failure mode loud either way.

## Test plan
- [x] Reproduced live on .58: sabotaged the unit's ExecStart, ran "Set up AI" via dashboard, observed the rate-limit failure with PR #24 alone
- [ ] Re-run same E2E with this PR on top: should pass on first try

🤖 Generated with [Claude Code](https://claude.com/claude-code)