### PR TITLE
feat(backup): carry HOMEBRAIN_EMAIL_KEY across cross-instance restore

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -134,6 +134,41 @@ ARCHIVE_PATH="$BACKUP_MOUNTDIR/homebrain_backup${SUFFIX}_${DATE}.tar.gz"
 
 mkdir -p "$STAGING_DIR/nc_data" "$STAGING_DIR/nc_apps" "$STAGING_DIR/nc_db" "$STAGING_DIR/nc_config" "$STAGING_DIR/ha_config"
 
+# ── Portable instance secrets ───────────────────────────────────────────────
+# These .env entries are NOT per-install identity (MASTER_PASSWORD,
+# VAULT_ADMIN_TOKEN/NONCE, NEWT_* etc. stay with the box). They are
+# derivation keys whose value the user-facing data is bound to:
+#
+#   HOMEBRAIN_EMAIL_KEY    Fernet key used to encrypt every multi-account
+#                          token at rest (email, HA, NC). Restoring the
+#                          *_accounts.json files without this key onto a
+#                          fresh instance would leave the user with
+#                          undecryptable garbage — they'd have to re-enter
+#                          every IMAP password and re-issue every HA LLAT.
+#                          The key itself derives from MASTER_PASSWORD via
+#                          PBKDF2, but since each install has a different
+#                          master pw, the cross-install Fernet key MUST be
+#                          carried with the encrypted blobs.
+#
+#   HOMEBRAIN_SELF_NONCE   Per-install nonce for the self-MCP bearer token
+#                          derivation. Restoring it keeps the bearer stable
+#                          across the migration (no functional impact
+#                          either way — the dashboard re-derives on start
+#                          — but quieter logs).
+#
+# Format: shell-sourceable, NOT a complete .env (we strip everything else).
+INSTANCE_SECRETS_FILE="$STAGING_DIR/instance_secrets.env"
+{
+    [[ -n "${HOMEBRAIN_EMAIL_KEY:-}" ]] && echo "HOMEBRAIN_EMAIL_KEY=${HOMEBRAIN_EMAIL_KEY}"
+    [[ -n "${HOMEBRAIN_SELF_NONCE:-}" ]] && echo "HOMEBRAIN_SELF_NONCE=${HOMEBRAIN_SELF_NONCE}"
+} > "$INSTANCE_SECRETS_FILE"
+if [[ -s "$INSTANCE_SECRETS_FILE" ]]; then
+    chmod 600 "$INSTANCE_SECRETS_FILE"
+    log_info "Portable instance secrets captured for cross-instance restore."
+else
+    rm -f "$INSTANCE_SECRETS_FILE"
+fi
+
 # 5. Stop Services / Enable Maintenance Mode
 log_info "Preparing services..."
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -61,6 +61,32 @@ fi
 log_info "Extracting backup to temporary location $TMP_DIR..."
 tar -xzf "$BACKUP_FILE" -C "$TMP_DIR"
 
+# ── Portable instance-secret merge ──────────────────────────────────────────
+# Pull HOMEBRAIN_EMAIL_KEY / HOMEBRAIN_SELF_NONCE from the archive (if
+# present) into the destination .env BEFORE we start any containers or
+# restore the openclaw_integrations directory. Without this step, the
+# *_accounts.json files (multi-account email / HA / NC) are encrypted
+# with the source instance's Fernet key and the destination would derive
+# a different one from its own MASTER_PASSWORD — leaving the user with
+# undecryptable account tokens. See backup.sh for the rationale.
+if [[ -f "${TMP_DIR}/instance_secrets.env" ]]; then
+    log_info "Merging portable instance secrets from backup..."
+    while IFS='=' read -r key value; do
+        [[ -z "$key" || "$key" == \#* ]] && continue
+        # Strip any surrounding quotes the value may have picked up.
+        value="${value%\"}"; value="${value#\"}"
+        value="${value%\'}"; value="${value#\'}"
+        if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
+            # Replace existing. Use | delimiter to avoid clashing with the
+            # base64 / urlsafe characters in Fernet keys.
+            sed -i "s|^${key}=.*|${key}=${value}|" "$ENV_FILE"
+        else
+            echo "${key}=${value}" >> "$ENV_FILE"
+        fi
+        log_info "  imported ${key}"
+    done < "${TMP_DIR}/instance_secrets.env"
+fi
+
 # --- Smart Detection ---
 log_info "Analyzing backup structure..."
 


### PR DESCRIPTION
## Why
Cross-instance restore (HomeCloud RPi5 backup → HomeBrain x86 install) needs to preserve the Fernet key used to encrypt multi-account secrets at rest. Each install has its own MASTER_PASSWORD → its own derived key, so restoring the encrypted `*_accounts.json` files onto a fresh box leaves the user with undecryptable garbage. They'd have to re-enter every IMAP password and re-issue every HA LLAT just because the box changed.

Triggered by the user's imminent migration from their RPi5 HomeCloud to the new `berlin.homebrain.house` AI HomeBrain.

## What carries, what doesn't

**Carried** (in a small `instance_secrets.env` staged into the archive):
- `HOMEBRAIN_EMAIL_KEY` — Fernet key for email/HA/NC account tokens. **Critical.**
- `HOMEBRAIN_SELF_NONCE` — per-install nonce for the self-MCP bearer derivation. **Nice-to-have** (dashboard re-derives anyway, but quieter logs).

**Not carried** (per-install identity stays with the box):
- `MASTER_PASSWORD`, `MANAGER_PASSWORD`
- `NEWT_ID`, `NEWT_SECRET`, `PANGOLIN_*`
- `VAULT_ADMIN_TOKEN`, `VAULT_ADMIN_NONCE` (Vault container reads them from .env; the fresh provision's values are what the live container loads — no migration needed since the admin token is not stored in vault DB)
- `MYSQL_*`, `HA_ADMIN_*` (restore reconciles these from restored NC config.php)

## Implementation
- `backup.sh`: dump those two keys into `${STAGING_DIR}/instance_secrets.env`. Mode 0600.
- `restore.sh`: parse and merge into the destination `.env` BEFORE any container or downstream restore step runs. Replace existing values (covers the case where `_email_fernet_key()` lazily generated one on the destination during the fresh provision).

## Test plan
- [x] `bash -n` clean
- [ ] On `.58` post-deploy: a cross-instance restore drill (could be a same-instance backup re-applied) keeps the encrypted *_accounts.json decryptable. Will be validated implicitly by the user's actual migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)