### PR TITLE
feat(ai): enable MTP speculative decoding for 27B (+48% TG)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -148,3 +148,55 @@ All 35B-A3B entries in `platform_models.json` carry `--presence-penalty 1.5 --re
 - Architecture: 40 layers, 256 experts (8 active per token), n_embd=2048, n_head=16, n_head_kv=2.
 - KV cache at 131K ctx with q8_0: ~1.4 GB on GPU.
 - Q5 quants stay under VRAM limit at -ot 20-39; Q6_K needs 18-39 to leave ~700 MB headroom for compute buffers; Q8_K_XL needs 14-39 (26 of 40 layers on CPU) and is CPU-bound.
+
+## Multi-Token Prediction (MTP) sweep — b9186 (2026-05-17)
+
+llama.cpp [PR #22673](https://github.com/ggml-org/llama.cpp/pull/22673) (merged 2026-05-16) adds a `draft-mtp` speculative-decoding path that uses a small auxiliary head shipped inside MTP-flavored GGUFs (`unsloth/Qwen3.6-{27B,35B-A3B}-MTP-GGUF`). The unsloth release claims 1.4–2× generation speedup on dense models and 1.15–1.25× on MoE.
+
+Hardware: RX 9060 XT + Ryzen 5 5600, Vulkan + RADV_PERFTEST=rm_kq=1, llama.cpp b9186, docker stack running (prod-realistic), 3 deterministic 512-token runs per cell.
+
+### 27B (dense DeltaNet hybrid) — large win
+
+| `--spec-draft-n-max` | TG t/s | Acceptance | Δ vs baseline |
+|---|---:|---:|---:|
+| baseline (no MTP) | 17.24 | — | — |
+| **n=2** | **25.55** | 61.9% | **+48.2%** |
+| n=3 | 25.14 | 53.4% | +45.9% |
+| n=4 | 23.23 | 45.3% | +34.7% |
+| n=6 | 10.56 | 34.2% | −38.7% |
+
+Three interleaved baselines (17.21 / 17.25 / 17.26) and two n=3 reruns (both 25.14) confirm stability. Adopted **n_max=2** in `platform_models.json`.
+
+### 35B-A3B (MoE) — MTP is net negative in every config
+
+Cross-product of quant × CPU-expert-offload depth × KV cache, with and without MTP n=2. Each row is the mean of 3 runs; baselines were re-measured between MTP runs to control for thermal drift.
+
+| Quant | KV | `-ot` pattern | Baseline | MTP n=2 | MTP Δ |
+|---|---|---|---:|---:|---:|
+| **Q4_K_M** | q8 | blk.23-39 (prod, 17 layers offl.) | **33.68** | 32.53 | −3.4% |
+| Q4_K_M | q8 | blk.20-39 (20 layers) | 31.86 | 31.61 | −0.8% |
+| Q4_K_M | q4 | blk.23-39 | 29.26 | 31.65 | +8.2% |
+| Q4_K_M | q4 | blk.20-39 | 31.81 | 30.43 | −4.3% |
+| Q4_K_M | q4 | blk.18-39 (22 layers) | 30.70 | 29.46 | −4.0% |
+| Q4_K_M | q4 | blk.15-39 (25 layers) | 28.98 | 29.27 | +1.0% |
+| **Q5_K_XL** | q8 | blk.20-39 (prod) | 28.40 | 27.45 | −3.3% |
+| Q5_K_XL | q8 | blk.20-39, n=3 | 28.41 | 25.69 | −9.6% |
+| Q5_K_XL | q4 | blk.20-39 | 28.69 | 27.96 | −2.5% |
+| Q5_K_XL | q4 | blk.25-39 | 22.05 | 20.83 | −5.5% |
+| Q5_K_XL | q4 | blk.28-39 | 16.12 | 17.23 | +6.9%¹ |
+| Q5_K_XL | q4 | blk.30-39 | 16.55 | 18.17 | +9.8%¹ |
+| Q5_K_M | q4 | blk.25-39 | 24.44 | 21.31 | −12.8% |
+| Q5_K_M | q4 | blk.20-39 | 29.03 | 26.83 | −7.6% |
+
+¹ MTP relative win exists only where baseline is already crippled by VRAM-ceiling thrash (`-ot` keeps more weight on GPU than fits). Absolute TG is still worse than the unconstrained config.
+
+**Findings**
+- The current production config (Q4_K_M + q8 KV + `-ot blk.23-39`) at **33.68 t/s** is the absolute speed champion. MTP hurts it by 3.4%.
+- The dense-vs-MoE gap matches unsloth's prediction *direction* (large on dense, small on MoE) but our MoE result is below their 1.15× floor. Hypothesis: heavy `-ot ffn_.*exps=CPU` defeats MTP's parallel verification — the CPU expert step is serial regardless of how many tokens you draft, so the speculative path adds draft cost without amortizing the verify cost. Their numbers likely assume all weights on GPU.
+- `--spec-draft-p-split` and `--spec-draft-n-min` are no-ops for `draft-mtp` — verified by identical accept counts across all values. The flags only apply to `draft-simple` / `draft-eagle3`.
+- Q5_K_M is dominated by Q4_K_M at the same offload + KV across the board; not worth shipping.
+
+**Decisions**
+- 27B IQ4_XS: switch to MTP-GGUF + `--spec-type draft-mtp --spec-draft-n-max 2`. Stored as Phase-4 in `platform_models.json`.
+- 35B-A3B (all quants): **do not enable MTP.** Keep current configs.
+- llama.cpp tag bumped to b9186 in `versions.json` (first tagged release with the merged PR).

--- a/config/platform_models.json
+++ b/config/platform_models.json
@@ -89,15 +89,15 @@
     {
       "id": "Qwen3.6-27B-IQ4_XS",
       "filename": "Qwen3.6-27B-IQ4_XS.gguf",
-      "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/resolve/main/Qwen3.6-27B-IQ4_XS.gguf",
-      "min_size_bytes": 14000000000,
+      "url": "https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF/resolve/main/Qwen3.6-27B-IQ4_XS.gguf",
+      "min_size_bytes": 15000000000,
       "context_window": 49152,
-      "extra_flags": "-ngl 99 --parallel 1 --jinja -fa on --cache-type-k q4_0 --cache-type-v q4_0 -t 6 -b 4096 -ub 2048 --temp 1.0 --top-k 20 --top-p 0.95 --min-p 0 --chat-template-kwargs '{\"preserve_thinking\": true}'",
+      "extra_flags": "-ngl 99 --parallel 1 --jinja -fa on --cache-type-k q4_0 --cache-type-v q4_0 -t 6 -b 4096 -ub 2048 --temp 1.0 --top-k 20 --top-p 0.95 --min-p 0 --spec-type draft-mtp --spec-draft-n-max 2 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
-        "tg128_ts": 17.17,
+        "tg128_ts": 25.55,
         "pp512_ts": 435,
-        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, DDR4, Vulkan + RADV_PERFTEST=rm_kq=1, llama.cpp b8996, ngl=99",
-        "notes": "Hybrid DeltaNet SSM+attn (16/64 standard attn layers, 48 DeltaNet). RS must stay GPU-local — nkvo breaks DeltaNet fused kernel (garbage output). ngl<99 drops to ~2 t/s; partial offload defeats DeltaNet GPU fusion. ctv/ctk with fa is mandatory on AMD Vulkan. Phase-2 finding: TG was VRAM-bound at ctx=65536 (16.24 GB / 99.6%), not kernel-bound. Phase-3 ctx sweep with q4_0 KV: 32K/40K/48K all hold peak TG ~17.17 t/s (15.6/15.8/16.0 GB); 56K starts throttling at 16.22 GB (-2.4%); 64K is the -13% cliff. Chosen config keeps q4_0 KV (same as before, less precise attention but 50% more usable context than q8_0 at the same VRAM ceiling) and bumps ctx to 48K. Net: TG +15.4% vs old prod (14.89 -> 17.17), context 65K -> 48K (-26%)."
+        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, DDR4, Vulkan + RADV_PERFTEST=rm_kq=1, llama.cpp b9186, ngl=99, MTP n_max=2",
+        "notes": "Hybrid DeltaNet SSM+attn (16/64 standard attn layers, 48 DeltaNet). RS must stay GPU-local — nkvo breaks DeltaNet fused kernel (garbage output). ngl<99 drops to ~2 t/s; partial offload defeats DeltaNet GPU fusion. ctv/ctk with fa is mandatory on AMD Vulkan. Phase-3 ctx sweep with q4_0 KV: 32K/40K/48K all hold peak TG ~17.17 t/s; 56K throttles (-2.4%); 64K is the -13% cliff. Phase-4 MTP (b9186 PR #22673, unsloth MTP-GGUF with draft head): n_max=2 lifts TG from 17.24 to 25.55 t/s (+48.2%) with 61.9% draft acceptance, all three interleaved baselines stable at 17.21-17.26. n_max=3 ~25.14 (+45.9%); n_max=4 23.23 (+34.7%); n_max=6 collapses to 10.56 (-39%). --spec-draft-p-split and --spec-draft-n-min are no-ops for draft-mtp (verified)."
       },
       "default": false
     }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "llama_cpp": {
-    "tag": "b9174",
-    "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9174/llama-b9174-bin-ubuntu-vulkan-x64.tar.gz"
+    "tag": "b9186",
+    "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9186/llama-b9186-bin-ubuntu-vulkan-x64.tar.gz"
   },
   "whisper_cpp": {
     "git_ref": "v1.8.4"


### PR DESCRIPTION
## Summary

- Bumps llama.cpp **b8996 → b9186** to pick up [PR #22673 (multi-token prediction)](https://github.com/ggml-org/llama.cpp/pull/22673).
- **27B IQ4_XS (dense): +48.2% TG** with MTP `n_max=2` — 17.24 → **25.55 t/s** (61.9% draft acceptance). Three interleaved baselines (17.21 / 17.25 / 17.26) confirm stability.
- **35B-A3B (MoE): no change.** MTP is net negative in every config we tested (best result is −3.4% vs the current prod 33.68 t/s). Documented so future contributors don't repeat the sweep.

## Sweep matrix (35B-A3B)

| Quant | KV | offload | Baseline | MTP n=2 | Δ |
|---|---|---|---:|---:|---:|
| **Q4_K_M (prod)** | q8 | blk.23-39 | **33.68** | 32.53 | −3.4% |
| Q4_K_M | q4 | blk.23-39 | 29.26 | 31.65 | +8.2% (still below prod) |
| Q5_K_XL (default) | q8 | blk.20-39 | 28.40 | 27.45 | −3.3% |
| Q5_K_M | q4 | blk.20-39 | 29.03 | 26.83 | −7.6% |

Why MTP loses on our MoE: `-ot ffn_.*exps=CPU` forces every token's expert step through CPU regardless of how many tokens you draft, so MTP adds draft cost without amortizing the verify cost. Unsloth's 1.15–1.25× claim for MoE likely assumes all-weights-on-GPU which doesn't fit our 16 GB VRAM.

Other findings (in BENCHMARKS.md):
- `--spec-draft-p-split` and `--spec-draft-n-min` are no-ops for `draft-mtp` — verified by identical accept counts.
- 27B `n_max ∈ {3, 4, 6}` get progressively worse (n=6 collapses to 10.56 t/s, −38.7%).

## Test plan

- [x] llama-server on .58 rebuilt at master tip, verified `--spec-type draft-mtp` flag exists
- [x] MTP-GGUFs downloaded for 27B IQ4_XS + 35B-A3B Q5_K_XL / Q4_K_M / Q5_K_M
- [x] 3 deterministic runs per config, interleaved baselines for thermal control
- [x] Docker stack running during the final sweep (prod-realistic)
- [ ] Production .58 update via dashboard once merged: `versions.json` bump triggers llama-server reinstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)