### PR TITLE
fix(backup): include ha_accounts.json + nc_accounts.json

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -225,15 +225,21 @@ if [[ "${HAS_GPU:-false}" == "true" ]]; then
         log_warn "OpenClaw config not found at ${OPENCLAW_DIR}/openclaw.json — skipping."
     fi
 
-    # Integration tokens (HA, Nextcloud, Email, Self) and pending consent
-    # state. Mode 0600, owned by homebrain — preserve perms on restore.
+    # Integration credentials (HA accounts, NC accounts, email accounts,
+    # Self bearer token, vault session, pending consent state). Mode 0600,
+    # owned by homebrain — preserve perms on restore. Legacy *.token files
+    # (ha.token, nextcloud.token, homebrain.token) are included too so a
+    # box that has not yet been migrated still backs up cleanly; the
+    # dashboard's first integration_status() call after restore folds them
+    # into the new accounts store and deletes them.
     if compgen -G "${OPENCLAW_DIR}/*.token" > /dev/null \
-        || [[ -f "${OPENCLAW_DIR}/email_accounts.json" ]] \
+        || compgen -G "${OPENCLAW_DIR}/*_accounts.json" > /dev/null \
         || [[ -f "${OPENCLAW_DIR}/pending_actions.json" ]] \
         || [[ -f "${OPENCLAW_DIR}/vault.session" ]]; then
         mkdir -p "${STAGING_DIR}/openclaw_integrations"
         for f in ha.token nextcloud.token homebrain.token vault.session \
-                 email_accounts.json pending_actions.json; do
+                 ha_accounts.json nc_accounts.json email_accounts.json \
+                 pending_actions.json; do
             [[ -f "${OPENCLAW_DIR}/${f}" ]] && cp -a "${OPENCLAW_DIR}/${f}" "${STAGING_DIR}/openclaw_integrations/"
         done
         log_info "OpenClaw integration credentials backed up."

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -150,7 +150,8 @@ if [[ -d "${TMP_DIR}/openclaw_integrations" ]]; then
     log_info "Restoring OpenClaw integration credentials..."
     mkdir -p "${HOMEBRAIN_HOME}/.openclaw"
     for f in ha.token nextcloud.token homebrain.token vault.session \
-             email_accounts.json pending_actions.json; do
+             ha_accounts.json nc_accounts.json email_accounts.json \
+             pending_actions.json; do
         [[ -f "${TMP_DIR}/openclaw_integrations/${f}" ]] || continue
         cp -a "${TMP_DIR}/openclaw_integrations/${f}" "${HOMEBRAIN_HOME}/.openclaw/${f}"
         chmod 600 "${HOMEBRAIN_HOME}/.openclaw/${f}"


### PR DESCRIPTION
## Why
PR #33 introduced multi-account state for HomeAssistant and Nextcloud in `~/.openclaw/{ha,nc}_accounts.json`, but `backup.sh` and `restore.sh` still only listed the legacy single-token files (`ha.token`, `nextcloud.token`). A backup taken after multi-account adoption silently misses them; a restore loses every account configuration above the first.

Caught while preparing the backup/restore E2E test loop — about to be exercised on .58 right after this merges.

## What changes
- Add `ha_accounts.json` + `nc_accounts.json` to the explicit allowlist in both scripts. Legacy `*.token` files stay on the list so a not-yet-migrated box still backs up cleanly; the dashboard's first `integration_status()` call after restore folds them into the new accounts store and deletes them.
- Broaden `backup.sh`'s existence check so a box that only has the new `*_accounts.json` (no legacy tokens left) still produces the `openclaw_integrations/` section.

## Test plan
- [x] `bash -n` clean
- [ ] Full backup/restore E2E on `.58` — next step

🤖 Generated with [Claude Code](https://claude.com/claude-code)