### PR TITLE
fix(manager): include /sbin and /usr/sbin in systemd PATH

### DIFF
--- a/config/homebrain-manager.service
+++ b/config/homebrain-manager.service
@@ -7,7 +7,11 @@ StartLimitBurst=5
 [Service]
 User=root
 WorkingDirectory=/opt/homebrain/src
-Environment="PATH=/usr/local/bin:/usr/bin:/bin"
+# Include /sbin and /usr/sbin so the manager's subprocess calls find
+# admin tools that live there (blkid, mount, mkfs.*, parted, ip, etc.).
+# Debian/Ubuntu root historically gets this PATH; systemd starts services
+# with a stripped one unless we set it explicitly.
+Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/sbin:/usr/bin:/bin"
 ExecStart=/opt/homebrain/venv/bin/gunicorn --workers 3 --bind 0.0.0.0:80 --timeout 30 app:app
 Restart=always
 RestartSec=10


### PR DESCRIPTION
Manager unit shipped without /sbin in PATH → blkid (which lives in /sbin) wasn't found → dashboard drive-mount returned 'Could not read drive info (blkid failed)' on the user's RPi5 production today. Add the sbin dirs back; also fixes any other admin-tool subprocess shellouts.