### PR TITLE
fix(openclaw): ensure baseUrl + gateway.mode survive config migration

### DIFF
--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1102,6 +1102,14 @@ patch_openclaw_config() {
 
     jq --arg id "$model_id" --argjson ctx "${ctx_size:-131072}" --argjson origins "$origins" \
         "${jq_extra_args[@]}" '
+        # OpenClaw 2026.5+ schema makes both required and refuses to start
+        # without them ("missing baseUrl" / "missing gateway.mode" → exit 78).
+        # Existing configs migrated from older releases lacked these keys, so
+        # we always (re)assert them. local mode is correct for the bundled
+        # llama-server on 127.0.0.1; remote-access tunnelling is handled by
+        # Pangolin/Caddy in front of the gateway, not by OpenClaw itself.
+        .models.providers.llamacpp.baseUrl = "http://127.0.0.1:8001/v1" |
+        .gateway.mode = (.gateway.mode // "local") |
         .models.providers.llamacpp.models[0].id = $id |
         .models.providers.llamacpp.models[0].name = $id |
         .models.providers.llamacpp.models[0].contextWindow = $ctx |


### PR DESCRIPTION
## Summary
- \`patch_openclaw_config\` now always asserts \`models.providers.llamacpp.baseUrl = "http://127.0.0.1:8001/v1"\` and \`gateway.mode\` (default \`"local"\`, preserved if already set).

## Why
OpenClaw 2026.5+ refuses to start (\`status=78/CONFIG\`) when either key is missing. Configs migrated from older releases never picked them up — we only seed the template on first install; otherwise we patch in place, and the patch never wrote these keys.

Repro path: production target (.58), AI install/start after system upgrade.
\`\`\`
[ERROR] daemon start failed. Try: sudo -u homebrain openclaw daemon install --force
\`\`\`
\`openclaw daemon install --force\` then surfaced:
\`\`\`
- models.providers.llamacpp.baseUrl: Invalid input: expected string, received undefined
\`\`\`
Patching that revealed the second:
\`\`\`
Gateway start blocked: existing config is missing gateway.mode.
\`\`\`
With both keys patched in, the gateway started cleanly (\`[gateway] ready\`).

## Test plan
- [ ] On a host with a pre-2026.5 \`openclaw.json\` lacking either key: \`sudo bash scripts/utilities.sh setup_ai\` results in a healthy \`openclaw-gateway\` user service and \`is-active=active\`.
- [ ] Fresh install (seed copy path): values from the seed template are preserved (no clobber of a non-default \`gateway.mode\`).

Follow-up to #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)