### PR TITLE
feat(openclaw): seed Telegram/Signal/Matrix/Nextcloud-Talk channels

### DIFF
--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -114,6 +114,38 @@
       "groupPolicy": "allowlist",
       "debounceMs": 0,
       "mediaMaxMb": 50
+    },
+    "telegram": {
+      "enabled": false,
+      "dmPolicy": "allowlist",
+      "allowFrom": [],
+      "groupPolicy": "allowlist",
+      "debounceMs": 0,
+      "mediaMaxMb": 50
+    },
+    "signal": {
+      "enabled": false,
+      "dmPolicy": "allowlist",
+      "allowFrom": [],
+      "groupPolicy": "allowlist",
+      "debounceMs": 0,
+      "mediaMaxMb": 50
+    },
+    "matrix": {
+      "enabled": false,
+      "dmPolicy": "allowlist",
+      "allowFrom": [],
+      "groupPolicy": "allowlist",
+      "debounceMs": 0,
+      "mediaMaxMb": 50
+    },
+    "nextcloud-talk": {
+      "enabled": false,
+      "dmPolicy": "allowlist",
+      "allowFrom": [],
+      "groupPolicy": "allowlist",
+      "debounceMs": 0,
+      "mediaMaxMb": 50
     }
   },
   "gateway": {
@@ -149,6 +181,18 @@
     "entries": {
       "whatsapp": {
         "enabled": true
+      },
+      "telegram": {
+        "enabled": false
+      },
+      "signal": {
+        "enabled": false
+      },
+      "matrix": {
+        "enabled": false
+      },
+      "nextcloud-talk": {
+        "enabled": false
       },
       "browser": {
         "enabled": true

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1080,6 +1080,29 @@ patch_openclaw_config() {
         .channels.whatsapp.dmPolicy = "allowlist" |
         .channels.whatsapp.allowFrom = (.channels.whatsapp.allowFrom // []) |
         .plugins.entries.whatsapp.enabled = true |
+        # Non-destructive migration: ensure additional curated messenger
+        # channels (Telegram, Signal, Matrix, Nextcloud Talk) appear in the
+        # OpenClaw control UI so users can configure credentials there.
+        # Uses jq `//` so an existing user-tuned entry is never overwritten —
+        # we only fill the key when it is missing entirely.
+        # Each channel ships disabled; user enables it from OpenClaw UI after
+        # entering credentials (bot token / linked-device / username+pwd / …).
+        .channels.telegram = (.channels.telegram //
+            {"enabled": false, "dmPolicy": "allowlist", "allowFrom": [],
+             "groupPolicy": "allowlist", "debounceMs": 0, "mediaMaxMb": 50}) |
+        .channels.signal = (.channels.signal //
+            {"enabled": false, "dmPolicy": "allowlist", "allowFrom": [],
+             "groupPolicy": "allowlist", "debounceMs": 0, "mediaMaxMb": 50}) |
+        .channels.matrix = (.channels.matrix //
+            {"enabled": false, "dmPolicy": "allowlist", "allowFrom": [],
+             "groupPolicy": "allowlist", "debounceMs": 0, "mediaMaxMb": 50}) |
+        .channels["nextcloud-talk"] = (.channels["nextcloud-talk"] //
+            {"enabled": false, "dmPolicy": "allowlist", "allowFrom": [],
+             "groupPolicy": "allowlist", "debounceMs": 0, "mediaMaxMb": 50}) |
+        .plugins.entries.telegram = (.plugins.entries.telegram // {"enabled": false}) |
+        .plugins.entries.signal = (.plugins.entries.signal // {"enabled": false}) |
+        .plugins.entries.matrix = (.plugins.entries.matrix // {"enabled": false}) |
+        .plugins.entries["nextcloud-talk"] = (.plugins.entries["nextcloud-talk"] // {"enabled": false}) |
         .gateway.controlUi.allowedOrigins = $origins |
         .tools.media.audio.enabled = true |
         .tools.media.audio.scope.default = "allow" |


### PR DESCRIPTION
## Why
OpenClaw's control UI only renders channels declared in its config. Our seed only declared `whatsapp`, so a user asking *"how do I link Telegram?"* had no UI affordance — they'd need to hand-edit `~/.openclaw/openclaw.json`.

## Curated channel set
Four additions, picked through a HomeBrain product lens (private-cloud, self-host friendly, broad appeal):

| Channel | Pairing model | Why ship it |
|---|---|---|
| **telegram** | BotFather token | Mass-market, simplest credential |
| **signal** | Linked device | Privacy story, ethos-aligned |
| **matrix** | username + access token | Self-host federation |
| **nextcloud-talk** | NC server URL + bot account | We *already* ship Nextcloud — closes the loop on "everything on your box" |

Skipped (not in seed): Slack, Discord, MS Teams, iMessage / BlueBubbles, Feishu, Zalo, LINE, IRC, etc. Users who want them can declare them manually; we don't want to balloon the UI with channels most users won't use.

All four ship `enabled: false`. They appear in the OpenClaw UI as configurable channels but don't auto-attempt to connect before credentials are provided (which would spam logs). User configures credentials in OpenClaw control UI, then flips the toggle.

## Migration for existing installs
`patch_openclaw_config` (in `scripts/utilities.sh`) now uses jq `//` (or-default) to fill any missing channel key from the curated set. Existing user-tuned entries are preserved untouched. Runs on every `setup_ai` invocation (model switch, re-deploy, dashboard "Set up AI" button), so existing boxes pick up the new channels next time their AI stack is touched — no manual `jq` step required.

Offline dry-run with a pre-customised `telegram` (with `botToken` + non-empty `allowFrom`) confirmed the customisation survives the migration verbatim while the missing `signal`/`matrix`/`nextcloud-talk` get added.

## Test plan
- [x] JSON validates
- [x] `bash -n` clean
- [x] Offline jq dry-run preserves user-tuned entry
- [ ] On `.58`: run setup_ai once, confirm OpenClaw control UI surfaces all four channels and existing WhatsApp config is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)