### PR TITLE
fix(openclaw): unique endpoint names for WS routes

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2181,9 +2181,9 @@ def openclaw_ws_proxy(ws, subpath):
     return _openclaw_ws_handle(ws, subpath)
 
 
-sock.route("/openclaw")(openclaw_ws_proxy_root)
-sock.route("/openclaw/")(openclaw_ws_proxy_root)
-sock.route("/openclaw/<path:subpath>")(openclaw_ws_proxy)
+sock.route("/openclaw", endpoint="openclaw_ws_root")(openclaw_ws_proxy_root)
+sock.route("/openclaw/", endpoint="openclaw_ws_root_slash")(openclaw_ws_proxy_root)
+sock.route("/openclaw/<path:subpath>", endpoint="openclaw_ws_sub")(openclaw_ws_proxy)
 
 
 def _openclaw_ws_handle(ws, subpath):


### PR DESCRIPTION
## Summary

Follow-up to #54. Binding `openclaw_ws_proxy_root` under both `/openclaw` and `/openclaw/` failed at module import because Flask's `add_url_rule` rejects duplicate endpoint names (and flask-sock derives the endpoint from the function name unless overridden):

```
AssertionError: View function mapping is overwriting an existing endpoint function: openclaw_ws_proxy_root
```

On .58 the manager's auto-restart loop blew past the burst limit and the unit settled in `failed` state, requiring sudo intervention to recover. Pass an explicit `endpoint=` to each `sock.route(...)` so the rules are distinct.

## Recovery on .58

Manager API is offline, so this PR can't deploy itself. Once merged, run on the box:

```
sudo systemctl reset-failed homebrain-manager.service
sudo bash /opt/homebrain/scripts/update.sh dev main
```

The second command pulls the new main, restarts the service, and brings the manager back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)