### PR TITLE
feat(integrations): multi-account Home Assistant + Nextcloud

### DIFF
--- a/scripts/mcp-homeassistant.py
+++ b/scripts/mcp-homeassistant.py
@@ -1,31 +1,35 @@
 #!/usr/bin/env python3
-"""HomeBrain Home Assistant MCP server.
+"""HomeBrain Home Assistant MCP server (multi-account).
 
-Exposes a small, allowlisted slice of the HA REST API to OpenClaw. Talks to
-HA over its native HTTP API using a long-lived access token (LLAT) that the
-HomeBrain dashboard provisions automatically.
+Exposes a small, allowlisted slice of the HA REST API to OpenClaw. Users
+may register multiple HA instances (different houses, different domains)
+and the agent picks one with the `account` parameter on every tool call.
 
 Why this shim instead of HA core's official `mcp_server` integration:
   * Predictable behaviour across HA versions (the official one moves fast).
   * Allowlist enforcement at the MCP layer — we deny destructive domains
     (`homeassistant.restart`, `recorder.*`, etc.) before they ever hit HA.
-  * The dashboard already owns the LLAT lifecycle; reusing it keeps the
+  * The dashboard owns LLAT lifecycle, so reusing it keeps the
     "one root of identity" principle (see INTEGRATIONS_PLAN.md §1.2).
 
 Environment:
