### PR TITLE
fix(utilities): replace ((retries++)) with assignment to play nice with set -e

### DIFF
--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1256,7 +1256,12 @@ setup_openclaw() {
             return 0
         fi
         sleep 2
-        ((retries++))
+        # NB: `((retries++))` returns exit status 1 when retries is currently 0
+        # (post-increment yields the old value, 0 is falsy in arithmetic
+        # context), which `set -euo pipefail` then treats as fatal — exiting
+        # the script before the first probe iteration even completes. Use the
+        # assignment form which always returns 0.
+        retries=$((retries + 1))
     done
 
     log_error "OpenClaw gateway did not bind to :${oc_port} within 60 s."


### PR DESCRIPTION
## Summary
bash 5.x exits the entire script when an arithmetic compound command `((expr))` evaluates to `0`, because `((expr))` returns exit status 1 in that case. `((retries++))` post-increments — on the first iteration `retries` is 0, the expression evaluates to 0, exit status 1, `set -euo pipefail` then kills the function silently. The TCP-probe loop introduced in PR #24 never made it past iteration 0.

The old code at this site got away with the same construct only because its lenient grep verify always matched on iteration 0, so the loop returned 0 before the increment ever ran. PR #24's stricter TCP probe legitimately fails on iteration 0 (port still binding), which trips the gotcha.

Fix: `retries=$((retries + 1))` — arithmetic **expansion** inside an assignment; assignment unconditionally returns 0.

Reproduced live on `.58` (bash 5.2.37):
```bash
$ bash -c 'set -euo pipefail; r=0; while [[ $r -lt 3 ]]; do echo iter $r; ((r++)); done'
iter 0
exit 1   # <- never reaches iter 1
```
With the fixed form: prints `iter 0..2` and exits cleanly.

macOS bash 3.2 doesn't trip on this, which is why local testing wouldn't have caught it.

## Test plan
- [x] Demonstrated the gotcha on the target's bash 5.2.37, and confirmed the assignment form runs the loop to completion.
- [ ] Re-run sabotage-then-Set-up-AI E2E on `.58` after merge — should now reach the TCP probe, see the port bind ~5–20s in, and log success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)