### PR TITLE
revert(update): drop dep-version trace log added in #58

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -116,7 +116,6 @@ if command -v jq >/dev/null 2>&1 && [[ -f "$INSTALL_DIR/config/versions.json" ]]
         fi
     fi
     UPDATE_DEPS_SCRIPT="$SCRIPT_DIR/update-deps.sh"
-    log_info "Dep-version check: HAS_GPU=${HAS_GPU:-unset} update-deps=$([[ -f "$UPDATE_DEPS_SCRIPT" ]]&&echo present||echo missing) llama=${old_llama_tag:-}→${new_llama_tag:-} openclaw=${old_openclaw_ver:-}→${new_openclaw_ver:-}"
     if [[ -f "$UPDATE_DEPS_SCRIPT" ]] && [[ "${HAS_GPU:-false}" == "true" ]]; then
         if [[ -n "$new_llama_tag" && "$old_llama_tag" != "$new_llama_tag" ]]; then
             log_info "llama.cpp: ${old_llama_tag} → ${new_llama_tag}. Updating binary..."


### PR DESCRIPTION
PR #58 added a debug log_info to diagnose why the openclaw config refresh block was silently skipping. PR #57's \$INSTALL_DIR path fix resolved it (verified live: openclaw.json allowedOrigins on .58 now includes loopback + LAN IP + homebrain.local + berlin.homebrain.house). Trace is no longer useful — drop it.