### PR TITLE
fix(openclaw): drop models.providers.llamacpp.timeoutSeconds=0 patch

### DIFF
--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -46,9 +46,6 @@
       "models": {
         "llamacpp/Qwen3.6-35B-A3B-UD-Q5_K_XL": {}
       },
-      "llm": {
-        "idleTimeoutSeconds": 0
-      },
       "workspace": "/home/homebrain/.openclaw/workspace",
       "compaction": {
         "mode": "safeguard"

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1071,7 +1071,11 @@ patch_openclaw_config() {
         .models.providers.llamacpp.models[0].id = $id |
         .models.providers.llamacpp.models[0].name = $id |
         .models.providers.llamacpp.models[0].contextWindow = $ctx |
-        .agents.defaults.llm.idleTimeoutSeconds = 0 |
+        # OpenClaw 2026.5+ removed agents.defaults.llm. The new
+        # models.providers.<id>.timeoutSeconds field is a per-request
+        # timeout (min 1) — not the keep-model-warm knob the legacy
+        # idleTimeoutSeconds was. Leave it unset so the schema default
+        # applies; fine for our local single-provider setup.
         .agents.defaults.model.primary = ("llamacpp/" + $id) |
         .agents.defaults.models = {("llamacpp/" + $id): {}} |
         .browser.executablePath = "/usr/bin/google-chrome-stable" |
@@ -1228,6 +1232,23 @@ setup_openclaw() {
                 die "OpenClaw npm install failed and no existing openclaw binary found."
             fi
         fi
+    fi
+
+    # --- [1b/3] Install external channel plugins ---
+    # OpenClaw 2026.5+ moved several channel plugins (matrix,
+    # nextcloud-talk, …) out of the core bundle. The dashboard's seed
+    # declares them in plugins.entries so they appear in the control UI
+    # for credential entry; without the plugin code installed, the
+    # gateway emits "plugin not installed" warnings and the channel
+    # cannot connect. Install them via the OpenClaw plugin registry.
+    # Idempotent — `plugins install` is a no-op when the plugin is
+    # already present.
+    if command -v openclaw >/dev/null 2>&1; then
+        for plugin in 'clawhub:@openclaw/matrix' '@openclaw/nextcloud-talk'; do
+            log_info "Ensuring OpenClaw plugin: ${plugin}"
+            run_as_admin timeout 60 openclaw plugins install "$plugin" 2>&1 \
+                | grep -vE '^$' | head -10 || log_warn "plugins install ${plugin} reported issues (non-fatal)"
+        done
     fi
 
     # --- [2/3] Write config ---


### PR DESCRIPTION
## Why
PR #38 set `models.providers.llamacpp.timeoutSeconds = 0` as the supposed "modern equivalent" of the legacy `agents.defaults.llm.idleTimeoutSeconds = 0`. The schema rejects `0`:

```
models.providers.llamacpp.timeoutSeconds: Too small: expected number to be >0
```

And the semantics differ anyway — the new field is a per-request HTTP timeout, not the keep-model-warm knob the legacy field provided.

Just don't set the field. The schema default is sensible for a local single-provider setup, and there's nothing about our use case that needs a custom request timeout.

(Comment rewritten without an apostrophe — single-quoted jq heredoc rule from PR #30.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)