### PR TITLE
fix(openclaw): bind WS handler without stacking sock.route

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2167,19 +2167,23 @@ def openclaw_proxy(subpath=""):
     return Response(stream_with_context(generate()), status=upstream.status_code, headers=resp_headers)
 
 
-@sock.route("/openclaw")
-@sock.route("/openclaw/")
+# The Control UI's `new WebSocket(gatewayUrl)` call targets the basePath
+# root, not a subpath — without an exact-match route flask-sock never matches
+# and the bare `/openclaw` upgrade falls through to the HTTP proxy view → 400.
+# Register the handler under all three rules. NB: sock.route decorators do not
+# return the wrapped function, so they can't be stacked syntactically; call
+# them as plain functions to bind the same handler under each rule.
 def openclaw_ws_proxy_root(ws):
-    """The Control UI's `new WebSocket(gatewayUrl)` call targets the basePath
-    root, not a subpath — without these routes flask-sock never matches and
-    the bare `/openclaw` upgrade falls through to the HTTP proxy view → 400.
-    """
     return _openclaw_ws_handle(ws, "")
 
 
-@sock.route("/openclaw/<path:subpath>")
 def openclaw_ws_proxy(ws, subpath):
     return _openclaw_ws_handle(ws, subpath)
+
+
+sock.route("/openclaw")(openclaw_ws_proxy_root)
+sock.route("/openclaw/")(openclaw_ws_proxy_root)
+sock.route("/openclaw/<path:subpath>")(openclaw_ws_proxy)
 
 
 def _openclaw_ws_handle(ws, subpath):


### PR DESCRIPTION
## Summary

Follow-up to #53. The previous fix added bare `/openclaw` and `/openclaw/` routes by stacking `@sock.route` decorators on a single function. flask-sock's `route()` decorator registers the wrapped function with Flask and returns **None** — so the second `@sock.route` saw `None` as its target and the manager crashed with `TypeError: 'NoneType' object is not callable` inside `flask_sock/__init__.py:62` the moment a bare-path WS upgrade actually fired (101 followed by 500 on the same TCP connection, observed live on .58).

Bind the same handler under all three rules by calling `sock.route(...)` as a function instead.

## Test plan

- [ ] LAN: open dashboard → click "Open AI Assistant →". Page loads, no auth dialog, chat works.
- [ ] Manager log no longer shows `TypeError: 'NoneType' object is not callable` on /openclaw [GET].

🤖 Generated with [Claude Code](https://claude.com/claude-code)