### PR TITLE
chore(deps): bump pinned versions (patch/minor only, May 2026)

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,15 +1,15 @@
 {
   "llama_cpp": {
-    "tag": "b8996",
-    "url": "https://github.com/ggml-org/llama.cpp/releases/download/b8996/llama-b8996-bin-ubuntu-vulkan-x64.tar.gz"
+    "tag": "b9174",
+    "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9174/llama-b9174-bin-ubuntu-vulkan-x64.tar.gz"
   },
   "whisper_cpp": {
     "git_ref": "v1.8.4"
   },
   "openclaw": {
-    "version": "2026.4.24"
+    "version": "2026.5.12"
   },
   "vaultwarden": {
-    "tag": "1.35.7"
+    "tag": "1.35.8"
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb:11.4.9
+    image: mariadb:11.4.10
     restart: unless-stopped
     command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
     volumes:
@@ -22,7 +22,7 @@ services:
       retries: 5
   
   redis:
-    image: redis:8.4.0-alpine
+    image: redis:8.4.3-alpine
     restart: unless-stopped
     volumes:
       - redis_data:/data
@@ -33,7 +33,7 @@ services:
       retries: 5
 
   nextcloud:
-    image: nextcloud:32.0.3-apache
+    image: nextcloud:32.0.9-apache
     restart: unless-stopped
     ports:
       - "${NEXTCLOUD_PORT:-8080}:80"
@@ -85,7 +85,7 @@ services:
     # it on the profile keeps port 8443 free and reduces attack surface.
     profiles:
       - vault-lan-https
-    image: caddy:2.10-alpine
+    image: caddy:2.11.3-alpine
     restart: unless-stopped
     ports:
       - "${VAULT_LOCAL_HTTPS_PORT:-8443}:8443"
@@ -113,7 +113,7 @@ services:
       retries: 5
 
   vaultwarden:
-    image: vaultwarden/server:${VAULTWARDEN_TAG:-1.35.7}
+    image: vaultwarden/server:${VAULTWARDEN_TAG:-1.35.8}
     restart: unless-stopped
     ports:
       - "127.0.0.1:${VAULT_PORT:-8082}:80"


### PR DESCRIPTION
## Why
Quarterly-ish dependency refresh across the stack. Conservative — patches within the same minor (or minor within same major) only, so breakage risk stays low. Skipped major-version steps for HA and Pangolin/newt — they need their own focused PRs.

## What changes

| Component  | Was            | Now             | Rationale |
|------------|----------------|-----------------|-----------|
| Nextcloud  | `32.0.3-apache`  | `32.0.9-apache`   | 6 stable patches within 32.0 |
| MariaDB    | `11.4.9`         | `11.4.10`         | single patch |
| Redis      | `8.4.0-alpine`   | `8.4.3-alpine`    | 3 patches same minor |
| Caddy      | `2.10-alpine`    | `2.11.3-alpine`   | minor; Caddy is famously back-compat |
| Vaultwarden| `1.35.7`         | `1.35.8`          | single patch (skipped `1.36.0` major) |
| llama.cpp  | `b8996`          | `b9174`           | ~180 release-numbers; near-daily cadence |
| OpenClaw   | `2026.4.24`      | `2026.5.12`       | silences the recurring "config written by newer (2026.5.6)" warning we've been seeing on every CLI invocation |
| whisper.cpp| `v1.8.4`         | `v1.8.4`          | already latest |

## Skipped intentionally
- **HomeAssistant 2025.12.5 → 2026.5.2**: 5 minor versions, breaking-change track. Needs its own PR with full integration audit.
- **fosrl/newt 1.8.1 → 1.12.5**: Pangolin protocol step; needs Pangolin server compat check first.
- **cloudflare/cloudflared 2025.11.1 → 2026.5.0**: not in current critical path (cloudflare-* profiles only).

## Test plan
- [x] `versions.json` valid JSON, compose file parses
- [ ] On `.58`: `git pull && systemctl restart homebrain-manager`, run dev-channel update to pull container tags; confirm all six containers come back healthy. Then trigger `setup_ai` for llama.cpp + OpenClaw and verify the gateway picks up `2026.5.12` cleanly + the config-drift warning is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)