### PR TITLE
fix(openclaw): sweep stale plugin-runtime-deps on every setup

### DIFF
--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1141,6 +1141,26 @@ setup_openclaw() {
 
     load_versions  # sets OPENCLAW_VERSION
 
+    # Sweep stale plugin-runtime-deps trees from prior OpenClaw versions.
+    # Each setup leaves ~200-700 MB of staged node_modules under
+    # ~/.openclaw/plugin-runtime-deps/openclaw-<version>-<hash>/ — the
+    # internal cleanup hits "ENOTEMPTY: rmdir openclaw/plugin-sdk" on
+    # symlink targets and gives up, so old trees pile up across upgrades.
+    # Drop everything that doesn't match the version we're about to
+    # install; the live tree is rebuilt by the gateway after install.
+    local prd="${HOMEBRAIN_HOME}/.openclaw/plugin-runtime-deps"
+    if [[ -d "$prd" ]]; then
+        for dir in "$prd"/openclaw-*; do
+            [[ -d "$dir" ]] || continue
+            local base
+            base=$(basename "$dir")
+            if [[ "$base" != openclaw-"${OPENCLAW_VERSION}"-* ]]; then
+                log_info "Removing stale plugin-runtime-deps: $base"
+                rm -rf -- "$dir"
+            fi
+        done
+    fi
+
     # Pre-flight: warn if llama-server is not reachable
     if ! curl -sf --max-time 5 http://127.0.0.1:8001/health >/dev/null 2>&1; then
         log_warn "llama-server is not responding on port 8001. OpenClaw may not work correctly."


### PR DESCRIPTION
## Why
OpenClaw stages each install's plugin runtime dependencies under `~/.openclaw/plugin-runtime-deps/openclaw-<version>-<hash>/`, and on upgrade it tries to remove the predecessor — but the cleanup hits `ENOTEMPTY: rmdir openclaw/plugin-sdk` on a symlink-target dir and gives up. Result: 200-700 MB of dead weight per upgrade.

\`.58\` was carrying **927 MB** across two trees today (`openclaw-2026.4.24-... live, openclaw-unknown-... stale from a dev install months ago`). On a smaller box (RPi) this fills the disk fast.

The same `ENOTEMPTY` warnings flooded the journal every gateway restart — they're not fatal but they mask real failures and look alarming.

## What changes
At the top of `setup_openclaw`, enumerate everything under `plugin-runtime-deps/` whose directory name doesn't match `openclaw-${OPENCLAW_VERSION}-*` and `rm -rf` it. The gateway rebuilds the live tree on its next start; we never touch it.

\`\`\`bash
local prd="${HOMEBRAIN_HOME}/.openclaw/plugin-runtime-deps"
if [[ -d "$prd" ]]; then
    for dir in "$prd"/openclaw-*; do
        [[ -d "$dir" ]] || continue
        local base
        base=$(basename "$dir")
        if [[ "$base" != openclaw-"${OPENCLAW_VERSION}"-* ]]; then
            log_info "Removing stale plugin-runtime-deps: $base"
            rm -rf -- "$dir"
        fi
    done
fi
\`\`\`

## Test plan
- [x] `bash -n` clean
- [ ] Live on `.58`: run setup_ai once, confirm the `openclaw-unknown-*` stale tree is gone and only the current version's tree remains