### PR TITLE
fix(openclaw): include LAN/mDNS/Pangolin in controlUi allowedOrigins

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -125,6 +125,33 @@ if command -v jq >/dev/null 2>&1 && [[ -f "$INSTALL_DIR/config/versions.json" ]]
         if [[ -n "$new_openclaw_ver" && "$old_openclaw_ver" != "$new_openclaw_ver" ]]; then
             log_info "OpenClaw: ${old_openclaw_ver} → ${new_openclaw_ver}. Updating..."
             bash "$UPDATE_DEPS_SCRIPT" openclaw || log_warn "OpenClaw update failed — check logs."
+        else
+            # Config drift catch-all: the openclaw npm package didn't change but the
+            # patch_openclaw_config jq pipeline in utilities.sh may have (new schema
+            # keys, refreshed allowedOrigins, etc.). Re-patch the existing
+            # openclaw.json and only bounce the daemon when the file actually
+            # changes — the npm install is skipped because the version matched.
+            if command -v openclaw >/dev/null 2>&1; then
+                CFG="${HOMEBRAIN_HOME:-/home/homebrain}/.openclaw/openclaw.json"
+                if [[ -f "$CFG" ]]; then
+                    log_info "Refreshing openclaw.json against current utilities.sh..."
+                    cp "$CFG" "${CFG}.preupdate"
+                    # shellcheck disable=SC1091
+                    source "$SCRIPT_DIR/utilities.sh"
+                    load_env 2>/dev/null || true
+                    load_versions 2>/dev/null || true
+                    if patch_openclaw_config "$CFG" "${AI_MODEL_ID:-}" "${OC_CTX_SIZE:-}"; then
+                        if ! cmp -s "${CFG}.preupdate" "$CFG"; then
+                            log_info "openclaw.json changed — restarting daemon to apply."
+                            run_as_admin systemctl --user restart openclaw-gateway >/dev/null 2>&1 \
+                                || log_warn "openclaw-gateway restart failed — check logs."
+                        else
+                            log_info "openclaw.json already matches expected shape — no daemon restart."
+                        fi
+                    fi
+                    rm -f "${CFG}.preupdate"
+                fi
+            fi
         fi
     fi
 fi

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1080,10 +1080,25 @@ patch_openclaw_config() {
         return 0
     fi
 
-    # Build allowed origins for cross-origin WebSocket from HomeBrain dashboard
+    # Build allowed origins the OpenClaw Control UI accepts. The SPA does a
+    # client-side check of `location.origin` against this list before it
+    # touches the gateway WS; the proxy-side Origin rewriting we do server-side
+    # doesn't help here because the check fires inside the user's browser.
+    # Cover every way the dashboard is reachable: loopback, LAN IP, mDNS
+    # name, and (when remote mode is provisioned) the Pangolin domain.
     local lan_ip
     lan_ip=$(hostname -I 2>/dev/null | awk '{print $1}')
-    local origins="[\"http://${lan_ip}\", \"http://${lan_ip}:80\", \"http://localhost\", \"http://127.0.0.1\"]"
+    local origins_jq='['
+    origins_jq+='"http://localhost","http://127.0.0.1",'
+    origins_jq+='"http://homebrain.local","http://homebrain.local:80",'
+    if [[ -n "${lan_ip:-}" ]]; then
+        origins_jq+="\"http://${lan_ip}\",\"http://${lan_ip}:80\","
+    fi
+    if [[ -n "${PANGOLIN_DOMAIN:-}" ]]; then
+        origins_jq+="\"https://${PANGOLIN_DOMAIN}\","
+    fi
+    origins_jq="${origins_jq%,}]"
+    local origins="$origins_jq"
 
     # Derive a stable gateway token from MASTER_PASSWORD so it survives redeployment
     local gw_token=""


### PR DESCRIPTION
## Summary

After PR #50–#55 the Control UI loads and the WS bridge upgrades cleanly, but the SPA now rejects the connection with:

> origin not allowed (open the Control UI from the gateway host or allow it in `gateway.controlUi.allowedOrigins`)

The SPA does a **client-side** origin check against the gateway's advertised allowedOrigins list. The manager's proxy-side Origin header rewriting (we already drop/replace it on the upstream leg) doesn't help here — the check fires inside the user's browser, against the *page's* origin, not against the proxied request.

Our `patch_openclaw_config` only wrote `http://${lan_ip}` + `http://${lan_ip}:80` + loopback. Anyone reaching the dashboard via `http://homebrain.local` (mDNS) or `https://berlin.homebrain.house` (Pangolin) hits the gate.

## Changes

1. `scripts/utilities.sh` `patch_openclaw_config()` — append `http://homebrain.local` (with and without `:80`) and `https://${PANGOLIN_DOMAIN}` (when remote mode is provisioned).
2. `scripts/update.sh` — re-run `patch_openclaw_config` after every rsync, not only on OpenClaw version bumps. The jq pipeline (and any future schema/origins additions) drifts with the manager codebase, so same-version updates need to refresh the live config. Restart the gateway daemon only when the patched file actually differs.

## Test plan

After the next `/api/manager/update`:

- [ ] Inspect `~/.openclaw/openclaw.json` → `gateway.controlUi.allowedOrigins` should contain at least:
  - `http://127.0.0.1`, `http://localhost`
  - `http://homebrain.local`, `http://homebrain.local:80`
  - `http://<LAN_IP>`, `http://<LAN_IP>:80`
  - `https://berlin.homebrain.house` (provisioned Pangolin domain)
- [ ] LAN: open dashboard via LAN IP or mDNS → click Open AI Assistant → no "origin not allowed" error, chat works.
- [ ] Pangolin: same via `https://berlin.homebrain.house/`.
- [ ] Subsequent manager updates (no openclaw version bump) keep the same origins and skip the daemon restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)