### PR TITLE
feat(dashboard): add local/external split for Home Assistant MCP

### DIFF
--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -824,6 +824,7 @@
                         <button class="btn-primary" onclick="connHaAdd()">Add</button>
                         <button onclick="closeForm('details-ha')" aria-label="Close">✕</button>
                     </div>
+                    <small id="ha-local-hint" style="display:none; margin-top:6px; color:var(--accent);"></small>
                     <small style="display:block; margin-top:6px; color:var(--text-dim);">
                         In each Home Assistant instance: Profile → Security → Long-lived access tokens → Create. Add one row per house. The agent picks the right one with the <code>account</code> parameter.
                     </small>
@@ -1316,6 +1317,8 @@
             if (!el) return;
             if (el.tagName === 'DETAILS') el.open = false;
             else el.hidden = true;
+            const hint = document.getElementById('ha-local-hint');
+            if (id === 'details-ha' && hint) hint.style.display = 'none';
         }
         const CONN_LABELS = {
             self:          { name: 'Self-tools',     sub: 'Backups, status, restart' },
@@ -1388,8 +1391,12 @@
                         buttons.push(`<button class="${cta}" onclick="openDetails('details-nc','nc-name')">Add external NC…</button>`);
                     }
                     if (it.key === 'homeassistant') {
-                        const cls = (it.accounts || []).length > 0 ? '' : 'btn-primary';
-                        buttons.push(`<button class="${cls}" onclick="openDetails('details-ha','ha-name')">Add account…</button>`);
+                        const hasLocal = (it.accounts || []).some(a => a.name === 'home');
+                        if (!hasLocal) {
+                            buttons.push(`<button onclick="connHaAddLocal()" title="Pre-fill with the HomeBrain-shipped Home Assistant; you only paste the token">Add HomeBrain HA</button>`);
+                        }
+                        const cta = (it.accounts || []).length > 0 ? '' : 'btn-primary button';
+                        buttons.push(`<button class="${cta}" onclick="openDetails('details-ha','ha-name')">Add external HA…</button>`);
                     }
                     if (it.key === 'email') {
                         const haveAccount = (it.accounts || []).length > 0;
@@ -1512,6 +1519,21 @@
                 closeForm('details-nc');
             }
             connRefresh();
+        }
+
+        function connHaAddLocal() {
+            // No backend equivalent of NC's occ user:add-app-password — HA tokens
+            // are user-scoped and require the HA UI. Best we can do is pre-fill the
+            // form so the user only pastes the token.
+            document.getElementById('ha-name').value = 'home';
+            document.getElementById('ha-base-url').value = 'http://127.0.0.1:8123';
+            const hint = document.getElementById('ha-local-hint');
+            if (hint) {
+                const tokenUrl = `${window.location.protocol}//${window.location.hostname}:8123/profile/security`;
+                hint.innerHTML = `Open <a href="${tokenUrl}" target="_blank" rel="noopener">Home Assistant → Profile → Security</a>, create a long-lived access token, and paste it below.`;
+                hint.style.display = 'block';
+            }
+            openDetails('details-ha', 'ha-token-input');
         }
 
         async function connNcAddLocal() {


### PR DESCRIPTION
## Summary

- MCP panel had inconsistent flows: Nextcloud got both **Add HomeBrain NC** (one-click) and **Add external NC…**, but Home Assistant only had a single **Add account…** that forced typing the local URL.
- Add an **Add HomeBrain HA** sibling button that pre-fills the form with the canonical local base URL (`http://127.0.0.1:8123`) and label `home`, focuses the token field, and surfaces a clickable hint linking to the running HA's token page (`/profile/security` on the same origin's :8123).
- Rename **Add account…** → **Add external HA…** to match the NC labeling and signal the split.
- HA can't go fully one-click like NC: long-lived access tokens are user-scoped and require the HA UI — there is no shell equivalent of `occ user:add-app-password`. This is the minimum-friction parity that's honest about that constraint (one paste instead of three).

## Test plan

- [ ] Open dashboard, navigate to Agent connections.
- [ ] **No HA account yet**: row shows both `Add HomeBrain HA` and `Add external HA…` (latter is primary CTA).
- [ ] Click `Add HomeBrain HA`: form opens with `name=home`, `base_url=http://127.0.0.1:8123`, token field focused, hint visible.
- [ ] Hint link opens `http://<dashboard-host>:8123/profile/security` in a new tab.
- [ ] Paste a long-lived token, click Add — account is created, button disappears on next refresh (already-have-local rule).
- [ ] Click `Add external HA…` for a second house — form opens empty, behaves as before.
- [ ] Close form — hint hides.
- [ ] No regression on NC two-button flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)