-  HA_BASE_URL    e.g. http://homeassistant:8123 or http://localhost:8123
-  HA_TOKEN       long-lived access token (read from a file by the dashboard
-                 and injected here via openclaw mcp set's `env` block)
-  HA_TOKEN_FILE  optional alternative — file path containing the token,
-                 mode 0600. Wins over HA_TOKEN if set.
+  HA_ACCOUNTS_FILE             path to ~/.openclaw/ha_accounts.json
+                               (list of {name, base_url, token}; token
+                               is Fernet-encrypted using
+                               HOMEBRAIN_INTEGRATIONS_KEY).
+  HOMEBRAIN_INTEGRATIONS_KEY   Fernet key for at-rest decryption.
+
+Legacy fallback (single-account installs pre-multi-account):
+  HA_BASE_URL, HA_TOKEN, HA_TOKEN_FILE — used only if HA_ACCOUNTS_FILE
+  is absent. The dashboard migrates these on first read.
 """
 from __future__ import annotations
 
 import os
 import sys
+import json
 import urllib.error
 import urllib.request
-import json
 from typing import Any
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -33,9 +37,14 @@ from mcp_common import (  # noqa: E402
     Consent, audit, consent_required, err, ok, serve, unavailable,
 )
 
-HA_BASE_URL = os.environ.get("HA_BASE_URL", "http://localhost:8123").rstrip("/")
-HA_TOKEN_FILE = os.environ.get("HA_TOKEN_FILE", "")
-HA_TOKEN = os.environ.get("HA_TOKEN", "")
+HA_ACCOUNTS_FILE = os.environ.get("HA_ACCOUNTS_FILE", "")
+INTEGRATIONS_KEY = os.environ.get("HOMEBRAIN_INTEGRATIONS_KEY", "")
+
+# Legacy single-account fallback — kept so the MCP keeps working if it's
+# ever spawned before the dashboard migrates a legacy install.
+LEGACY_BASE_URL = os.environ.get("HA_BASE_URL", "").rstrip("/")
+LEGACY_TOKEN_FILE = os.environ.get("HA_TOKEN_FILE", "")
+LEGACY_TOKEN = os.environ.get("HA_TOKEN", "")
 
 # Domains the agent is permitted to call services on. Critical/destructive
 # domains intentionally absent. This list is the trust boundary; do not
@@ -47,25 +56,83 @@ SERVICE_DOMAIN_ALLOWLIST = {
     "button", "notify", "humidifier", "water_heater", "lawn_mower",
     "remote", "siren", "valve",
 }
-
-# Services we deny even within an allowed domain (e.g. "automation.delete").
 SERVICE_NAME_DENYLIST = {"delete", "remove", "clear_skipped_update", "purge"}
 
 
-def _token() -> str:
-    if HA_TOKEN_FILE and os.path.exists(HA_TOKEN_FILE):
+def _decrypt(blob: str) -> str:
+    if not INTEGRATIONS_KEY:
+        return blob
+    try:
+        from cryptography.fernet import Fernet  # type: ignore
+        return Fernet(INTEGRATIONS_KEY.encode()).decrypt(blob.encode()).decode()
+    except Exception:
+        return blob
+
+
+def _accounts() -> list[dict]:
+    if HA_ACCOUNTS_FILE and os.path.exists(HA_ACCOUNTS_FILE):
         try:
-            return open(HA_TOKEN_FILE).read().strip()
+            with open(HA_ACCOUNTS_FILE) as f:
+                data = json.load(f)
+            return data.get("accounts", []) if isinstance(data, dict) else []
+        except (OSError, json.JSONDecodeError):
+            return []
+    # Legacy single-account fallback.
+    tok = ""
+    if LEGACY_TOKEN_FILE and os.path.exists(LEGACY_TOKEN_FILE):
+        try:
+            tok = open(LEGACY_TOKEN_FILE).read().strip()
         except OSError:
-            return ""
-    return HA_TOKEN.strip()
-
-
-def _http(method: str, path: str, body: Any = None, timeout: int = 8) -> tuple[int, dict | list | str]:
-    tok = _token()
+            pass
     if not tok:
-        return 0, "no HA token configured"
-    url = f"{HA_BASE_URL}{path}"
+        tok = LEGACY_TOKEN.strip()
+    if tok and LEGACY_BASE_URL:
+        return [{"name": "home", "base_url": LEGACY_BASE_URL, "token": tok}]
+    return []
+
+
+def _pick_account(name: str | None) -> dict | None:
+    accounts = _accounts()
+    if not accounts:
+        return None
+    if not name:
+        # Single-account installs default to the only entry. Multi-account
+        # installs require an explicit account.
+        return accounts[0] if len(accounts) == 1 else None
+    for a in accounts:
+        if a.get("name") == name:
+            return a
+    return None
+
+
+def _account_or_err(args: dict) -> tuple[dict | None, dict | None]:
+    """Returns (account, None) on success or (None, err_response) on failure.
+    Centralises the "which account?" lookup so every tool gets the same
+    error messaging for missing/ambiguous selection."""
+    name = (args.get("account") or "").strip() or None
+    a = _pick_account(name)
+    if a is not None:
+        return a, None
+    accounts = _accounts()
+    if not accounts:
+        return None, unavailable("no Home Assistant accounts configured")
+    if not name and len(accounts) > 1:
+        names = ", ".join(repr(x.get("name")) for x in accounts)
+        return None, err(
+            f"multiple HA accounts configured; pass `account` (one of: {names})",
+            hint="Use ha.list_accounts to see the configured set.",
+        )
+    return None, err(f"account '{name}' not found",
+                     hint="Use ha.list_accounts to see the configured set.")
+
+
+def _http(account: dict, method: str, path: str, body: Any = None,
+          timeout: int = 8) -> tuple[int, dict | list | str]:
+    base = (account.get("base_url") or "").rstrip("/")
+    tok = _decrypt(account.get("token") or "")
+    if not (base and tok):
+        return 0, "account missing base_url or token"
+    url = f"{base}{path}"
     data = json.dumps(body).encode() if body is not None else None
     req = urllib.request.Request(url, data=data, method=method)
     req.add_header("Authorization", f"Bearer {tok}")
@@ -87,19 +154,33 @@ def _http(method: str, path: str, body: Any = None, timeout: int = 8) -> tuple[i
 # Tools
 # ---------------------------------------------------------------------------
 
-def t_health(_args: dict) -> dict:
-    code, body = _http("GET", "/api/")
+def t_list_accounts(_args: dict) -> dict:
+    accounts = [{"name": a.get("name"), "base_url": a.get("base_url")}
+                for a in _accounts()]
+    return ok(accounts=accounts, total=len(accounts),
+              hint=("Pass `account: <name>` on other tools to pick one. "
+                    "Single-account installs default to the only entry."))
+
+
+def t_health(args: dict) -> dict:
+    account, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
+    code, body = _http(account, "GET", "/api/")
     if code == 200:
-        return ok(message=body.get("message") if isinstance(body, dict) else "")
-    return unavailable(f"HA at {HA_BASE_URL} unreachable: {body}")
+        return ok(account=account["name"],
+                  message=body.get("message") if isinstance(body, dict) else "")
+    return unavailable(f"HA '{account['name']}' at {account['base_url']} unreachable: {body}")
 
 
 def t_entity_search(args: dict) -> dict:
-    """Search entity_ids and friendly names by free-text query."""
+    account, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
     q = (args.get("query") or "").lower().strip()
     if not q:
         return err("query is required")
-    code, body = _http("GET", "/api/states")
+    code, body = _http(account, "GET", "/api/states")
     if code != 200 or not isinstance(body, list):
         return unavailable(f"HA states unreachable: {body}")
     matches = []
@@ -115,19 +196,23 @@ def t_entity_search(args: dict) -> dict:
             })
             if len(matches) >= 50:
                 break
-    return ok(results=matches, total=len(matches))
+    return ok(account=account["name"], results=matches, total=len(matches))
 
 
 def t_state(args: dict) -> dict:
+    account, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
     eid = args.get("entity_id") or ""
     if not eid:
         return err("entity_id is required")
-    code, body = _http("GET", f"/api/states/{eid}")
+    code, body = _http(account, "GET", f"/api/states/{eid}")
     if code == 404:
         return err("entity not found")
     if code != 200 or not isinstance(body, dict):
         return unavailable(f"HA unreachable: {body}")
     return ok(
+        account=account["name"],
         entity_id=body.get("entity_id"),
         state=body.get("state"),
         attributes=body.get("attributes") or {},
@@ -135,10 +220,11 @@ def t_state(args: dict) -> dict:
     )
 
 
-def t_area_list(_args: dict) -> dict:
-    """Use the /api/template endpoint to enumerate areas, since HA has no
-    REST endpoint for the area registry itself."""
-    code, body = _http("POST", "/api/template",
+def t_area_list(args: dict) -> dict:
+    account, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
+    code, body = _http(account, "POST", "/api/template",
                        {"template": "{{ areas() | list | tojson }}"})
     if code != 200 or not isinstance(body, str):
         return unavailable(f"HA template eval failed: {body}")
@@ -146,10 +232,13 @@ def t_area_list(_args: dict) -> dict:
         ids = json.loads(body)
     except json.JSONDecodeError:
         return err("could not parse areas response")
-    return ok(areas=ids, total=len(ids))
+    return ok(account=account["name"], areas=ids, total=len(ids))
 
 
 def t_call_service(args: dict) -> dict:
+    account, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
     domain = (args.get("domain") or "").strip()
     service = (args.get("service") or "").strip()
     target = args.get("target") or {}
@@ -167,8 +256,9 @@ def t_call_service(args: dict) -> dict:
     if service in SERVICE_NAME_DENYLIST:
         return err(f"service '{service}' is denied for safety")
 
-    summary = f"Home Assistant: call {domain}.{service} on {target or 'default target'}"
-    payload = {"domain": domain, "service": service,
+    summary = (f"Home Assistant ({account['name']}): call {domain}.{service} "
+               f"on {target or 'default target'}")
+    payload = {"account": account["name"], "domain": domain, "service": service,
                "target": target, "service_data": data}
 
     if not confirm:
@@ -179,49 +269,75 @@ def t_call_service(args: dict) -> dict:
     if not redeemed:
         return err("confirmation_token invalid or expired")
 
+    # Defensive: confirm the redeemed payload still points at a configured
+    # account (could have been removed between issue and redeem).
+    redeem_account = _pick_account(redeemed.get("account"))
+    if redeem_account is None:
+        return err(f"account '{redeemed.get('account')}' no longer configured")
+
     body = {**redeemed.get("service_data", {}),
             **({"target": redeemed.get("target")} if redeemed.get("target") else {})}
-    code, resp = _http("POST",
+    code, resp = _http(redeem_account, "POST",
                        f"/api/services/{redeemed['domain']}/{redeemed['service']}",
                        body)
     if code not in (200, 201):
         audit("homeassistant", "call_service.fail",
+              account=redeem_account["name"],
               domain=redeemed["domain"], service=redeemed["service"], code=code)
         return err(f"HA service call failed: {resp}")
     audit("homeassistant", "call_service.ok",
+          account=redeem_account["name"],
           domain=redeemed["domain"], service=redeemed["service"],
           target=redeemed.get("target"))
-    return ok(executed=True, response=resp if isinstance(resp, list) else None)
+    return ok(account=redeem_account["name"], executed=True,
+              response=resp if isinstance(resp, list) else None)
 
+
+_ACCOUNT_PROP = {
+    "type": "string",
+    "description": ("Configured account name to act on. Omit when only one "
+                    "account is configured; required when multiple are. Use "
+                    "ha.list_accounts to enumerate."),
+}
 
 TOOLS = [
-    {"name": "ha.health",
-     "description": "Check that Home Assistant is reachable and return its API banner.",
+    {"name": "ha.list_accounts",
+     "description": "List configured Home Assistant accounts (name + base_url).",
      "inputSchema": {"type": "object", "properties": {}}},
-    {"name": "ha.entity_search",
-     "description": "Search HA entities by free-text query (matches entity_id and friendly_name). Returns metadata only — entity_id, friendly name, current state.",
+    {"name": "ha.health",
+     "description": "Check that a Home Assistant instance is reachable.",
      "inputSchema": {"type": "object",
-                     "properties": {"query": {"type": "string"}},
+                     "properties": {"account": _ACCOUNT_PROP}}},
+    {"name": "ha.entity_search",
+     "description": ("Search HA entities by free-text query (matches entity_id "
+                     "and friendly_name). Returns metadata only — entity_id, "
+                     "friendly name, current state."),
+     "inputSchema": {"type": "object",
+                     "properties": {"query": {"type": "string"},
+                                    "account": _ACCOUNT_PROP},
                      "required": ["query"]}},
     {"name": "ha.state",
      "description": "Fetch current state and attributes for one entity_id.",
      "inputSchema": {"type": "object",
-                     "properties": {"entity_id": {"type": "string"}},
+                     "properties": {"entity_id": {"type": "string"},
+                                    "account": _ACCOUNT_PROP},
                      "required": ["entity_id"]}},
     {"name": "ha.area_list",
      "description": "List all configured Home Assistant areas (rooms).",
-     "inputSchema": {"type": "object", "properties": {}}},
+     "inputSchema": {"type": "object",
+                     "properties": {"account": _ACCOUNT_PROP}}},
     {"name": "ha.call_service",
      "description": (
-         "Invoke a Home Assistant service. ACT-tier: first call returns a "
-         "consent token; the agent must surface a confirmation prompt to "
-         "the user and re-call with confirmation_token=action_id. "
-         "Allowlisted domains only — destructive domains are denied "
-         "server-side."
+         "Invoke a Home Assistant service. Just call this directly with the "
+         "domain, service, target, and optional account; the runtime prompts "
+         "the user for approval automatically — you do not need to ask the "
+         "user for a token first. Allowlisted domains only — destructive "
+         "domains are denied server-side."
      ),
      "inputSchema": {
          "type": "object",
          "properties": {
+             "account": _ACCOUNT_PROP,
              "domain": {"type": "string"},
              "service": {"type": "string"},
              "target": {"type": "object",
@@ -235,6 +351,7 @@ TOOLS = [
 
 
 DISPATCH = {
+    "ha.list_accounts": t_list_accounts,
     "ha.health": t_health,
     "ha.entity_search": t_entity_search,
     "ha.state": t_state,
@@ -251,4 +368,4 @@ def dispatch(name: str, args: dict) -> dict:
 
 
 if __name__ == "__main__":
-    serve("homebrain-homeassistant", "0.1.0", TOOLS, dispatch)
+    serve("homebrain-homeassistant", "0.2.0", TOOLS, dispatch)

--- a/scripts/mcp-nextcloud.py
+++ b/scripts/mcp-nextcloud.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-"""HomeBrain Nextcloud MCP server.
+"""HomeBrain Nextcloud MCP server (multi-account).
 
-Talks to the local Nextcloud over WebDAV (files) and OCS (notes, calendar,
-contacts, talk). Authenticates with an *app password* — never the master
-NC password — created during integration bootstrap by `occ user:add-app-password`.
+Talks to one or more Nextcloud instances over WebDAV (files) and OCS
+(notes, shares). Authenticates with an *app password* per account — never
+the master NC password — created either automatically against the
+HomeBrain-shipped NC, or pasted in from an external NC's
+Personal → Security → App passwords flow.
 
 Privacy posture (see INTEGRATIONS_PLAN.md §3.2):
   * `nc.files_list` returns paths and sizes only, never contents.
@@ -13,10 +15,16 @@ Privacy posture (see INTEGRATIONS_PLAN.md §3.2):
     themselves so the LM never ingests the bytes.
 
 Environment:
-  NC_BASE_URL    e.g. http://localhost:8080  or  https://nc.<tunnel>
-  NC_USER        Nextcloud username (typically the admin user)
-  NC_TOKEN_FILE  path to file containing the app password (mode 0600)
-  NC_TOKEN       fallback if NC_TOKEN_FILE not set
+  NC_ACCOUNTS_FILE             path to ~/.openclaw/nc_accounts.json
+                               (list of {name, base_url, user, token}
+                               with token Fernet-encrypted using
+                               HOMEBRAIN_INTEGRATIONS_KEY).
+  HOMEBRAIN_INTEGRATIONS_KEY   Fernet key for at-rest decryption.
+
+Legacy fallback (single-account installs pre-multi-account):
+  NC_BASE_URL, NC_USER, NC_TOKEN, NC_TOKEN_FILE — used only if
+  NC_ACCOUNTS_FILE is absent. The dashboard migrates these on first
+  read.
 """
 from __future__ import annotations
 
@@ -34,40 +42,101 @@ from mcp_common import (  # noqa: E402
     Consent, audit, consent_required, err, ok, serve, unavailable,
 )
 
-NC_BASE_URL = os.environ.get("NC_BASE_URL", "http://localhost:8080").rstrip("/")
-NC_USER = os.environ.get("NC_USER", "")
-NC_TOKEN_FILE = os.environ.get("NC_TOKEN_FILE", "")
-NC_TOKEN = os.environ.get("NC_TOKEN", "")
+NC_ACCOUNTS_FILE = os.environ.get("NC_ACCOUNTS_FILE", "")
+INTEGRATIONS_KEY = os.environ.get("HOMEBRAIN_INTEGRATIONS_KEY", "")
+
+# Legacy single-account fallback — kept so this MCP keeps working if
+# spawned before the dashboard migrates a legacy install.
+LEGACY_BASE_URL = os.environ.get("NC_BASE_URL", "").rstrip("/")
+LEGACY_USER = os.environ.get("NC_USER", "")
+LEGACY_TOKEN_FILE = os.environ.get("NC_TOKEN_FILE", "")
+LEGACY_TOKEN = os.environ.get("NC_TOKEN", "")
 
 MAX_DOWNLOAD_BYTES = 2_000_000
 
 DAV_NS = "{DAV:}"
 
 
-def _token() -> str:
-    if NC_TOKEN_FILE and os.path.exists(NC_TOKEN_FILE):
+def _decrypt(blob: str) -> str:
+    if not INTEGRATIONS_KEY:
+        return blob
+    try:
+        from cryptography.fernet import Fernet  # type: ignore
+        return Fernet(INTEGRATIONS_KEY.encode()).decrypt(blob.encode()).decode()
+    except Exception:
+        return blob
+
+
+def _accounts() -> list[dict]:
+    if NC_ACCOUNTS_FILE and os.path.exists(NC_ACCOUNTS_FILE):
         try:
-            return open(NC_TOKEN_FILE).read().strip()
+            with open(NC_ACCOUNTS_FILE) as f:
+                data = json.load(f)
+            return data.get("accounts", []) if isinstance(data, dict) else []
+        except (OSError, json.JSONDecodeError):
+            return []
+    # Legacy single-account fallback.
+    tok = ""
+    if LEGACY_TOKEN_FILE and os.path.exists(LEGACY_TOKEN_FILE):
+        try:
+            tok = open(LEGACY_TOKEN_FILE).read().strip()
         except OSError:
-            return ""
-    return NC_TOKEN.strip()
+            pass
+    if not tok:
+        tok = LEGACY_TOKEN.strip()
+    if tok and LEGACY_BASE_URL and LEGACY_USER:
+        return [{"name": "homebrain", "base_url": LEGACY_BASE_URL,
+                 "user": LEGACY_USER, "token": tok}]
+    return []
 
 
-def _auth_header() -> str | None:
-    tok = _token()
-    if not NC_USER or not tok:
+def _pick_account(name: str | None) -> dict | None:
+    accounts = _accounts()
+    if not accounts:
         return None
-    raw = f"{NC_USER}:{tok}".encode()
+    if not name:
+        return accounts[0] if len(accounts) == 1 else None
+    for a in accounts:
+        if a.get("name") == name:
+            return a
+    return None
+
+
+def _account_or_err(args: dict) -> tuple[dict | None, dict | None]:
+    name = (args.get("account") or "").strip() or None
+    a = _pick_account(name)
+    if a is not None:
+        return a, None
+    accounts = _accounts()
+    if not accounts:
+        return None, unavailable("no Nextcloud accounts configured")
+    if not name and len(accounts) > 1:
+        names = ", ".join(repr(x.get("name")) for x in accounts)
+        return None, err(
+            f"multiple NC accounts configured; pass `account` (one of: {names})",
+            hint="Use nc.list_accounts to see the configured set.",
+        )
+    return None, err(f"account '{name}' not found",
+                     hint="Use nc.list_accounts to see the configured set.")
+
+
+def _auth_header(account: dict) -> str | None:
+    user = account.get("user", "")
+    tok = _decrypt(account.get("token") or "")
+    if not user or not tok:
+        return None
+    raw = f"{user}:{tok}".encode()
     return "Basic " + base64.b64encode(raw).decode()
 
 
-def _http(method: str, path: str, body: bytes | None = None,
+def _http(account: dict, method: str, path: str, body: bytes | None = None,
           headers: dict | None = None, timeout: int = 10,
           ocs: bool = False) -> tuple[int, bytes, dict]:
-    auth = _auth_header()
+    auth = _auth_header(account)
     if not auth:
-        return 0, b"no NC credentials configured", {}
-    url = f"{NC_BASE_URL}{path}"
+        return 0, b"account missing user or token", {}
+    base = (account.get("base_url") or "").rstrip("/")
+    url = f"{base}{path}"
     req = urllib.request.Request(url, data=body, method=method)
     req.add_header("Authorization", auth)
     if ocs:
@@ -84,9 +153,40 @@ def _http(method: str, path: str, body: bytes | None = None,
         return 0, str(e).encode(), {}
 
 
+def _dav_files_prefix(account: dict) -> str:
+    return f"/remote.php/dav/files/{account.get('user', '')}"
+
+
 # ---------------------------------------------------------------------------
-# WebDAV — files
+# Tools
 # ---------------------------------------------------------------------------
+
+def t_list_accounts(_args: dict) -> dict:
+    accounts = [{"name": a.get("name"), "base_url": a.get("base_url"),
+                 "user": a.get("user")} for a in _accounts()]
+    return ok(accounts=accounts, total=len(accounts),
+              hint=("Pass `account: <name>` on other tools to pick one. "
+                    "Single-account installs default to the only entry."))
+
+
+def t_health(args: dict) -> dict:
+    account, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
+    code, body, _ = _http(account, "GET", "/status.php")
+    if code != 200:
+        return unavailable(f"Nextcloud '{account['name']}' at "
+                           f"{account['base_url']} unreachable: {code}")
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError:
+        return err("could not parse status.php")
+    return ok(account=account["name"], version=data.get("versionstring"),
+              installed=data.get("installed"),
+              maintenance=data.get("maintenance"))
+
+
+# --- WebDAV files ----------------------------------------------------------
 
 PROPFIND_BODY = (
     b'<?xml version="1.0"?>'
@@ -98,17 +198,22 @@ PROPFIND_BODY = (
 
 
 def t_files_list(args: dict) -> dict:
+    account, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
     path = (args.get("path") or "/").strip()
     if not path.startswith("/"):
         path = "/" + path
-    dav_path = f"/remote.php/dav/files/{NC_USER}{path}"
-    code, body, _ = _http("PROPFIND", dav_path, PROPFIND_BODY,
+    prefix = _dav_files_prefix(account)
+    dav_path = f"{prefix}{path}"
+    code, body, _ = _http(account, "PROPFIND", dav_path, PROPFIND_BODY,
                           headers={"Depth": "1",
                                    "Content-Type": "application/xml"})
     if code in (0, 401):
         return unavailable(f"Nextcloud unreachable or unauthorised ({code})")
     if code not in (207, 200):
-        return err(f"PROPFIND failed: {code}", body=body[:200].decode("utf-8", "replace"))
+        return err(f"PROPFIND failed: {code}",
+                   body=body[:200].decode("utf-8", "replace"))
     try:
         root = ET.fromstring(body)
     except ET.ParseError:
@@ -116,7 +221,7 @@ def t_files_list(args: dict) -> dict:
     entries = []
     for resp in root.findall(f"{DAV_NS}response"):
         href = (resp.findtext(f"{DAV_NS}href") or "").rstrip("/")
-        if not href or href.endswith(f"/files/{NC_USER}{path.rstrip('/')}"):
+        if not href or href.endswith(f"{prefix}{path.rstrip('/')}"):
             continue  # skip the directory itself
         propstat = resp.find(f"{DAV_NS}propstat/{DAV_NS}prop")
         if propstat is None:
@@ -124,8 +229,6 @@ def t_files_list(args: dict) -> dict:
         is_dir = propstat.find(f"{DAV_NS}resourcetype/{DAV_NS}collection") is not None
         size = propstat.findtext(f"{DAV_NS}getcontentlength") or ""
         modified = propstat.findtext(f"{DAV_NS}getlastmodified") or ""
-        # Trim "/remote.php/dav/files/<user>" prefix from the displayed path.
-        prefix = f"/remote.php/dav/files/{NC_USER}"
         rel = href[len(prefix):] if href.startswith(prefix) else href
         entries.append({
             "path": rel,
@@ -134,29 +237,31 @@ def t_files_list(args: dict) -> dict:
             "size": int(size) if size.isdigit() else None,
             "modified": modified,
         })
-    return ok(entries=entries, total=len(entries))
+    return ok(account=account["name"], entries=entries, total=len(entries))
 
 
 def t_files_search(args: dict) -> dict:
     """Use Nextcloud's WebDAV SEARCH against the full file index."""
+    account, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
     q = (args.get("query") or "").strip()
     if not q:
         return err("query is required")
-    # Nextcloud supports a SEARCH report on /remote.php/dav.
     body = (
         f'<?xml version="1.0" encoding="UTF-8"?>'
         f'<d:searchrequest xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">'
         f'  <d:basicsearch>'
         f'    <d:select><d:prop><oc:fileid/><d:displayname/>'
         f'      <d:getcontentlength/><d:resourcetype/></d:prop></d:select>'
-        f'    <d:from><d:scope><d:href>/files/{NC_USER}</d:href>'
+        f'    <d:from><d:scope><d:href>/files/{account.get("user", "")}</d:href>'
         f'      <d:depth>infinity</d:depth></d:scope></d:from>'
         f'    <d:where><d:like><d:prop><d:displayname/></d:prop>'
         f'      <d:literal>%{q}%</d:literal></d:like></d:where>'
         f'  </d:basicsearch>'
         f'</d:searchrequest>'
     ).encode()
-    code, resp, _ = _http("SEARCH", "/remote.php/dav",
+    code, resp, _ = _http(account, "SEARCH", "/remote.php/dav",
                           body, headers={"Content-Type": "application/xml"})
     if code not in (207, 200):
         return err(f"SEARCH failed: {code}",
@@ -165,6 +270,7 @@ def t_files_search(args: dict) -> dict:
         root = ET.fromstring(resp)
     except ET.ParseError:
         return err("could not parse search response")
+    prefix = _dav_files_prefix(account)
     matches = []
     for r in root.findall(f"{DAV_NS}response"):
         href = (r.findtext(f"{DAV_NS}href") or "").rstrip("/")
@@ -173,7 +279,6 @@ def t_files_search(args: dict) -> dict:
             continue
         is_dir = prop.find(f"{DAV_NS}resourcetype/{DAV_NS}collection") is not None
         size = prop.findtext(f"{DAV_NS}getcontentlength") or ""
-        prefix = f"/remote.php/dav/files/{NC_USER}"
         rel = href[len(prefix):] if href.startswith(prefix) else href
         matches.append({
             "path": rel,
@@ -182,27 +287,36 @@ def t_files_search(args: dict) -> dict:
         })
         if len(matches) >= 100:
             break
-    return ok(results=matches, total=len(matches))
+    return ok(account=account["name"], results=matches, total=len(matches))
 
 
 def t_files_download(args: dict) -> dict:
-    """REVEAL-tier: fetch a small file's contents. Capped at 2 MB.
-    Requires a confirmation token (act/reveal hybrid)."""
+    """Fetch a small file's contents. Capped at 2 MB.
+    Just call this directly; the runtime prompts the user for approval."""
+    account, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
     path = (args.get("path") or "").strip()
     confirm = args.get("confirmation_token")
     chat_id = args.get("_chat_id")
     if not path:
         return err("path is required")
-    summary = f"Nextcloud: download contents of {path} (capped at {MAX_DOWNLOAD_BYTES // 1000} kB)"
+    summary = (f"Nextcloud ({account['name']}): download contents of {path} "
+               f"(capped at {MAX_DOWNLOAD_BYTES // 1000} kB)")
     if not confirm:
-        action_id = Consent.issue("nextcloud", summary, {"path": path}, chat_id)
+        action_id = Consent.issue("nextcloud", summary,
+                                  {"account": account["name"], "path": path},
+                                  chat_id)
         return consent_required(action_id, summary)
     redeemed = Consent.verify(confirm, "nextcloud", chat_id)
     if not redeemed:
         return err("confirmation_token invalid or expired")
-    if not path.startswith("/"):
-        path = "/" + path
-    code, body, _ = _http("GET", f"/remote.php/dav/files/{NC_USER}{path}")
+    redeem_account = _pick_account(redeemed.get("account")) or account
+    p = redeemed["path"] if redeemed.get("path") else path
+    if not p.startswith("/"):
+        p = "/" + p
+    code, body, _ = _http(redeem_account, "GET",
+                          f"{_dav_files_prefix(redeem_account)}{p}")
     if code in (0, 401):
         return unavailable("Nextcloud unreachable or unauthorised")
     if code == 404:
@@ -210,38 +324,45 @@ def t_files_download(args: dict) -> dict:
     if code != 200:
         return err(f"download failed: {code}")
     if len(body) > MAX_DOWNLOAD_BYTES:
-        audit("nextcloud", "download.too_large", path=path, bytes=len(body))
+        audit("nextcloud", "download.too_large",
+              account=redeem_account["name"], path=p, bytes=len(body))
         return err(
             f"file is {len(body)} bytes (cap {MAX_DOWNLOAD_BYTES}); "
             "use nc.files_share for large files"
         )
-    audit("nextcloud", "download", path=path, bytes=len(body))
+    audit("nextcloud", "download", account=redeem_account["name"],
+          path=p, bytes=len(body))
     try:
         text = body.decode("utf-8")
-        return ok(path=path, encoding="utf-8", content=text, size=len(body))
+        return ok(account=redeem_account["name"], path=p,
+                  encoding="utf-8", content=text, size=len(body))
     except UnicodeDecodeError:
-        return ok(path=path, encoding="base64",
-                  content=base64.b64encode(body).decode(),
-                  size=len(body))
+        return ok(account=redeem_account["name"], path=p, encoding="base64",
+                  content=base64.b64encode(body).decode(), size=len(body))
 
 
 def t_files_share(args: dict) -> dict:
-    """Create a public share link for a file/folder. ACT-tier."""
+    """Create a public read-only share link. Just call this directly."""
+    account, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
     path = (args.get("path") or "").strip()
     expire_days = int(args.get("expire_days") or 7)
     confirm = args.get("confirmation_token")
     chat_id = args.get("_chat_id")
     if not path:
         return err("path is required")
-    summary = f"Nextcloud: create public share link for {path} (expires in {expire_days} days)"
+    summary = (f"Nextcloud ({account['name']}): create public share link for "
+               f"{path} (expires in {expire_days} days)")
     if not confirm:
         action_id = Consent.issue("nextcloud", summary,
-                                  {"path": path, "expire_days": expire_days},
-                                  chat_id)
+                                  {"account": account["name"], "path": path,
+                                   "expire_days": expire_days}, chat_id)
         return consent_required(action_id, summary)
     redeemed = Consent.verify(confirm, "nextcloud", chat_id)
     if not redeemed:
         return err("confirmation_token invalid or expired")
+    redeem_account = _pick_account(redeemed.get("account")) or account
 
     from urllib.parse import urlencode
     form = urlencode({
@@ -249,7 +370,7 @@ def t_files_share(args: dict) -> dict:
         "shareType": "3",  # public link
         "permissions": "1",  # read-only
     }).encode()
-    code, body, _ = _http("POST",
+    code, body, _ = _http(redeem_account, "POST",
                           "/ocs/v2.php/apps/files_sharing/api/v1/shares",
                           body=form,
                           headers={"Content-Type": "application/x-www-form-urlencoded"},
@@ -262,16 +383,19 @@ def t_files_share(args: dict) -> dict:
         url = ((data.get("ocs") or {}).get("data") or {}).get("url", "")
     except json.JSONDecodeError:
         url = ""
-    audit("nextcloud", "share", path=redeemed["path"], expire_days=expire_days)
-    return ok(share_url=url, expire_days=expire_days, path=redeemed["path"])
+    audit("nextcloud", "share", account=redeem_account["name"],
+          path=redeemed["path"], expire_days=expire_days)
+    return ok(account=redeem_account["name"], share_url=url,
+              expire_days=expire_days, path=redeemed["path"])
 
 
-# ---------------------------------------------------------------------------
-# Notes
-# ---------------------------------------------------------------------------
+# --- Notes -----------------------------------------------------------------
 
-def t_notes_list(_args: dict) -> dict:
-    code, body, _ = _http("GET", "/index.php/apps/notes/api/v1/notes",
+def t_notes_list(args: dict) -> dict:
+    account, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
+    code, body, _ = _http(account, "GET", "/index.php/apps/notes/api/v1/notes",
                           headers={"Accept": "application/json"})
     if code != 200:
         return unavailable(f"Notes API returned {code}")
@@ -282,14 +406,17 @@ def t_notes_list(_args: dict) -> dict:
     summaries = [{"id": n.get("id"), "title": n.get("title"),
                   "category": n.get("category"),
                   "modified": n.get("modified")} for n in data]
-    return ok(notes=summaries, total=len(summaries))
+    return ok(account=account["name"], notes=summaries, total=len(summaries))
 
 
 def t_notes_get(args: dict) -> dict:
+    account, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
     nid = args.get("id")
     if nid is None:
         return err("id is required")
-    code, body, _ = _http("GET",
+    code, body, _ = _http(account, "GET",
                           f"/index.php/apps/notes/api/v1/notes/{int(nid)}",
                           headers={"Accept": "application/json"})
     if code == 404:
@@ -300,30 +427,36 @@ def t_notes_get(args: dict) -> dict:
         n = json.loads(body)
     except json.JSONDecodeError:
         return err("could not parse note")
-    return ok(id=n.get("id"), title=n.get("title"),
+    return ok(account=account["name"], id=n.get("id"), title=n.get("title"),
               content=n.get("content"), category=n.get("category"),
               modified=n.get("modified"))
 
 
 def t_notes_create(args: dict) -> dict:
+    account, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
     title = args.get("title") or "(untitled)"
     content = args.get("content") or ""
     category = args.get("category") or ""
     confirm = args.get("confirmation_token")
     chat_id = args.get("_chat_id")
-    summary = f"Nextcloud: create note '{title}' ({len(content)} chars)"
+    summary = (f"Nextcloud ({account['name']}): create note '{title}' "
+               f"({len(content)} chars)")
     if not confirm:
         action_id = Consent.issue("nextcloud", summary,
-                                  {"title": title, "content": content,
-                                   "category": category},
+                                  {"account": account["name"], "title": title,
+                                   "content": content, "category": category},
                                   chat_id)
         return consent_required(action_id, summary)
     redeemed = Consent.verify(confirm, "nextcloud", chat_id)
     if not redeemed:
         return err("confirmation_token invalid or expired")
+    redeem_account = _pick_account(redeemed.get("account")) or account
     body = json.dumps({"title": redeemed["title"], "content": redeemed["content"],
                        "category": redeemed["category"]}).encode()
-    code, resp, _ = _http("POST", "/index.php/apps/notes/api/v1/notes",
+    code, resp, _ = _http(redeem_account, "POST",
+                          "/index.php/apps/notes/api/v1/notes",
                           body=body,
                           headers={"Content-Type": "application/json"})
     if code not in (200, 201):
@@ -332,41 +465,41 @@ def t_notes_create(args: dict) -> dict:
         n = json.loads(resp)
     except json.JSONDecodeError:
         n = {}
-    audit("nextcloud", "notes.create",
+    audit("nextcloud", "notes.create", account=redeem_account["name"],
           title=redeemed["title"], note_id=n.get("id"))
-    return ok(id=n.get("id"), title=n.get("title"))
+    return ok(account=redeem_account["name"], id=n.get("id"), title=n.get("title"))
 
 
-# ---------------------------------------------------------------------------
-# Health
-# ---------------------------------------------------------------------------
-
-def t_health(_args: dict) -> dict:
-    code, body, _ = _http("GET", "/status.php")
-    if code != 200:
-        return unavailable(f"Nextcloud at {NC_BASE_URL} unreachable: {code}")
-    try:
-        data = json.loads(body)
-    except json.JSONDecodeError:
-        return err("could not parse status.php")
-    return ok(version=data.get("versionstring"),
-              installed=data.get("installed"),
-              maintenance=data.get("maintenance"))
-
+_ACCOUNT_PROP = {
+    "type": "string",
+    "description": ("Configured account name to act on. Omit when only one "
+                    "account is configured; required when multiple are. Use "
+                    "nc.list_accounts to enumerate."),
+}
 
 TOOLS = [
+    {"name": "nc.list_accounts",
+     "description": "List configured Nextcloud accounts (name + base_url + user).",
+     "inputSchema": {"type": "object", "properties": {}}},
     {"name": "nc.health",
      "description": "Check Nextcloud reachability and report version.",
-     "inputSchema": {"type": "object", "properties": {}}},
+     "inputSchema": {"type": "object",
+                     "properties": {"account": _ACCOUNT_PROP}}},
     {"name": "nc.files_list",
-     "description": "List files in a Nextcloud folder. Returns paths, sizes, and modification times only — never file contents.",
+     "description": ("List files in a Nextcloud folder. Returns paths, sizes, "
+                     "and modification times only — never file contents."),
      "inputSchema": {"type": "object",
-                     "properties": {"path": {"type": "string",
-                                             "description": "Folder path, e.g. '/Documents'. Default '/'."}}}},
+                     "properties": {
+                         "path": {"type": "string",
+                                  "description": "Folder path, e.g. '/Documents'. Default '/'."},
+                         "account": _ACCOUNT_PROP,
+                     }}},
     {"name": "nc.files_search",
-     "description": "Search Nextcloud files by name (substring match). Returns paths only — never file contents.",
+     "description": ("Search Nextcloud files by name (substring match). "
+                     "Returns paths only — never file contents."),
      "inputSchema": {"type": "object",
-                     "properties": {"query": {"type": "string"}},
+                     "properties": {"query": {"type": "string"},
+                                    "account": _ACCOUNT_PROP},
                      "required": ["query"]}},
     {"name": "nc.files_download",
      "description": (
@@ -376,35 +509,47 @@ TOOLS = [
      ),
      "inputSchema": {"type": "object",
                      "properties": {"path": {"type": "string"},
+                                    "account": _ACCOUNT_PROP,
                                     "confirmation_token": {"type": "string"}},
                      "required": ["path"]}},
     {"name": "nc.files_share",
-     "description": "Create a public read-only share link for a Nextcloud file or folder. Just call this directly with the path and expire_days; the runtime prompts the user for approval automatically — you do not need to ask the user for a token first.",
+     "description": ("Create a public read-only share link for a Nextcloud "
+                     "file or folder. Just call this directly with the path "
+                     "and expire_days; the runtime prompts the user for "
+                     "approval automatically — you do not need to ask the "
+                     "user for a token first."),
      "inputSchema": {"type": "object",
                      "properties": {"path": {"type": "string"},
                                     "expire_days": {"type": "integer"},
+                                    "account": _ACCOUNT_PROP,
                                     "confirmation_token": {"type": "string"}},
                      "required": ["path"]}},
     {"name": "nc.notes_list",
      "description": "List Nextcloud Notes (titles and metadata only).",
-     "inputSchema": {"type": "object", "properties": {}}},
+     "inputSchema": {"type": "object",
+                     "properties": {"account": _ACCOUNT_PROP}}},
     {"name": "nc.notes_get",
      "description": "Fetch full content of one note by id.",
      "inputSchema": {"type": "object",
-                     "properties": {"id": {"type": "integer"}},
+                     "properties": {"id": {"type": "integer"},
+                                    "account": _ACCOUNT_PROP},
                      "required": ["id"]}},
     {"name": "nc.notes_create",
-     "description": "Create a Nextcloud note. Call this directly with title/content; the runtime prompts the user for approval automatically.",
+     "description": ("Create a Nextcloud note. Call this directly with "
+                     "title/content; the runtime prompts the user for "
+                     "approval automatically."),
      "inputSchema": {"type": "object",
                      "properties": {"title": {"type": "string"},
                                     "content": {"type": "string"},
                                     "category": {"type": "string"},
+                                    "account": _ACCOUNT_PROP,
                                     "confirmation_token": {"type": "string"}},
                      "required": ["title", "content"]}},
 ]
 
 
 DISPATCH = {
+    "nc.list_accounts": t_list_accounts,
     "nc.health": t_health,
     "nc.files_list": t_files_list,
     "nc.files_search": t_files_search,
@@ -424,4 +569,4 @@ def dispatch(name: str, args: dict) -> dict:
 
 
 if __name__ == "__main__":
-    serve("homebrain-nextcloud", "0.1.0", TOOLS, dispatch)
+    serve("homebrain-nextcloud", "0.2.0", TOOLS, dispatch)

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -43,8 +43,12 @@ HOMEBRAIN_HOME = os.environ.get("HOMEBRAIN_HOME", "/home/homebrain")
 OPENCLAW_DIR = os.path.join(HOMEBRAIN_HOME, ".openclaw")
 LOG_DIR = "/var/log/homebrain"
 
+# Legacy single-account files — kept for migration; new accounts live in
+# the *_ACCOUNTS_FILE companions below as JSON arrays.
 HA_TOKEN_FILE = os.path.join(OPENCLAW_DIR, "ha.token")
 NC_TOKEN_FILE = os.path.join(OPENCLAW_DIR, "nextcloud.token")
+HA_ACCOUNTS_FILE = os.path.join(OPENCLAW_DIR, "ha_accounts.json")
+NC_ACCOUNTS_FILE = os.path.join(OPENCLAW_DIR, "nc_accounts.json")
 EMAIL_ACCOUNTS_FILE = os.path.join(OPENCLAW_DIR, "email_accounts.json")
 SELF_TOKEN_FILE = os.path.join(OPENCLAW_DIR, "homebrain.token")
 
@@ -296,39 +300,33 @@ def _spec_self() -> dict:
 
 
 def _spec_homeassistant() -> dict | None:
-    if not os.path.exists(HA_TOKEN_FILE):
+    # The HA MCP now reads a per-account list at runtime, so the spec
+    # only points it at the file. Returning None when there are no
+    # accounts leaves the integration "configured: false" in the UI.
+    _migrate_legacy_ha_token()  # one-shot; cheap if already done
+    if not _load_ha_accounts():
         return None
-    env = _read_env()
-    # MCP servers run on the host, not inside the docker network.
-    ha_port = env.get("HA_PORT", "8123")
-    base = env.get("HA_BASE_URL") or f"http://127.0.0.1:{ha_port}"
     return {
         "command": PYTHON_BIN,
         "args": [os.path.join(SCRIPTS_DIR, "mcp-homeassistant.py")],
         "env": {
-            "HA_BASE_URL": base,
-            "HA_TOKEN_FILE": HA_TOKEN_FILE,
+            "HA_ACCOUNTS_FILE": HA_ACCOUNTS_FILE,
+            "HOMEBRAIN_INTEGRATIONS_KEY": _email_fernet_key(),
             "HOMEBRAIN_AUDIT_DIR": LOG_DIR,
         },
     }
 
 
 def _spec_nextcloud() -> dict | None:
-    if not os.path.exists(NC_TOKEN_FILE):
+    _migrate_legacy_nc_token()
+    if not _load_nc_accounts():
         return None
-    env = _read_env()
-    # MCP servers run on the host, not inside the docker network — use the
-    # host-exposed port (NEXTCLOUD_PORT, default 8080) on 127.0.0.1.
-    nc_port = env.get("NEXTCLOUD_PORT", "8080")
-    base = env.get("NC_BASE_URL") or f"http://127.0.0.1:{nc_port}"
-    user = env.get("NEXTCLOUD_ADMIN_USER", "admin")
     return {
         "command": PYTHON_BIN,
         "args": [os.path.join(SCRIPTS_DIR, "mcp-nextcloud.py")],
         "env": {
-            "NC_BASE_URL": base,
-            "NC_USER": user,
-            "NC_TOKEN_FILE": NC_TOKEN_FILE,
+            "NC_ACCOUNTS_FILE": NC_ACCOUNTS_FILE,
+            "HOMEBRAIN_INTEGRATIONS_KEY": _email_fernet_key(),
             "HOMEBRAIN_AUDIT_DIR": LOG_DIR,
         },
     }
@@ -401,37 +399,174 @@ def reconcile_all_mcp() -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Per-integration bootstrap helpers
+# Home Assistant + Nextcloud account stores (multi-account)
 # ---------------------------------------------------------------------------
+# Each integration keeps a JSON file under ~/.openclaw with a list of
+# accounts. Tokens are Fernet-encrypted at rest using the same key as
+# email account passwords (HOMEBRAIN_INTEGRATIONS_KEY in MCP env, aka
+# HOMEBRAIN_EMAIL_KEY in .env — same value, name kept for compat). Users
+# may add as many accounts as they want, each pointing at a different
+# domain. The MCP server-side dispatches tools by `account` parameter.
 
-def bootstrap_homeassistant(token: str | None = None) -> tuple[bool, str]:
-    """Persist a long-lived access token. If `token` is None, attempt to
-    auto-create one against the running HA container using the admin
-    credentials baked into .env at provision time. Falling back to a manual
-    paste flow is the dashboard's responsibility."""
-    if token:
-        _write_secret(HA_TOKEN_FILE, token)
-        return True, "stored"
+def _load_ha_accounts() -> list[dict]:
+    if not os.path.exists(HA_ACCOUNTS_FILE):
+        return []
+    try:
+        with open(HA_ACCOUNTS_FILE) as f:
+            d = json.load(f)
+        return d.get("accounts", []) if isinstance(d, dict) else []
+    except (OSError, json.JSONDecodeError):
+        return []
+
+
+def _save_ha_accounts(accounts: list[dict]) -> None:
+    blob = json.dumps({"accounts": accounts}, indent=2)
+    _write_secret(HA_ACCOUNTS_FILE, blob)
+
+
+def add_ha_account(name: str, base_url: str, token: str) -> tuple[bool, str]:
+    if not all([name, base_url, token]):
+        return False, "name, base_url, and token are required"
+    accounts = _load_ha_accounts()
+    if any(a.get("name") == name for a in accounts):
+        return False, f"account '{name}' already exists"
+    accounts.append({
+        "name": name,
+        "base_url": base_url.rstrip("/"),
+        "token": _encrypt_secret(token),
+    })
+    _save_ha_accounts(accounts)
+    return True, "added"
+
+
+def remove_ha_account(name: str) -> bool:
+    accounts = _load_ha_accounts()
+    new = [a for a in accounts if a.get("name") != name]
+    if len(new) == len(accounts):
+        return False
+    if new:
+        _save_ha_accounts(new)
+    else:
+        os.remove(HA_ACCOUNTS_FILE)
+    return True
+
+
+def _load_nc_accounts() -> list[dict]:
+    if not os.path.exists(NC_ACCOUNTS_FILE):
+        return []
+    try:
+        with open(NC_ACCOUNTS_FILE) as f:
+            d = json.load(f)
+        return d.get("accounts", []) if isinstance(d, dict) else []
+    except (OSError, json.JSONDecodeError):
+        return []
+
+
+def _save_nc_accounts(accounts: list[dict]) -> None:
+    blob = json.dumps({"accounts": accounts}, indent=2)
+    _write_secret(NC_ACCOUNTS_FILE, blob)
+
+
+def add_nc_account(name: str, base_url: str, user: str, token: str) -> tuple[bool, str]:
+    if not all([name, base_url, user, token]):
+        return False, "name, base_url, user, and token are required"
+    accounts = _load_nc_accounts()
+    if any(a.get("name") == name for a in accounts):
+        return False, f"account '{name}' already exists"
+    accounts.append({
+        "name": name,
+        "base_url": base_url.rstrip("/"),
+        "user": user,
+        "token": _encrypt_secret(token),
+    })
+    _save_nc_accounts(accounts)
+    return True, "added"
+
+
+def remove_nc_account(name: str) -> bool:
+    accounts = _load_nc_accounts()
+    new = [a for a in accounts if a.get("name") != name]
+    if len(new) == len(accounts):
+        return False
+    if new:
+        _save_nc_accounts(new)
+    else:
+        os.remove(NC_ACCOUNTS_FILE)
+    return True
+
+
+# --- Migration from legacy single-account token files ----------------------
+
+def _migrate_legacy_ha_token() -> None:
+    """If the legacy `~/.openclaw/ha.token` exists, fold it into the new
+    accounts store as account 'home' (the user's primary HA install) and
+    delete the file. One-shot; safe to call on every spec build."""
+    if not os.path.exists(HA_TOKEN_FILE):
+        return
+    if _load_ha_accounts():
+        # Already migrated or user added accounts manually; just drop the
+        # stale token file so the migration check stops firing.
+        try:
+            os.remove(HA_TOKEN_FILE)
+        except OSError:
+            pass
+        return
+    try:
+        token = open(HA_TOKEN_FILE).read().strip()
+    except OSError:
+        return
     env = _read_env()
-    ha_user = env.get("HA_ADMIN_USER", "")
-    ha_pass = env.get("HA_ADMIN_PASSWORD", "")
-    if not (ha_user and ha_pass):
-        return False, "no admin credentials in .env; paste a token manually"
-    # HA's /auth/token + long_lived_access_tokens flow is multi-step and
-    # changes between versions. We document the manual path as the reliable
-    # one, and surface a hint in the UI if the auto path fails.
-    return False, "auto-create not yet implemented; paste a token manually"
+    ha_port = env.get("HA_PORT", "8123")
+    base = env.get("HA_BASE_URL") or f"http://127.0.0.1:{ha_port}"
+    add_ha_account("home", base, token)
+    try:
+        os.remove(HA_TOKEN_FILE)
+    except OSError:
+        pass
 
 
-def bootstrap_nextcloud() -> tuple[bool, str]:
-    """Create a Nextcloud app password via `occ user:add-app-password` for
-    the admin user. Idempotent on the file (we always overwrite); not on
-    Nextcloud (every call creates a new app password — old ones remain
-    until manually revoked)."""
+def _migrate_legacy_nc_token() -> None:
+    """Mirror of _migrate_legacy_ha_token for Nextcloud. The legacy
+    single-account flow always pointed at the HomeBrain-shipped NC, so we
+    name the migrated entry 'homebrain'."""
+    if not os.path.exists(NC_TOKEN_FILE):
+        return
+    if _load_nc_accounts():
+        try:
+            os.remove(NC_TOKEN_FILE)
+        except OSError:
+            pass
+        return
+    try:
+        token = open(NC_TOKEN_FILE).read().strip()
+    except OSError:
+        return
+    env = _read_env()
+    nc_port = env.get("NEXTCLOUD_PORT", "8080")
+    base = env.get("NC_BASE_URL") or f"http://127.0.0.1:{nc_port}"
+    user = env.get("NEXTCLOUD_ADMIN_USER", "admin")
+    add_nc_account("homebrain", base, user, token)
+    try:
+        os.remove(NC_TOKEN_FILE)
+    except OSError:
+        pass
+
+
+# --- HomeBrain-NC convenience bootstrap ------------------------------------
+# Auto-creates an app password against the LOCAL HomeBrain-shipped Nextcloud
+# and stores it as account 'homebrain'. Used by the dashboard's one-click
+# "Add this HomeBrain's Nextcloud" button. External NCs go through
+# add_nc_account directly with a user-supplied app password.
+
+def bootstrap_local_nextcloud() -> tuple[bool, str]:
     env = _read_env()
     user = env.get("NEXTCLOUD_ADMIN_USER", "")
     if not user:
         return False, "NEXTCLOUD_ADMIN_USER not in .env"
+    nc_port = env.get("NEXTCLOUD_PORT", "8080")
+    base = env.get("NC_BASE_URL") or f"http://127.0.0.1:{nc_port}"
+    if any(a.get("name") == "homebrain" for a in _load_nc_accounts()):
+        return False, "account 'homebrain' already exists"
     try:
         nc_cid = subprocess.check_output(
             ["docker", "compose", "-f",
@@ -440,8 +575,6 @@ def bootstrap_nextcloud() -> tuple[bool, str]:
         ).decode().strip()
         if not nc_cid:
             return False, "Nextcloud container not running"
-        # `occ user:add-app-password` reads the user's password from stdin in
-        # newer NC versions. Pass --password-from-env for robustness.
         admin_pass = env.get("NEXTCLOUD_ADMIN_PASSWORD", "")
         if not admin_pass:
             return False, "NEXTCLOUD_ADMIN_PASSWORD not in .env"
@@ -452,27 +585,28 @@ def bootstrap_nextcloud() -> tuple[bool, str]:
              user, "--password-from-env"],
             capture_output=True, text=True, timeout=20,
         )
-        # NC prints the app password on stdout, sometimes prefixed with text.
         out = proc.stdout.strip().splitlines()
         if proc.returncode != 0 or not out:
             return False, f"occ failed: {proc.stderr.strip()[:200]}"
-        # The token is the last whitespace-separated word on the last line.
         token = out[-1].split()[-1]
         if not token or len(token) < 20:
             return False, f"unexpected occ output: {proc.stdout.strip()[:200]}"
-        _write_secret(NC_TOKEN_FILE, token)
-        return True, "stored"
+        return add_nc_account("homebrain", base, user, token)
     except Exception as e:
         return False, str(e)
 
 
-def disconnect_homeassistant() -> None:
+def disconnect_homeassistant_all() -> None:
+    if os.path.exists(HA_ACCOUNTS_FILE):
+        os.remove(HA_ACCOUNTS_FILE)
     if os.path.exists(HA_TOKEN_FILE):
         os.remove(HA_TOKEN_FILE)
     _openclaw_mcp_unset(MCP_NAMES["homeassistant"])
 
 
-def disconnect_nextcloud() -> None:
+def disconnect_nextcloud_all() -> None:
+    if os.path.exists(NC_ACCOUNTS_FILE):
+        os.remove(NC_ACCOUNTS_FILE)
     if os.path.exists(NC_TOKEN_FILE):
         os.remove(NC_TOKEN_FILE)
     _openclaw_mcp_unset(MCP_NAMES["nextcloud"])
@@ -550,9 +684,17 @@ def integration_status(key: str) -> dict:
     if key == "self":
         info["configured"] = bool(_self_token())
     elif key == "homeassistant":
-        info["configured"] = os.path.exists(HA_TOKEN_FILE)
+        _migrate_legacy_ha_token()
+        accounts = _load_ha_accounts()
+        info["configured"] = bool(accounts)
+        info["accounts"] = [{"name": a.get("name"), "base_url": a.get("base_url")}
+                            for a in accounts]
     elif key == "nextcloud":
-        info["configured"] = os.path.exists(NC_TOKEN_FILE)
+        _migrate_legacy_nc_token()
+        accounts = _load_nc_accounts()
+        info["configured"] = bool(accounts)
+        info["accounts"] = [{"name": a.get("name"), "base_url": a.get("base_url"),
+                             "user": a.get("user")} for a in accounts]
     elif key == "vault":
         # Match the existing dashboard logic — vault is "configured" once
         # the admin token has been derived in .env.
@@ -625,46 +767,72 @@ def register_integrations(app, limiter) -> None:  # noqa: C901
             return jsonify({"error": "unauthenticated"}), 401
         return jsonify({"results": reconcile_all_mcp()})
 
-    # ---- Home Assistant ----------------------------------------------------
-    def ha_connect():
+    # ---- Home Assistant (multi-account) ------------------------------------
+    def ha_add():
         if not session.get("authenticated"):
             return jsonify({"error": "unauthenticated"}), 401
         body = request.get_json(silent=True) or {}
-        token = (body.get("token") or "").strip()
-        ok_, msg = bootstrap_homeassistant(token=token or None)
+        ok_, msg = add_ha_account(
+            name=(body.get("name") or "").strip(),
+            base_url=(body.get("base_url") or "").strip(),
+            token=(body.get("token") or "").strip(),
+        )
         if not ok_:
             return jsonify({"error": msg}), 400
-        results = reconcile_all_mcp()
-        return jsonify({"status": "connected", "reconcile": results})
+        reconcile_all_mcp()
+        return jsonify({"status": "added"})
 
-    def ha_disconnect():
+    def ha_remove():
         if not session.get("authenticated"):
             return jsonify({"error": "unauthenticated"}), 401
-        disconnect_homeassistant()
-        _openclaw_daemon_restart()
-        return jsonify({"status": "disconnected"})
+        body = request.get_json(silent=True) or {}
+        if not remove_ha_account((body.get("name") or "").strip()):
+            return jsonify({"error": "account not found"}), 404
+        reconcile_all_mcp()
+        return jsonify({"status": "removed"})
 
     def ha_test():
         if not session.get("authenticated"):
             return jsonify({"error": "unauthenticated"}), 401
         return jsonify(_ping_mcp("homeassistant"))
 
-    # ---- Nextcloud ---------------------------------------------------------
-    def nc_connect():
+    # ---- Nextcloud (multi-account) -----------------------------------------
+    def nc_add():
+        """Add an EXTERNAL Nextcloud account. For the HomeBrain-shipped NC,
+        use nc_add_local which auto-creates an app password."""
         if not session.get("authenticated"):
             return jsonify({"error": "unauthenticated"}), 401
-        ok_, msg = bootstrap_nextcloud()
+        body = request.get_json(silent=True) or {}
+        ok_, msg = add_nc_account(
+            name=(body.get("name") or "").strip(),
+            base_url=(body.get("base_url") or "").strip(),
+            user=(body.get("user") or "").strip(),
+            token=(body.get("token") or "").strip(),
+        )
         if not ok_:
             return jsonify({"error": msg}), 400
-        results = reconcile_all_mcp()
-        return jsonify({"status": "connected", "reconcile": results})
+        reconcile_all_mcp()
+        return jsonify({"status": "added"})
 
-    def nc_disconnect():
+    def nc_add_local():
+        """One-click: auto-create an app password against the HomeBrain-
+        shipped Nextcloud and store it as account 'homebrain'."""
         if not session.get("authenticated"):
             return jsonify({"error": "unauthenticated"}), 401
-        disconnect_nextcloud()
-        _openclaw_daemon_restart()
-        return jsonify({"status": "disconnected"})
+        ok_, msg = bootstrap_local_nextcloud()
+        if not ok_:
+            return jsonify({"error": msg}), 400
+        reconcile_all_mcp()
+        return jsonify({"status": "added", "name": "homebrain"})
+
+    def nc_remove():
+        if not session.get("authenticated"):
+            return jsonify({"error": "unauthenticated"}), 401
+        body = request.get_json(silent=True) or {}
+        if not remove_nc_account((body.get("name") or "").strip()):
+            return jsonify({"error": "account not found"}), 404
+        reconcile_all_mcp()
+        return jsonify({"status": "removed"})
 
     def nc_test():
         if not session.get("authenticated"):
@@ -863,21 +1031,25 @@ def register_integrations(app, limiter) -> None:  # noqa: C901
                      limiter.limit("10 per minute")(reconcile),
                      methods=["POST"])
 
-    app.add_url_rule("/api/integrations/homeassistant/connect",
-                     "ha_connect",
-                     limiter.limit("5 per minute")(ha_connect),
+    app.add_url_rule("/api/integrations/homeassistant/add",
+                     "ha_add",
+                     limiter.limit("10 per minute")(ha_add),
                      methods=["POST"])
-    app.add_url_rule("/api/integrations/homeassistant/disconnect",
-                     "ha_disconnect", ha_disconnect, methods=["POST"])
+    app.add_url_rule("/api/integrations/homeassistant/remove",
+                     "ha_remove", ha_remove, methods=["POST"])
     app.add_url_rule("/api/integrations/homeassistant/test",
                      "ha_test", ha_test, methods=["POST"])
 
-    app.add_url_rule("/api/integrations/nextcloud/connect",
-                     "nc_connect",
-                     limiter.limit("5 per minute")(nc_connect),
+    app.add_url_rule("/api/integrations/nextcloud/add",
+                     "nc_add",
+                     limiter.limit("10 per minute")(nc_add),
                      methods=["POST"])
-    app.add_url_rule("/api/integrations/nextcloud/disconnect",
-                     "nc_disconnect", nc_disconnect, methods=["POST"])
+    app.add_url_rule("/api/integrations/nextcloud/add_local",
+                     "nc_add_local",
+                     limiter.limit("5 per minute")(nc_add_local),
+                     methods=["POST"])
+    app.add_url_rule("/api/integrations/nextcloud/remove",
+                     "nc_remove", nc_remove, methods=["POST"])
     app.add_url_rule("/api/integrations/nextcloud/test",
                      "nc_test", nc_test, methods=["POST"])
     app.add_url_rule("/api/integrations/vault/test",

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -815,13 +815,33 @@
                 <small id="conn-msg" style="display:block; margin-top:6px; min-height:1em; color:var(--text-dim); font-size:0.88em;"></small>
 
                 <div hidden id="details-ha" class="conn-form">
-                    <div style="display:flex; gap:8px;">
-                        <input type="text" id="ha-token-input" placeholder="Long-lived access token (paste from HA → Profile → Security)" style="flex:1; margin-bottom:0;" onkeydown="if (event.key === 'Enter') { event.preventDefault(); connHaConnect(); }">
-                        <button class="btn-primary" onclick="connHaConnect()">Connect</button>
+                    <div style="display:grid; grid-template-columns: 1fr 2fr; gap:8px;">
+                        <input type="text" id="ha-name"     placeholder="Label (e.g. Home, Cabin)">
+                        <input type="text" id="ha-base-url" placeholder="https://ha.example.com">
+                        <input type="text" id="ha-token-input" placeholder="Long-lived access token (paste from HA → Profile → Security)" style="grid-column:1/-1;" onkeydown="if (event.key === 'Enter') { event.preventDefault(); connHaAdd(); }">
+                    </div>
+                    <div style="margin-top:8px; display:flex; gap:8px;">
+                        <button class="btn-primary" onclick="connHaAdd()">Add</button>
                         <button onclick="closeForm('details-ha')" aria-label="Close">✕</button>
                     </div>
                     <small style="display:block; margin-top:6px; color:var(--text-dim);">
-                        In Home Assistant: Profile → Security → Long-lived access tokens → Create. Paste the token here.
+                        In each Home Assistant instance: Profile → Security → Long-lived access tokens → Create. Add one row per house. The agent picks the right one with the <code>account</code> parameter.
+                    </small>
+                </div>
+
+                <div hidden id="details-nc" class="conn-form">
+                    <div style="display:grid; grid-template-columns: 1fr 2fr; gap:8px;">
+                        <input type="text" id="nc-name"     placeholder="Label (e.g. Personal)">
+                        <input type="text" id="nc-base-url" placeholder="https://nc.example.com">
+                        <input type="text" id="nc-user"     placeholder="Username">
+                        <input type="password" id="nc-token" placeholder="App password (Personal → Security → App passwords)">
+                    </div>
+                    <div style="margin-top:8px; display:flex; gap:8px;">
+                        <button class="btn-primary" onclick="connNcAdd()">Add</button>
+                        <button onclick="closeForm('details-nc')" aria-label="Close">✕</button>
+                    </div>
+                    <small style="display:block; margin-top:6px; color:var(--text-dim);">
+                        For your HomeBrain&rsquo;s Nextcloud, the row offers a one-click <em>Add HomeBrain NC</em> instead. Use this form for external instances.
                     </small>
                 </div>
 
@@ -1342,23 +1362,35 @@
                                 : (it.configured ? '<span class="status-badge status-unknown" title="Saved but not yet picked up by the agent — Re-sync under Troubleshoot">pending sync</span>'
                                                  : '<span class="status-badge status-stopped" title="Not set up yet">not connected</span>');
                     let extras = '';
+                    // Multi-account integrations all surface a per-account
+                    // list under the row title with a small remove button.
                     if (it.key === 'email' && (it.accounts || []).length) {
-                        extras = '<small style="display:block; color:var(--text-dim); margin-top:4px;">' +
-                                 it.accounts.map(a => `${a.name} (${a.user})`).join(' · ') + '</small>';
+                        extras = renderAccountList(it.accounts.map(a => ({
+                            name: a.name, sub: a.user })), 'email');
+                    }
+                    if (it.key === 'homeassistant' && (it.accounts || []).length) {
+                        extras = renderAccountList(it.accounts.map(a => ({
+                            name: a.name, sub: a.base_url })), 'homeassistant');
+                    }
+                    if (it.key === 'nextcloud' && (it.accounts || []).length) {
+                        extras = renderAccountList(it.accounts.map(a => ({
+                            name: a.name, sub: `${a.user || ''} @ ${a.base_url || ''}` })), 'nextcloud');
                     }
                     if (it.key === 'vault' && it.unlocked) {
                         extras = '<small style="display:block; color:var(--accent); margin-top:4px;">unlocked</small>';
                     }
                     const buttons = [];
                     if (it.key === 'nextcloud') {
-                        buttons.push(it.configured
-                            ? `<button onclick="connNcDisconnect()">Disconnect</button>`
-                            : `<button class="btn-primary" onclick="connNcConnect()">Connect</button>`);
+                        const hasLocal = (it.accounts || []).some(a => a.name === 'homebrain');
+                        if (!hasLocal) {
+                            buttons.push(`<button onclick="connNcAddLocal()" title="Auto-create app password against the HomeBrain-shipped Nextcloud">Add HomeBrain NC</button>`);
+                        }
+                        const cta = (it.accounts || []).length > 0 ? 'button' : 'btn-primary button';
+                        buttons.push(`<button class="${cta}" onclick="openDetails('details-nc','nc-name')">Add external NC…</button>`);
                     }
                     if (it.key === 'homeassistant') {
-                        buttons.push(it.configured
-                            ? `<button onclick="connHaDisconnect()">Disconnect</button>`
-                            : `<button class="btn-primary" onclick="openDetails('details-ha','ha-token-input')">Connect…</button>`);
+                        const cls = (it.accounts || []).length > 0 ? '' : 'btn-primary';
+                        buttons.push(`<button class="${cls}" onclick="openDetails('details-ha','ha-name')">Add account…</button>`);
                     }
                     if (it.key === 'email') {
                         const haveAccount = (it.accounts || []).length > 0;
@@ -1404,31 +1436,92 @@
             } catch (e) { msg.innerText = 'Apply failed: ' + e; }
             connRefresh();
         }
-        async function connHaConnect() {
-            const tok = (document.getElementById('ha-token-input') || {}).value || '';
-            if (!tok.trim()) { alert('Paste a HA long-lived access token first.'); return; }
-            const r = await fetch('/api/integrations/homeassistant/connect',
+        // Render an inline per-account list under an integration row.
+        // `kind` selects the remove endpoint (email | homeassistant | nextcloud).
+        function renderAccountList(accounts, kind) {
+            if (!accounts || !accounts.length) return '';
+            const items = accounts.map(a => {
+                const sub = a.sub ? ` <span style="color:var(--text-faint);">— ${a.sub}</span>` : '';
+                return `<span style="display:inline-flex; align-items:center; gap:4px; padding:2px 6px;
+                        background:var(--surface-2); border:1px solid var(--border); border-radius:var(--radius-pill);
+                        font-size:0.85em;">
+                        <strong>${a.name}</strong>${sub}
+                        <button onclick="connAccountRemove('${kind}','${a.name.replace(/'/g, "\\'")}')"
+                                style="padding:0 4px; background:transparent; border:0; color:var(--text-faint);
+                                       cursor:pointer; font-size:1em;" title="Remove account">✕</button>
+                       </span>`;
+            }).join(' ');
+            return `<div style="margin-top:6px; display:flex; flex-wrap:wrap; gap:4px;">${items}</div>`;
+        }
+
+        async function connAccountRemove(kind, name) {
+            if (!confirm(`Remove the ${kind} account "${name}"?`)) return;
+            const path = kind === 'email' ? 'email/remove'
+                       : kind === 'homeassistant' ? 'homeassistant/remove'
+                       : 'nextcloud/remove';
+            const r = await fetch(`/api/integrations/${path}`,
                 { method: 'POST', credentials: 'include',
                   headers: {'Content-Type': 'application/json'},
-                  body: JSON.stringify({ token: tok.trim() })});
+                  body: JSON.stringify({ name })});
+            const d = await r.json().catch(() => ({}));
+            document.getElementById('conn-msg').innerText = r.ok ? `Removed ${kind} account "${name}".` : (d.error || 'Remove failed');
+            connRefresh();
+        }
+
+        async function connHaAdd() {
+            const body = {
+                name: document.getElementById('ha-name').value.trim(),
+                base_url: document.getElementById('ha-base-url').value.trim(),
+                token: document.getElementById('ha-token-input').value.trim(),
+            };
+            if (!body.name || !body.base_url || !body.token) {
+                alert('Label, base URL, and token are required.');
+                return;
+            }
+            const r = await fetch('/api/integrations/homeassistant/add',
+                { method: 'POST', credentials: 'include',
+                  headers: {'Content-Type': 'application/json'},
+                  body: JSON.stringify(body)});
             const d = await r.json();
-            document.getElementById('conn-msg').innerText = r.ok ? 'Home Assistant connected.' : (d.error || 'Connect failed');
-            document.getElementById('ha-token-input').value = '';
-            if (r.ok) closeForm('details-ha');
+            document.getElementById('conn-msg').innerText = r.ok ? `Home Assistant account "${body.name}" added.` : (d.error || 'Add failed');
+            if (r.ok) {
+                ['ha-name', 'ha-base-url', 'ha-token-input'].forEach(id => document.getElementById(id).value = '');
+                closeForm('details-ha');
+            }
             connRefresh();
         }
-        async function connHaDisconnect() {
-            await fetch('/api/integrations/homeassistant/disconnect', { method: 'POST', credentials: 'include' });
-            connRefresh();
-        }
-        async function connNcConnect() {
-            const r = await fetch('/api/integrations/nextcloud/connect', { method: 'POST', credentials: 'include' });
+
+        async function connNcAdd() {
+            const body = {
+                name: document.getElementById('nc-name').value.trim(),
+                base_url: document.getElementById('nc-base-url').value.trim(),
+                user: document.getElementById('nc-user').value.trim(),
+                token: document.getElementById('nc-token').value,
+            };
+            if (!body.name || !body.base_url || !body.user || !body.token) {
+                alert('Label, base URL, user, and app password are required.');
+                return;
+            }
+            const r = await fetch('/api/integrations/nextcloud/add',
+                { method: 'POST', credentials: 'include',
+                  headers: {'Content-Type': 'application/json'},
+                  body: JSON.stringify(body)});
             const d = await r.json();
-            document.getElementById('conn-msg').innerText = r.ok ? 'Nextcloud app password created.' : (d.error || 'Connect failed');
+            document.getElementById('conn-msg').innerText = r.ok ? `Nextcloud account "${body.name}" added.` : (d.error || 'Add failed');
+            if (r.ok) {
+                ['nc-name', 'nc-base-url', 'nc-user', 'nc-token'].forEach(id => document.getElementById(id).value = '');
+                closeForm('details-nc');
+            }
             connRefresh();
         }
-        async function connNcDisconnect() {
-            await fetch('/api/integrations/nextcloud/disconnect', { method: 'POST', credentials: 'include' });
+
+        async function connNcAddLocal() {
+            const r = await fetch('/api/integrations/nextcloud/add_local',
+                { method: 'POST', credentials: 'include' });
+            const d = await r.json();
+            document.getElementById('conn-msg').innerText = r.ok
+                ? 'HomeBrain Nextcloud connected as "homebrain".'
+                : (d.error || 'Add failed');
             connRefresh();
         }
         async function connTest(key) {


### PR DESCRIPTION
## Why
Users with multiple houses can now control several HomeAssistant instances from one HomeBrain agent, and the agent can reach non-HomeBrain Nextcloud servers in addition to the locally-shipped one. Each account is selected at tool-call time with an `account` parameter.

## Storage
Two new files mirror email's existing pattern:
- `~/.openclaw/ha_accounts.json` — list of `{name, base_url, token}`
- `~/.openclaw/nc_accounts.json` — list of `{name, base_url, user, token}`

Tokens are Fernet-encrypted at rest using the same key path as email account passwords (`HOMEBRAIN_EMAIL_KEY` in `.env`, surfaced to MCP servers as `HOMEBRAIN_INTEGRATIONS_KEY` — same value, named for clarity since it now covers three integrations).

## Migration
First-time `integration_status()` / spec-build calls fold any legacy single-token file (`~/.openclaw/{ha,nextcloud}.token`) into the new accounts store as a `home` (HA) or `homebrain` (NC) entry, then delete the legacy file. One-shot, safe to call on every poll.

## MCP servers (bumped to v0.2.0)
- `mcp-homeassistant.py` and `mcp-nextcloud.py` read accounts at runtime.
- Every tool takes an optional `account` parameter. Single-account installs default to the only entry (zero behavioural change). Multi-account installs return a friendly error if the parameter is missing or names an unknown account, with `ha.list_accounts` / `nc.list_accounts` as the discovery tool.
- Consent tokens carry the account name through the issue/redeem cycle, so the action runs against the right instance even if the account list mutates mid-flow.

## Routes
- `POST /api/integrations/homeassistant/{add,remove,test}` *(replaces `/connect`, `/disconnect`)*
- `POST /api/integrations/nextcloud/{add,add_local,remove,test}` *(`add_local` is one-click for the HomeBrain-shipped NC; `add` is for external instances)*

## UI
- HA + NC rows in Settings → Agent integrations now show a chip list of configured accounts with per-chip ✕ remove. "Add account…" opens an inline form (label / base URL / token; +user for NC). NC also exposes a one-click **Add HomeBrain NC** button until the local entry exists.
- Mirrors the email card pattern, so the three multi-account integrations share one UI shape.

## Test plan
- [x] All four files parse clean (`ast.parse`, `bash -n`)
- [ ] Live on `.58`:
  - Confirm legacy `ha.token` migrates to a `home` account on first poll
  - Add a second HA account against a fake URL, confirm both appear in `ha.list_accounts`
  - Confirm the agent routes calls correctly via the `account` parameter
  - Same path for NC

🤖 Generated with [Claude Code](https://claude.com/claude-code)