### PR TITLE
fix(ha-mcp): flatten target into service_data for REST API

### DIFF
--- a/scripts/mcp-homeassistant.py
+++ b/scripts/mcp-homeassistant.py
@@ -287,8 +287,8 @@ def t_call_service(args: dict) -> dict:
     if redeem_account is None:
         return err(f"account '{redeemed.get('account')}' no longer configured")
 
-    body = {**redeemed.get("service_data", {}),
-            **({"target": redeemed.get("target")} if redeemed.get("target") else {})}
+    body = {**(redeemed.get("target") or {}),
+            **redeemed.get("service_data", {})}
     code, resp = _http(redeem_account, "POST",
                        f"/api/services/{redeemed['domain']}/{redeemed['service']}",
                        body)
@@ -378,8 +378,8 @@ def t_call_service_raw(args: dict) -> dict:
     if redeem_account is None:
         return err(f"account '{redeemed.get('account')}' no longer configured")
 
-    body = {**redeemed.get("service_data", {}),
-            **({"target": redeemed.get("target")} if redeemed.get("target") else {})}
+    body = {**(redeemed.get("target") or {}),
+            **redeemed.get("service_data", {})}
     code, resp = _http(redeem_account, "POST",
                        f"/api/services/{redeemed['domain']}/{redeemed['service']}",
                        body)


### PR DESCRIPTION
## Summary

- HA's REST API passes the POST body directly as `service_data` — it does **not** extract a nested `"target"` key (that's a WebSocket API / automation concept).
- With strict schema validation in HA 2024.2+, the unknown `"target"` key in service_data triggers `vol.Invalid` → **400 Bad Request** on every service call — `light.turn_on`, `light.turn_off`, `number.set_value`, etc.
- Fix: flatten `target` fields (`entity_id`, `area_id`, `device_id`) to top-level body keys so HA's core can extract them the way the REST API expects.
- Affects both `ha.call_service` (curated) and `ha.call_service_raw`.

Before: `{"brightness": 128, "target": {"entity_id": "light.foo"}}` → 400
After:  `{"entity_id": "light.foo", "brightness": 128}` → 200

## Test plan

- [ ] Call `ha.call_service` with `light.turn_on` + brightness on a real entity
- [ ] Call `ha.call_service_raw` with `number.set_value` on a real entity
- [ ] Verify `ha.call_service` with area_id target works

🤖 Generated with [Claude Code](https://claude.com/claude-code)