### PR TITLE
fix(integrations): cache openclaw mcp show output with a short TTL

### DIFF
--- a/src/integrations.py
+++ b/src/integrations.py
@@ -207,16 +207,48 @@ def _has_openclaw() -> bool:
     return shutil.which("openclaw") is not None
 
 
+# `openclaw mcp show` is implemented by spawning the OpenClaw Node CLI,
+# which in turn touches each configured MCP server to enumerate its tools —
+# each invocation can leave hundreds of MB of resident state and 600-700MB
+# child Node processes that don't tear down cleanly.
+#
+# integration_status() called _wired_in_openclaw() once per integration,
+# i.e. 5× per /api/integrations/status request, and the dashboard polls
+# that endpoint every 15 s. With even a single browser tab open the box
+# was forking a steady stream of openclaw children faster than they
+# could exit, marching to OOM (see project_clean_provision_e2e memo).
+#
+# Membership in `openclaw mcp show` only changes when we explicitly wire
+# or unwire via mcp_set/mcp_unset, so cache the output with a short TTL
+# and invalidate on writes.
+_MCP_SHOW_CACHE: dict[str, Any] = {"ts": 0.0, "value": ""}
+_MCP_SHOW_TTL_SECONDS = 5.0
+
+
 def _openclaw_mcp_show() -> str:
     if not _has_openclaw():
         return ""
+    now = time.time()
+    if now - _MCP_SHOW_CACHE["ts"] < _MCP_SHOW_TTL_SECONDS:
+        return _MCP_SHOW_CACHE["value"]
     try:
-        return subprocess.check_output(
+        out = subprocess.check_output(
             ["sudo", "-u", "homebrain", "openclaw", "mcp", "show"],
             stderr=subprocess.DEVNULL, timeout=5,
         ).decode()
     except Exception:
-        return ""
+        out = ""
+    _MCP_SHOW_CACHE["ts"] = now
+    _MCP_SHOW_CACHE["value"] = out
+    return out
+
+
+def _invalidate_mcp_show_cache() -> None:
+    """Force the next _openclaw_mcp_show() to spawn a fresh CLI call.
+    Call this after any mcp set / unset so the cached wiring view does
+    not lag behind a write the user just performed."""
+    _MCP_SHOW_CACHE["ts"] = 0.0
+    _MCP_SHOW_CACHE["value"] = ""
 
 
 def _openclaw_mcp_set(name: str, spec: dict) -> tuple[bool, str]:
@@ -228,6 +260,7 @@ def _openclaw_mcp_set(name: str, spec: dict) -> tuple[bool, str]:
              name, json.dumps(spec)],
             stderr=subprocess.STDOUT, timeout=15,
         )
+        _invalidate_mcp_show_cache()
         return True, ""
     except subprocess.CalledProcessError as e:
         return False, f"openclaw mcp set failed: {e}"
@@ -243,6 +276,8 @@ def _openclaw_mcp_unset(name: str) -> None:
         )
     except Exception:
         pass
+    finally:
+        _invalidate_mcp_show_cache()
 
 
 def _openclaw_daemon_restart() -> None:


### PR DESCRIPTION
## Why
\`_wired_in_openclaw()\` shells out to \`openclaw mcp show\` once per integration. \`integration_status()\` is called 5× (once per: self, ha, nc, vault, email) per \`/api/integrations/status\` request. The dashboard polls that endpoint every 15 s. With even a single browser tab open, the box was forking five \`openclaw\` Node CLI invocations every 15 s; each spawned 600-700 MB child Node processes for MCP enumeration that didn't always tear down cleanly.

Stragglers piled up. Load average on \`.58\` climbed from 0 → 134 in 9 minutes post-reboot with no user activity beyond an open dashboard tab, producing 118 openclaw processes. Killing them recovered the box; without this fix the loop returned immediately.

## What changes
\`openclaw mcp show\` is read-only — output only changes when we explicitly write via \`mcp set\` / \`mcp unset\`. So:

- **TTL cache**: 5 s. Membership for "is this MCP wired" doesn't change faster than that in practice.
- **Eager invalidation** on \`_openclaw_mcp_set\` (success path) and \`_openclaw_mcp_unset\` (finally clause), so the next read after a wire/unwire sees fresh truth.

### Effect

| Path | Before | After |
|---|---|---|
| Per \`/api/integrations/status\` request | 5 spawns | 1 spawn |
| Across multiple browser tabs polling at 15 s | N tabs × 5 spawns / 15 s | 1 spawn / 5 s, coalesced |
| Write (wire/unwire) | n/a | invalidates so the next read is fresh |

## Test plan
- [x] \`python3 -m ast.parse\` clean
- [ ] Deploy on \`.58\`: open dashboard with multiple tabs, observe \`pgrep openclaw\` stays low + steady, load average stays normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)