### PR TITLE
fix(openclaw): remove apostrophes from patch_openclaw_config comment

### DIFF
--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1124,17 +1124,16 @@ patch_openclaw_config() {
         # llama-server on 127.0.0.1; remote-access tunnelling is handled by
         # Pangolin/Caddy in front of the gateway, not by OpenClaw itself.
         .models.providers.llamacpp.baseUrl = "http://127.0.0.1:8001/v1" |
-        # Auth fields on the llamacpp provider. Without these, the embedded
+        # Auth fields on the llamacpp provider. Without these the embedded
         # agent fails every prompt with "No API key found for provider
-        # 'llamacpp'. Auth store: …/auth-profiles.json …". The bundled
-        # llama-server does not actually validate the key — any non-empty
-        # string is accepted — but OpenClaw still requires *something* to
-        # mark the provider as "auth-resolved" so the agent's startup auth
-        # probe passes. The 2026.5.12 config rewriter silently dropped
+        # llamacpp". The bundled llama-server does not actually validate
+        # the key — any non-empty string is accepted — but OpenClaw still
+        # requires the provider be auth-resolved before the agent will
+        # dispatch. The 2026.5.12 config rewriter silently dropped
         # raw-string apiKey/api fields on writeback; later 2026.5.x builds
         # preserve them, but installs that touched 2026.5.12 still have
-        # them missing. Re-assert idempotently so the fields self-heal on
-        # every dashboard update. `api: openai-completions` selects the
+        # them missing. Re-assert idempotently so the fields self-heal
+        # on every dashboard update. api openai-completions selects the
         # OpenAI-compat adapter llama-server speaks.
         .models.providers.llamacpp.apiKey = "1234" |
         .models.providers.llamacpp.api = "openai-completions" |


### PR DESCRIPTION
## Summary

- The jq pipeline inside `patch_openclaw_config` is wrapped in a single-quoted bash string.
- The comment added in #69 contained literal single quotes around `llamacpp`, which closed that bash string early and made bash fail with "syntax error near unexpected token (" at the next jq condition.
- Strip the apostrophes — the comment still says everything it needs to without them.

## Test plan

- [x] `bash -n scripts/utilities.sh` passes locally.
- [ ] Deploy via `/api/manager/update` on `192.168.178.58`, confirm update.sh completes the openclaw-refresh block, and verify the agent answers "hi".

🤖 Generated with [Claude Code](https://claude.com/claude-code)