### PR TITLE
fix(env.template): drop stale VAULTWARDEN_TAG=1.35.7 pin

### DIFF
--- a/config/.env.template
+++ b/config/.env.template
@@ -42,7 +42,10 @@ CF_TOKEN_HA=
 # --- HomeBrain Vault (Vaultwarden) ---
 # VAULT_ENABLED toggles the service on/off. Set to false to skip vault startup.
 VAULT_ENABLED=true
-VAULTWARDEN_TAG=1.35.7
+# VAULTWARDEN_TAG intentionally omitted — docker-compose.yml's
+# ${VAULTWARDEN_TAG:-<default>} expansion is the single source of truth.
+# update.sh writes a pin here only when a version bump in versions.json
+# disagrees with the running image.
 VAULT_PORT=8082
 # Caddy LAN HTTPS edge — only used in local-mode (Bitwarden mobile/desktop
 # clients refuse plain HTTP, so we terminate TLS with an internal CA).


### PR DESCRIPTION
PR #37's bump didn't propagate to .env.template — fresh provisions copy the stale 1.35.7 pin into .env and override compose's :1.35.8 default. Caught on the production deploy. Remove the line; compose default is the single source of truth.