### PR TITLE
fix(openclaw): adapt to 2026.5 config schema + external channel plugins

### DIFF
--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -46,9 +46,6 @@
       "models": {
         "llamacpp/Qwen3.6-35B-A3B-UD-Q5_K_XL": {}
       },
-      "llm": {
-        "idleTimeoutSeconds": 0
-      },
       "workspace": "/home/homebrain/.openclaw/workspace",
       "compaction": {
         "mode": "safeguard"

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1071,7 +1071,11 @@ patch_openclaw_config() {
         .models.providers.llamacpp.models[0].id = $id |
         .models.providers.llamacpp.models[0].name = $id |
         .models.providers.llamacpp.models[0].contextWindow = $ctx |
-        .agents.defaults.llm.idleTimeoutSeconds = 0 |
+        # OpenClaw 2026.5+ removed agents.defaults.llm; idle-timeout is
+        # configured per-provider via models.providers.<id>.timeoutSeconds
+        # (0 = no idle timeout — which is what we want for a local model
+        # that should stay warm).
+        .models.providers.llamacpp.timeoutSeconds = 0 |
         .agents.defaults.model.primary = ("llamacpp/" + $id) |
         .agents.defaults.models = {("llamacpp/" + $id): {}} |
         .browser.executablePath = "/usr/bin/google-chrome-stable" |
@@ -1228,6 +1232,23 @@ setup_openclaw() {
                 die "OpenClaw npm install failed and no existing openclaw binary found."
             fi
         fi
+    fi
+
+    # --- [1b/3] Install external channel plugins ---
+    # OpenClaw 2026.5+ moved several channel plugins (matrix,
+    # nextcloud-talk, …) out of the core bundle. The dashboard's seed
+    # declares them in plugins.entries so they appear in the control UI
+    # for credential entry; without the plugin code installed, the
+    # gateway emits "plugin not installed" warnings and the channel
+    # cannot connect. Install them via the OpenClaw plugin registry.
+    # Idempotent — `plugins install` is a no-op when the plugin is
+    # already present.
+    if command -v openclaw >/dev/null 2>&1; then
+        for plugin in 'clawhub:@openclaw/matrix' '@openclaw/nextcloud-talk'; do
+            log_info "Ensuring OpenClaw plugin: ${plugin}"
+            run_as_admin timeout 60 openclaw plugins install "$plugin" 2>&1 \
+                | grep -vE '^$' | head -10 || log_warn "plugins install ${plugin} reported issues (non-fatal)"
+        done
     fi
 
     # --- [2/3] Write config ---


### PR DESCRIPTION
## Why
PR #37 bumped OpenClaw `2026.4.24 → 2026.5.12`. Two schema changes break our seed:

### 1. `agents.defaults.llm` is gone
The new path for idle timeout is `models.providers.<id>.timeoutSeconds`. After the bump, `openclaw mcp list` fails validation on a config that still has the legacy key, with a user-facing hint to run `openclaw doctor --fix`.

### 2. Matrix + Nextcloud Talk are now external plugins
PR #29 seeded `plugins.entries.{matrix,nextcloud-talk}` so they appear in the OpenClaw control UI for credential entry. In 2026.5 those plugins were unbundled — they now ship from clawhub. Without an explicit `openclaw plugins install`, the gateway warns "plugin not installed" on every restart and the channels can never connect.

## What changes
- Remove `agents.defaults.llm` from `config/openclaw.json` and from `patch_openclaw_config()` in utilities.sh.
- Add the modern equivalent `models.providers.llamacpp.timeoutSeconds = 0` (same intent — no idle timeout — keep the local model warm).
- In `setup_openclaw` after npm-install of openclaw, run `openclaw plugins install` for `clawhub:@openclaw/matrix` and `@openclaw/nextcloud-talk`. The command is idempotent — no-op when the plugin is already present.

## Test plan
- [x] JSON valid, bash syntax clean
- [ ] On `.58` post-merge: `setup_ai` runs cleanly, `openclaw mcp list` no longer warns about legacy key or missing plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)