### PR TITLE
fix(integrations): wire self-MCP + vault-MCP on manager boot

### DIFF
--- a/src/integrations.py
+++ b/src/integrations.py
@@ -1137,6 +1137,52 @@ def register_integrations(app, limiter) -> None:  # noqa: C901
                      "integrations_audit_tail",
                      audit_tail, methods=["GET"])
 
+    # Post-provision self-heal: reconcile_all_mcp() was historically only
+    # triggered by the user clicking "Apply" in Connections, which left
+    # self-MCP + vault-MCP unwired on fresh installs and after upgrades that
+    # introduced new INTEGRATION_ORDER entries. Now we run it on app boot when
+    # the registry is missing the canonical self-MCP entry. Multi-worker safe
+    # via an exclusive flock on a tmpfs lockfile — at most one worker per host
+    # does the work, the rest no-op. Idempotent on subsequent boots once the
+    # self-MCP is wired.
+    threading.Thread(target=_startup_wire_if_needed, daemon=True).start()
+
+
+def _startup_wire_if_needed() -> None:
+    if not _has_openclaw():
+        return
+    try:
+        if _self_token() and _wired_in_openclaw(MCP_NAMES["self"]):
+            return
+    except Exception:
+        pass
+    import fcntl
+    lock_path = "/tmp/homebrain-startup-reconcile.lock"
+    try:
+        fd = open(lock_path, "w")
+    except OSError:
+        return
+    try:
+        try:
+            fcntl.flock(fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return
+        # Re-check inside the lock to avoid a redundant daemon restart if a
+        # sibling worker just finished.
+        if _self_token() and _wired_in_openclaw(MCP_NAMES["self"]):
+            return
+        logging.info("startup self-heal: wiring missing MCP servers")
+        try:
+            reconcile_all_mcp()
+        except Exception as e:
+            logging.warning("startup reconcile failed: %s", e)
+    finally:
+        try:
+            fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+        except Exception:
+            pass
+        fd.close()
+
 
 # ---------------------------------------------------------------------------
 # Smoke test against an MCP server (used by integration_test endpoints)


### PR DESCRIPTION
## Summary

- `reconcile_all_mcp()` was documented as "called at provision time" but no caller actually fires it — only the `/api/integrations/reconcile` endpoint (manual Apply click) runs it. New installs and any upgrade that adds entries to `INTEGRATION_ORDER` (vault, self) therefore leave those MCPs unwired.
- Discovered on the production target (.58): `homebrain-self` and `homebrain-vault` were missing from `openclaw mcp show` even though vaultwarden was running and the self-token derivation was viable. The agent couldn't use backups/status/restart tools, and vault tools, until someone happened to click Apply.
- Fix: post-route-registration, fire a daemon thread that checks whether the canonical self-MCP entry is wired; if not, take an exclusive flock and run `reconcile_all_mcp()` once. Idempotent on every subsequent boot.

## Multi-worker safety

Manager runs `gunicorn --worker-class gevent --workers 3` (PR #50). All three workers import `integrations.py` and spawn the startup thread. The flock at `/tmp/homebrain-startup-reconcile.lock` ensures exactly one of them does the work; the others see `BlockingIOError` and exit. A re-check inside the lock avoids triggering a redundant `openclaw daemon restart` when a sibling worker just finished.

## Test plan

- [ ] Stop manager, delete `~/.openclaw/homebrain.token`, run `openclaw mcp unset homebrain-self`, restart manager.
- [ ] Within ~10–15 s `~/.openclaw/homebrain.token` is recreated and `openclaw mcp show` lists `homebrain-self`.
- [ ] `/api/integrations/status` reports `self.configured=true, self.wired=true` without clicking Apply.
- [ ] Subsequent manager restarts do not trigger another openclaw daemon restart (re-check inside lock short-circuits).
- [ ] No regression on existing reconcile endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)