### PR TITLE
fix(openclaw): re-assert llamacpp.apiKey + .api on every config patch

### DIFF
--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1124,6 +1124,20 @@ patch_openclaw_config() {
         # llama-server on 127.0.0.1; remote-access tunnelling is handled by
         # Pangolin/Caddy in front of the gateway, not by OpenClaw itself.
         .models.providers.llamacpp.baseUrl = "http://127.0.0.1:8001/v1" |
+        # Auth fields on the llamacpp provider. Without these, the embedded
+        # agent fails every prompt with "No API key found for provider
+        # 'llamacpp'. Auth store: …/auth-profiles.json …". The bundled
+        # llama-server does not actually validate the key — any non-empty
+        # string is accepted — but OpenClaw still requires *something* to
+        # mark the provider as "auth-resolved" so the agent's startup auth
+        # probe passes. The 2026.5.12 config rewriter silently dropped
+        # raw-string apiKey/api fields on writeback; later 2026.5.x builds
+        # preserve them, but installs that touched 2026.5.12 still have
+        # them missing. Re-assert idempotently so the fields self-heal on
+        # every dashboard update. `api: openai-completions` selects the
+        # OpenAI-compat adapter llama-server speaks.
+        .models.providers.llamacpp.apiKey = "1234" |
+        .models.providers.llamacpp.api = "openai-completions" |
         .gateway.mode = (.gateway.mode // "local") |
         # Single-origin UX: the HomeBrain manager reverse-proxies the
         # OpenClaw Control UI under /openclaw, so the user reaches it via


### PR DESCRIPTION
## Summary

- Add `.models.providers.llamacpp.apiKey = "1234"` and `.models.providers.llamacpp.api = "openai-completions"` to the `patch_openclaw_config()` jq pipeline.
- Both fields are asserted idempotently, so any install that lost them (notably ones that ran OpenClaw 2026.5.12) self-heals on the next dashboard update.

## Background

The seed `config/openclaw.json` has these fields, but they aren't re-asserted by `patch_openclaw_config()`. OpenClaw 2026.5.12's config rewriter silently dropped raw-string `apiKey` / `api` values on any writeback (e.g. via `openclaw mcp set`), leaving the live config provider entry as:

```json
"llamacpp": {
  "models": [...],
  "baseUrl": "http://127.0.0.1:8001/v1"
}
```

Every prompt to the embedded `main` agent then fails immediately with:

> No API key found for provider "llamacpp". Auth store: /home/homebrain/.openclaw/agents/main/agent/auth-profiles.json …

The bundled `llama-server` accepts any key — but OpenClaw still demands the provider be auth-resolved before the agent dispatches. Manual patching of `openclaw.json` on .58 confirmed: once both fields are present, the agent answers normally.

## Test plan

- [x] Local jq dry-run on a synthetic config missing both fields → emits the expected `apiKey: "1234"` + `api: "openai-completions"`.
- [ ] Deploy via `/api/manager/update` on `192.168.178.58`, confirm `~/.openclaw/openclaw.json` has both fields, and verify an OpenClaw "hi" prompt returns a reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)