### PR TITLE
fix(openclaw): jq pipeline form for del() inside patch_openclaw_config

### DIFF
--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1077,8 +1077,7 @@ patch_openclaw_config() {
         # the legacy field was. Leave it unset so the schema default
         # applies; also delete any stale 0 that an earlier release
         # may have written (the value is rejected by the schema).
-        | del(.models.providers.llamacpp.timeoutSeconds)
-        |
+        del(.models.providers.llamacpp.timeoutSeconds) |
         .agents.defaults.model.primary = ("llamacpp/" + $id) |
         .agents.defaults.models = {("llamacpp/" + $id): {}} |
         .browser.executablePath = "/usr/bin/google-chrome-stable" |


### PR DESCRIPTION
Trivial follow-up to #40: jq's del() was on a line that started with '|' which it doesn't parse. Inline it.