### PR TITLE
fix(openclaw): pin seed channels to schema-valid minimal fields

### DIFF
--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -118,34 +118,21 @@
     "telegram": {
       "enabled": false,
       "dmPolicy": "allowlist",
-      "allowFrom": [],
-      "groupPolicy": "allowlist",
-      "debounceMs": 0,
-      "mediaMaxMb": 50
+      "groupPolicy": "allowlist"
     },
     "signal": {
       "enabled": false,
       "dmPolicy": "allowlist",
-      "allowFrom": [],
-      "groupPolicy": "allowlist",
-      "debounceMs": 0,
-      "mediaMaxMb": 50
+      "groupPolicy": "allowlist"
     },
     "matrix": {
       "enabled": false,
-      "dmPolicy": "allowlist",
-      "allowFrom": [],
-      "groupPolicy": "allowlist",
-      "debounceMs": 0,
-      "mediaMaxMb": 50
+      "groupPolicy": "allowlist"
     },
     "nextcloud-talk": {
       "enabled": false,
       "dmPolicy": "allowlist",
-      "allowFrom": [],
-      "groupPolicy": "allowlist",
-      "debounceMs": 0,
-      "mediaMaxMb": 50
+      "groupPolicy": "allowlist"
     }
   },
   "gateway": {

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1081,24 +1081,24 @@ patch_openclaw_config() {
         .channels.whatsapp.allowFrom = (.channels.whatsapp.allowFrom // []) |
         .plugins.entries.whatsapp.enabled = true |
         # Non-destructive migration: ensure additional curated messenger
-        # channels (Telegram, Signal, Matrix, Nextcloud Talk) appear in the
-        # OpenClaw control UI so users can configure credentials there.
-        # Uses jq `//` so an existing user-tuned entry is never overwritten —
-        # we only fill the key when it is missing entirely.
-        # Each channel ships disabled; user enables it from OpenClaw UI after
-        # entering credentials (bot token / linked-device / username+pwd / …).
+        # channels (Telegram, Signal, Matrix, Nextcloud Talk) appear in
+        # the OpenClaw control UI so users can configure credentials.
+        # Uses jq // so an existing user-tuned entry is never overwritten;
+        # we only fill the key when it is missing entirely. Each channel
+        # ships disabled, with the schema-required fields only — extra
+        # properties are rejected by the per-channel schemas
+        # (additionalProperties: false). Matrix uses dm.* nested config
+        # rather than dmPolicy; the others require dmPolicy + groupPolicy.
+        # Defaults to allowlist so an accidentally-enabled channel cannot
+        # DM the agent until the user explicitly allowlists a peer.
         .channels.telegram = (.channels.telegram //
-            {"enabled": false, "dmPolicy": "allowlist", "allowFrom": [],
-             "groupPolicy": "allowlist", "debounceMs": 0, "mediaMaxMb": 50}) |
+            {"enabled": false, "dmPolicy": "allowlist", "groupPolicy": "allowlist"}) |
         .channels.signal = (.channels.signal //
-            {"enabled": false, "dmPolicy": "allowlist", "allowFrom": [],
-             "groupPolicy": "allowlist", "debounceMs": 0, "mediaMaxMb": 50}) |
+            {"enabled": false, "dmPolicy": "allowlist", "groupPolicy": "allowlist"}) |
         .channels.matrix = (.channels.matrix //
-            {"enabled": false, "dmPolicy": "allowlist", "allowFrom": [],
-             "groupPolicy": "allowlist", "debounceMs": 0, "mediaMaxMb": 50}) |
+            {"enabled": false, "groupPolicy": "allowlist"}) |
         .channels["nextcloud-talk"] = (.channels["nextcloud-talk"] //
-            {"enabled": false, "dmPolicy": "allowlist", "allowFrom": [],
-             "groupPolicy": "allowlist", "debounceMs": 0, "mediaMaxMb": 50}) |
+            {"enabled": false, "dmPolicy": "allowlist", "groupPolicy": "allowlist"}) |
         .plugins.entries.telegram = (.plugins.entries.telegram // {"enabled": false}) |
         .plugins.entries.signal = (.plugins.entries.signal // {"enabled": false}) |
         .plugins.entries.matrix = (.plugins.entries.matrix // {"enabled": false}) |


### PR DESCRIPTION
## Why
PR #29 shipped Telegram/Signal/Matrix/Nextcloud-Talk channel declarations but copied WhatsApp's shape. The new channels' schemas reject fields like `debounceMs`, `selfChatMode`, `mediaMaxMb`, and (for Matrix) `dmPolicy`/`allowFrom`. The gateway crash-looped to systemd's rate-limit cap:

```
channels.telegram: invalid config: must NOT have additional properties
channels.matrix:   invalid config: must NOT have additional properties
```

…and fell back to `.last-good`. Net effect on the first .58 deploy: no new channels visible + a flaky gateway for ~30s.

## The right shape, per `openclaw config schema`

| Channel | Required | Notes |
|---|---|---|
| telegram, signal, nextcloud-talk | `dmPolicy`, `groupPolicy` | `additionalProperties: false` blocks WhatsApp's extras |
| matrix | (none) | No `dmPolicy` at all; uses nested `dm.*` config instead |

Trim seed and migration to required-minimum:
- telegram/signal/nextcloud-talk: `{enabled: false, dmPolicy: "allowlist", groupPolicy: "allowlist"}`
- matrix: `{enabled: false, groupPolicy: "allowlist"}`

`allowlist` chosen so an accidentally-enabled channel can't DM the agent until the user explicitly allowlists a peer in the OpenClaw UI.

## Also
Drop the apostrophe in `OpenClaw's` from the inline comment inside the single-quoted jq script — an unescaped `'` inside a bash `'…'` literal closes the string. `bash -n` caught it pre-push. Lesson: comments inside single-quoted heredocs need to stay apostrophe-free.

## Test plan
- [x] `bash -n` + `python3 json.load` clean
- [x] Offline sanity: required fields present where needed; matrix correctly omits dmPolicy
- [ ] On `.58`: re-run setup_ai, confirm gateway starts cleanly + all five channels visible in `openclaw channels status` and the control UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)