### PR TITLE
fix: align MCP servers — vault security, email accounts, missing tools

### DIFF
--- a/scripts/mcp-email.py
+++ b/scripts/mcp-email.py
@@ -432,6 +432,47 @@ def t_archive(args: dict) -> dict:
             pass
 
 
+def t_flag(args: dict) -> dict:
+    acc, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
+    name = acc["name"]
+    msg_id = args.get("id") or ""
+    remove = bool(args.get("remove", False))
+    confirm = args.get("confirmation_token")
+    chat_id = args.get("_chat_id")
+    if not msg_id:
+        return err("id is required")
+    action = "unflag" if remove else "flag"
+    summary = f"Email: {action} message {msg_id} on account '{name}'"
+    if not confirm:
+        action_id = Consent.issue("email", summary,
+                                  {"account": name, "id": msg_id,
+                                   "remove": remove}, chat_id)
+        return consent_required(action_id, summary)
+    redeemed = Consent.verify(confirm, "email", chat_id)
+    if not redeemed:
+        return err("confirmation_token invalid or expired")
+    redeem_acc = _pick_account(redeemed["account"])
+    if not redeem_acc:
+        return err("account not found")
+    conn = _imap(redeem_acc)
+    if not conn:
+        return unavailable("could not connect to IMAP")
+    try:
+        conn.select("INBOX")
+        op = "-FLAGS" if redeemed.get("remove") else "+FLAGS"
+        conn.store(redeemed["id"].encode(), op, r"(\Flagged)")
+        audit("email", "flag", account=redeemed["account"],
+              id=redeemed["id"], remove=redeemed.get("remove", False))
+        return ok(flagged=not redeemed.get("remove"), id=redeemed["id"])
+    finally:
+        try:
+            conn.logout()
+        except Exception:
+            pass
+
+
 TOOLS = [
     {"name": "email.list_accounts",
      "description": "List configured email accounts (names only — never credentials).",
@@ -483,6 +524,15 @@ TOOLS = [
                                     "id": {"type": "string"},
                                     "confirmation_token": {"type": "string"}},
                      "required": ["id"]}},
+    {"name": "email.flag",
+     "description": "Flag or unflag a message (IMAP \\Flagged). Consent-gated.",
+     "inputSchema": {"type": "object",
+                     "properties": {"account": {"type": "string"},
+                                    "id": {"type": "string"},
+                                    "remove": {"type": "boolean",
+                                               "description": "true to unflag (default false)"},
+                                    "confirmation_token": {"type": "string"}},
+                     "required": ["id"]}},
 ]
 
 
@@ -494,6 +544,7 @@ DISPATCH = {
     "email.draft": t_draft,
     "email.send_direct": t_send_direct,
     "email.archive": t_archive,
+    "email.flag": t_flag,
 }
 
 
@@ -505,4 +556,4 @@ def dispatch(name: str, args: dict) -> dict:
 
 
 if __name__ == "__main__":
-    serve("homebrain-email", "0.1.0", TOOLS, dispatch)
+    serve("homebrain-email", "0.2.0", TOOLS, dispatch)

--- a/scripts/mcp-email.py
+++ b/scripts/mcp-email.py
@@ -66,11 +66,34 @@ def _accounts() -> list[dict]:
     return data.get("accounts", []) if isinstance(data, dict) else []
 
 
-def _find(name: str) -> dict | None:
-    for a in _accounts():
+def _pick_account(name: str | None) -> dict | None:
+    accounts = _accounts()
+    if not accounts:
+        return None
+    if not name:
+        return accounts[0] if len(accounts) == 1 else None
+    for a in accounts:
         if a.get("name") == name:
             return a
     return None
+
+
+def _account_or_err(args: dict) -> tuple[dict | None, dict | None]:
+    name = (args.get("account") or "").strip() or None
+    a = _pick_account(name)
+    if a is not None:
+        return a, None
+    accounts = _accounts()
+    if not accounts:
+        return None, unavailable("no email accounts configured")
+    if not name and len(accounts) > 1:
+        names = ", ".join(repr(x.get("name")) for x in accounts)
+        return None, err(
+            f"multiple email accounts configured; pass `account` (one of: {names})",
+            hint="Use email.list_accounts to see the configured set.",
+        )
+    return None, err(f"account '{name}' not found",
+                     hint="Use email.list_accounts to see the configured set.")
 
 
 def _imap(account: dict) -> imaplib.IMAP4 | None:
@@ -126,11 +149,11 @@ def _summarise(msg_bytes: bytes, uid: str) -> dict:
 
 
 def t_list_unread(args: dict) -> dict:
-    name = args.get("account") or ""
+    acc, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
+    name = acc["name"]
     limit = int(args.get("limit") or 20)
-    acc = _find(name)
-    if not acc:
-        return err(f"account '{name}' not found")
     conn = _imap(acc)
     if not conn:
         return unavailable(f"could not connect to IMAP for '{name}'")
@@ -155,12 +178,12 @@ def t_list_unread(args: dict) -> dict:
 
 
 def t_search(args: dict) -> dict:
-    name = args.get("account") or ""
+    acc, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
+    name = acc["name"]
     query = args.get("query") or ""
     limit = int(args.get("limit") or 30)
-    acc = _find(name)
-    if not acc:
-        return err(f"account '{name}' not found")
     if not query:
         return err("query is required")
     conn = _imap(acc)
@@ -188,13 +211,15 @@ def t_search(args: dict) -> dict:
 
 
 def t_fetch(args: dict) -> dict:
-    """REVEAL-tier: pull a full message body."""
-    name = args.get("account") or ""
+    acc, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
+    name = acc["name"]
     msg_id = args.get("id") or ""
     confirm = args.get("confirmation_token")
     chat_id = args.get("_chat_id")
-    if not name or not msg_id:
-        return err("account and id are required")
+    if not msg_id:
+        return err("id is required")
     summary = f"Email: read full body of message {msg_id} from account '{name}'"
     if not confirm:
         action_id = Consent.issue("email", summary,
@@ -204,7 +229,7 @@ def t_fetch(args: dict) -> dict:
     redeemed = Consent.verify(confirm, "email", chat_id)
     if not redeemed:
         return err("confirmation_token invalid or expired")
-    acc = _find(redeemed["account"])
+    acc = _pick_account(redeemed["account"])
     if not acc:
         return err("account not found")
     conn = _imap(acc)
@@ -270,16 +295,17 @@ def _save_draft(account: dict, to: str, subject: str, body: str) -> tuple[bool, 
 
 
 def t_draft(args: dict) -> dict:
-    """ACT-tier: create a draft. Drafts are reversible; sends are not.
-    The agent CANNOT directly send — that's email.send_direct, gated."""
-    name = args.get("account") or ""
+    acc, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
+    name = acc["name"]
     to = args.get("to") or ""
     subject = args.get("subject") or ""
     body = args.get("body") or ""
     confirm = args.get("confirmation_token")
     chat_id = args.get("_chat_id")
-    if not all([name, to, subject]):
-        return err("account, to, subject required")
+    if not all([to, subject]):
+        return err("to and subject are required")
     summary = f"Email: create DRAFT to {to} via '{name}', subject '{subject}'"
     if not confirm:
         action_id = Consent.issue("email", summary,
@@ -290,7 +316,7 @@ def t_draft(args: dict) -> dict:
     redeemed = Consent.verify(confirm, "email", chat_id)
     if not redeemed:
         return err("confirmation_token invalid or expired")
-    acc = _find(redeemed["account"])
+    acc = _pick_account(redeemed["account"])
     if not acc:
         return err("account not found")
     saved, info = _save_draft(acc, redeemed["to"], redeemed["subject"], redeemed["body"])
@@ -303,21 +329,22 @@ def t_draft(args: dict) -> dict:
 
 
 def t_send_direct(args: dict) -> dict:
-    """ACT+ tier: send mail directly. Off by default; requires the
-    dashboard to opt-in via HOMEBRAIN_EMAIL_SEND_DIRECT=true."""
     if not SEND_DIRECT_ENABLED:
         return err(
             "email.send_direct is disabled",
             hint="Enable in HomeBrain dashboard → Connections → Email → Settings",
         )
-    name = args.get("account") or ""
+    acc, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
+    name = acc["name"]
     to = args.get("to") or ""
     subject = args.get("subject") or ""
     body = args.get("body") or ""
     confirm = args.get("confirmation_token")
     chat_id = args.get("_chat_id")
-    if not all([name, to, subject]):
-        return err("account, to, subject required")
+    if not all([to, subject]):
+        return err("to and subject are required")
     summary = f"Email: SEND to {to} via '{name}', subject '{subject}'"
     if not confirm:
         action_id = Consent.issue("email", summary,
@@ -328,7 +355,7 @@ def t_send_direct(args: dict) -> dict:
     redeemed = Consent.verify(confirm, "email", chat_id)
     if not redeemed:
         return err("confirmation_token invalid or expired")
-    acc = _find(redeemed["account"])
+    acc = _pick_account(redeemed["account"])
     if not acc:
         return err("account not found")
 
@@ -362,13 +389,15 @@ def t_send_direct(args: dict) -> dict:
 
 
 def t_archive(args: dict) -> dict:
-    """ACT-tier (low risk): mark seen + move to Archive folder."""
-    name = args.get("account") or ""
+    acc, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
+    name = acc["name"]
     msg_id = args.get("id") or ""
     confirm = args.get("confirmation_token")
     chat_id = args.get("_chat_id")
-    if not name or not msg_id:
-        return err("account and id required")
+    if not msg_id:
+        return err("id is required")
     summary = f"Email: archive message {msg_id} on account '{name}'"
     if not confirm:
         action_id = Consent.issue("email", summary,
@@ -378,15 +407,15 @@ def t_archive(args: dict) -> dict:
     redeemed = Consent.verify(confirm, "email", chat_id)
     if not redeemed:
         return err("confirmation_token invalid or expired")
-    acc = _find(redeemed["account"])
-    if not acc:
+    redeem_acc = _pick_account(redeemed["account"])
+    if not redeem_acc:
         return err("account not found")
-    conn = _imap(acc)
+    conn = _imap(redeem_acc)
     if not conn:
         return unavailable("could not connect to IMAP")
     try:
         conn.select("INBOX")
-        archive = acc.get("archive_folder") or "Archive"
+        archive = redeem_acc.get("archive_folder") or "Archive"
         try:
             conn.create(archive)
         except Exception:
@@ -408,39 +437,37 @@ TOOLS = [
      "description": "List configured email accounts (names only — never credentials).",
      "inputSchema": {"type": "object", "properties": {}}},
     {"name": "email.list_unread",
-     "description": "List unread messages from one account. Returns headers only (from, subject, date) — never bodies.",
+     "description": "List unread messages. Returns headers only (from, subject, date) — never bodies.",
      "inputSchema": {"type": "object",
                      "properties": {"account": {"type": "string"},
-                                    "limit": {"type": "integer"}},
-                     "required": ["account"]}},
+                                    "limit": {"type": "integer"}}}},
     {"name": "email.search",
-     "description": "IMAP TEXT search across one account. Returns headers only.",
+     "description": "IMAP TEXT search. Returns headers only.",
      "inputSchema": {"type": "object",
                      "properties": {"account": {"type": "string"},
                                     "query": {"type": "string"},
                                     "limit": {"type": "integer"}},
-                     "required": ["account", "query"]}},
+                     "required": ["query"]}},
     {"name": "email.fetch",
-     "description": "REVEAL-tier: fetch a full message body. Requires consent token. Audited.",
+     "description": "Fetch a full message body. Consent-gated and audited.",
      "inputSchema": {"type": "object",
                      "properties": {"account": {"type": "string"},
                                     "id": {"type": "string"},
                                     "confirmation_token": {"type": "string"}},
-                     "required": ["account", "id"]}},
+                     "required": ["id"]}},
     {"name": "email.draft",
-     "description": "ACT-tier: create a DRAFT (never sends). Requires consent token.",
+     "description": "Create a DRAFT (never sends). Consent-gated.",
      "inputSchema": {"type": "object",
                      "properties": {"account": {"type": "string"},
                                     "to": {"type": "string"},
                                     "subject": {"type": "string"},
                                     "body": {"type": "string"},
                                     "confirmation_token": {"type": "string"}},
-                     "required": ["account", "to", "subject"]}},
+                     "required": ["to", "subject"]}},
     {"name": "email.send_direct",
      "description": (
-         "ACT+ tier: send a message directly. Disabled by default. Enable "
-         "in HomeBrain dashboard → Connections → Email → Settings. Requires "
-         "consent token even when enabled."
+         "Send a message directly. Disabled by default — enable in "
+         "HomeBrain dashboard → Connections → Email → Settings. Consent-gated."
      ),
      "inputSchema": {"type": "object",
                      "properties": {"account": {"type": "string"},
@@ -448,14 +475,14 @@ TOOLS = [
                                     "subject": {"type": "string"},
                                     "body": {"type": "string"},
                                     "confirmation_token": {"type": "string"}},
-                     "required": ["account", "to", "subject"]}},
+                     "required": ["to", "subject"]}},
     {"name": "email.archive",
-     "description": "ACT-tier: archive a message (mark seen + move to Archive folder).",
+     "description": "Archive a message (mark seen + move to Archive folder). Consent-gated.",
      "inputSchema": {"type": "object",
                      "properties": {"account": {"type": "string"},
                                     "id": {"type": "string"},
                                     "confirmation_token": {"type": "string"}},
-                     "required": ["account", "id"]}},
+                     "required": ["id"]}},
 ]
 
 

--- a/scripts/mcp-nextcloud.py
+++ b/scripts/mcp-nextcloud.py
@@ -470,6 +470,54 @@ def t_notes_create(args: dict) -> dict:
     return ok(account=redeem_account["name"], id=n.get("id"), title=n.get("title"))
 
 
+def t_notes_update(args: dict) -> dict:
+    account, ebody = _account_or_err(args)
+    if ebody is not None:
+        return ebody
+    nid = args.get("id")
+    if nid is None:
+        return err("id is required")
+    title = args.get("title") or ""
+    content = args.get("content") or ""
+    category = args.get("category")
+    confirm = args.get("confirmation_token")
+    chat_id = args.get("_chat_id")
+    summary = (f"Nextcloud ({account['name']}): update note {nid}"
+               f"{f' ({title})' if title else ''}")
+    payload = {"account": account["name"], "id": int(nid),
+               "title": title, "content": content}
+    if category is not None:
+        payload["category"] = category
+    if not confirm:
+        action_id = Consent.issue("nextcloud", summary, payload, chat_id)
+        return consent_required(action_id, summary)
+    redeemed = Consent.verify(confirm, "nextcloud", chat_id)
+    if not redeemed:
+        return err("confirmation_token invalid or expired")
+    redeem_account = _pick_account(redeemed.get("account")) or account
+    body_dict: dict = {}
+    if redeemed.get("title"):
+        body_dict["title"] = redeemed["title"]
+    if redeemed.get("content"):
+        body_dict["content"] = redeemed["content"]
+    if "category" in redeemed:
+        body_dict["category"] = redeemed["category"]
+    body = json.dumps(body_dict).encode()
+    code, resp, _ = _http(redeem_account, "PUT",
+                          f"/index.php/apps/notes/api/v1/notes/{int(redeemed['id'])}",
+                          body=body,
+                          headers={"Content-Type": "application/json"})
+    if code != 200:
+        return err(f"note update failed: {code}")
+    try:
+        n = json.loads(resp)
+    except json.JSONDecodeError:
+        n = {}
+    audit("nextcloud", "notes.update", account=redeem_account["name"],
+          note_id=redeemed["id"])
+    return ok(account=redeem_account["name"], id=n.get("id"), title=n.get("title"))
+
+
 _ACCOUNT_PROP = {
     "type": "string",
     "description": ("Configured account name to act on. Omit when only one "
@@ -545,6 +593,18 @@ TOOLS = [
                                     "account": _ACCOUNT_PROP,
                                     "confirmation_token": {"type": "string"}},
                      "required": ["title", "content"]}},
+    {"name": "nc.notes_update",
+     "description": ("Update an existing Nextcloud note by id. Only fields "
+                     "you provide (title, content, category) are changed. "
+                     "Consent-gated."),
+     "inputSchema": {"type": "object",
+                     "properties": {"id": {"type": "integer"},
+                                    "title": {"type": "string"},
+                                    "content": {"type": "string"},
+                                    "category": {"type": "string"},
+                                    "account": _ACCOUNT_PROP,
+                                    "confirmation_token": {"type": "string"}},
+                     "required": ["id"]}},
 ]
 
 
@@ -558,6 +618,7 @@ DISPATCH = {
     "nc.notes_list": t_notes_list,
     "nc.notes_get": t_notes_get,
     "nc.notes_create": t_notes_create,
+    "nc.notes_update": t_notes_update,
 }
 
 
@@ -569,4 +630,4 @@ def dispatch(name: str, args: dict) -> dict:
 
 
 if __name__ == "__main__":
-    serve("homebrain-nextcloud", "0.2.0", TOOLS, dispatch)
+    serve("homebrain-nextcloud", "0.3.0", TOOLS, dispatch)

--- a/scripts/mcp-vault.py
+++ b/scripts/mcp-vault.py
@@ -10,11 +10,11 @@ Design tenets
   (mode 0600, owned by the calling user).
 * This MCP server reads that session token at every call. If the file is
   missing or the token is stale (`bw status` returns "locked"), the tool
-  returns an `unlocked: false` envelope rather than prompting — letting
+  returns an `unavailable` envelope rather than prompting — letting
   the agent decide how to ask the user.
 * Only metadata is returned by `vault.search` (name, username, URI, login
   notes). Full secrets require explicit `vault.reveal` with a per-item ID,
-  which logs the access to stderr (captured by journald).
+  which is consent-gated and audited.
 
 Wire-up
 -------
@@ -35,13 +35,9 @@ for ~/.openclaw/openclaw.json:
     ]
   }
 
-Or run as a systemd unit (see config/openclaw-mcp-vault.service) if your
-agent supports remote MCP via Unix socket.
-
 Dependencies
 ------------
 * Bitwarden CLI: `npm install -g @bitwarden/cli` (the `bw` binary)
-* Python: stdlib only (no external packages required for the wire protocol).
 """
 from __future__ import annotations
 
@@ -49,8 +45,11 @@ import json
 import os
 import subprocess
 import sys
-from datetime import datetime
-from typing import Any
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from mcp_common import (  # noqa: E402
+    Consent, audit, consent_required, err, ok, serve, unavailable,
+)
 
 VAULT_URL = os.environ.get("VAULT_URL", "")
 VAULT_BW_BIN = os.environ.get("VAULT_BW_BIN", "bw")
@@ -58,25 +57,6 @@ VAULT_SESSION_FILE = os.environ.get(
     "VAULT_SESSION_FILE",
     os.path.expanduser("~/.openclaw/vault.session"),
 )
-VAULT_AUDIT_LOG = os.environ.get(
-    "VAULT_AUDIT_LOG",
-    "/var/log/homebrain/mcp-vault-audit.log",
-)
-
-
-def _audit(action: str, **kwargs: Any) -> None:
-    """Append a one-line JSON record for every secret-touching call."""
-    rec = {"ts": datetime.utcnow().isoformat() + "Z", "action": action}
-    rec.update(kwargs)
-    line = json.dumps(rec, default=str)
-    sys.stderr.write(line + "\n")
-    sys.stderr.flush()
-    try:
-        os.makedirs(os.path.dirname(VAULT_AUDIT_LOG), exist_ok=True)
-        with open(VAULT_AUDIT_LOG, "a") as f:
-            f.write(line + "\n")
-    except OSError:
-        pass
 
 
 def _read_session() -> str | None:
@@ -91,7 +71,7 @@ def _read_session() -> str | None:
 def _bw(*args: str, session: str | None = None) -> tuple[int, str, str]:
     env = os.environ.copy()
     if VAULT_URL:
-        env["BW_SERVE_URL"] = VAULT_URL  # bw config
+        env["BW_SERVE_URL"] = VAULT_URL
     if session:
         env["BW_SESSION"] = session
     try:
@@ -106,288 +86,259 @@ def _bw(*args: str, session: str | None = None) -> tuple[int, str, str]:
         return 124, "", "bw command timed out"
 
 
-def _is_unlocked() -> bool:
+def _session_or_unavail() -> tuple[str | None, dict | None]:
     session = _read_session()
     if not session:
-        return False
+        return None, unavailable(
+            "vault is locked — unlock it from the HomeBrain dashboard")
     rc, out, _ = _bw("status", session=session)
     if rc != 0:
-        return False
+        return None, unavailable("vault status check failed")
     try:
-        return json.loads(out).get("status") == "unlocked"
+        if json.loads(out).get("status") != "unlocked":
+            return None, unavailable(
+                "vault is locked — unlock it from the HomeBrain dashboard")
     except json.JSONDecodeError:
-        return False
+        return None, unavailable("could not parse vault status")
+    return session, None
 
 
-# --- MCP wire protocol (JSON-RPC 2.0 over stdio, MCP 2025-06-18 spec) ---
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+def t_status(_args: dict) -> dict:
+    session = _read_session()
+    if not session:
+        return ok(unlocked=False, url=VAULT_URL)
+    rc, out, _ = _bw("status", session=session)
+    unlocked = False
+    if rc == 0:
+        try:
+            unlocked = json.loads(out).get("status") == "unlocked"
+        except json.JSONDecodeError:
+            pass
+    return ok(unlocked=unlocked, url=VAULT_URL)
+
+
+def t_search(args: dict) -> dict:
+    session, ebody = _session_or_unavail()
+    if ebody is not None:
+        return ebody
+    q = (args.get("query") or "").strip()
+    if not q:
+        return err("query is required")
+    rc, out, bw_err = _bw("list", "items", "--search", q, session=session)
+    if rc != 0:
+        return err(bw_err.strip() or "search failed")
+    try:
+        items = json.loads(out)
+    except json.JSONDecodeError:
+        return err("could not parse bw output")
+    results = []
+    for it in items:
+        login = it.get("login") or {}
+        uris = [u.get("uri", "") for u in (login.get("uris") or [])]
+        results.append({
+            "id": it.get("id"),
+            "name": it.get("name"),
+            "username": login.get("username"),
+            "uris": uris,
+            "folder_id": it.get("folderId"),
+        })
+    audit("vault", "search", query=q, hits=len(results))
+    return ok(results=results, total=len(results))
+
+
+def t_reveal(args: dict) -> dict:
+    session, ebody = _session_or_unavail()
+    if ebody is not None:
+        return ebody
+    item_id = (args.get("item_id") or "").strip()
+    reason = args.get("reason") or "(unspecified)"
+    confirm = args.get("confirmation_token")
+    chat_id = args.get("_chat_id")
+    if not item_id:
+        return err("item_id is required")
+
+    summary = f"Vault: reveal password for item {item_id} (reason: {reason})"
+    payload = {"item_id": item_id, "reason": reason}
+
+    if not confirm:
+        action_id = Consent.issue("vault", summary, payload, chat_id)
+        return consent_required(action_id, summary)
+
+    redeemed = Consent.verify(confirm, "vault", chat_id)
+    if not redeemed:
+        return err("confirmation_token invalid or expired")
+
+    rid = redeemed["item_id"]
+    rc, out, bw_err = _bw("get", "item", rid, session=session)
+    if rc != 0:
+        return err(bw_err.strip() or "item not found")
+    try:
+        item = json.loads(out)
+    except json.JSONDecodeError:
+        return err("could not parse bw output")
+    login = item.get("login") or {}
+    audit("vault", "reveal", item_id=rid,
+          item_name=item.get("name"), reason=redeemed["reason"])
+    return ok(
+        id=item.get("id"),
+        name=item.get("name"),
+        username=login.get("username"),
+        password=login.get("password"),
+        totp_seed_present=bool(login.get("totp")),
+        notes=item.get("notes"),
+    )
+
+
+def t_list_folders(_args: dict) -> dict:
+    session, ebody = _session_or_unavail()
+    if ebody is not None:
+        return ebody
+    rc, out, bw_err = _bw("list", "folders", session=session)
+    if rc != 0:
+        return err(bw_err.strip() or "list_folders failed")
+    try:
+        folders = json.loads(out)
+    except json.JSONDecodeError:
+        return err("could not parse bw output")
+    return ok(folders=[{"id": f.get("id"), "name": f.get("name")}
+                       for f in folders])
+
+
+def t_create_login(args: dict) -> dict:
+    session, ebody = _session_or_unavail()
+    if ebody is not None:
+        return ebody
+    item_name = args.get("name") or "(unnamed)"
+    username = args.get("username") or ""
+    password = args.get("password") or ""
+    uri = args.get("uri") or ""
+    folder_id = args.get("folder_id") or ""
+    confirm = args.get("confirmation_token")
+    chat_id = args.get("_chat_id")
+
+    summary = (f"Vault: save new login '{item_name}' (user: {username}, "
+               f"uri: {uri or 'none'})")
+    payload = {"name": item_name, "username": username,
+               "password": password, "uri": uri, "folder_id": folder_id}
+
+    if not confirm:
+        action_id = Consent.issue("vault", summary, payload, chat_id)
+        return consent_required(action_id, summary)
+
+    redeemed = Consent.verify(confirm, "vault", chat_id)
+    if not redeemed:
+        return err("confirmation_token invalid or expired")
+
+    rc, tmpl_out, _ = _bw("get", "template", "item", session=session)
+    if rc != 0:
+        return err("could not fetch item template")
+    try:
+        tmpl = json.loads(tmpl_out)
+    except json.JSONDecodeError:
+        return err("could not parse item template")
+    tmpl["type"] = 1  # login
+    tmpl["name"] = redeemed["name"]
+    tmpl["folderId"] = redeemed.get("folder_id") or None
+    tmpl["login"] = {
+        "username": redeemed["username"],
+        "password": redeemed["password"],
+        "uris": ([{"uri": redeemed["uri"], "match": None}]
+                 if redeemed.get("uri") else []),
+    }
+    encoded = subprocess.run(
+        [VAULT_BW_BIN, "encode"],
+        input=json.dumps(tmpl), capture_output=True, text=True, timeout=10,
+    )
+    if encoded.returncode != 0:
+        return err("bw encode failed")
+    rc, out, bw_err = _bw("create", "item", encoded.stdout.strip(),
+                           session=session)
+    if rc != 0:
+        return err(bw_err.strip() or "create failed")
+    try:
+        created = json.loads(out)
+    except json.JSONDecodeError:
+        return err("could not parse bw output")
+    audit("vault", "create_login", item_id=created.get("id"),
+          item_name=redeemed["name"], username=redeemed["username"],
+          uri=redeemed.get("uri"))
+    return ok(id=created.get("id"), name=created.get("name"))
+
 
 TOOLS = [
-    {
-        "name": "vault.search",
-        "description": (
-            "Search the local HomeBrain Vault by free-text query. Returns "
-            "metadata only (name, username, URI). No secrets are revealed. "
-            "Returns {unlocked: false} if the vault is locked — ask the user "
-            "to unlock it via the dashboard."
-        ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "query": {"type": "string", "description": "Free-text query"},
-            },
-            "required": ["query"],
-        },
-    },
-    {
-        "name": "vault.reveal",
-        "description": (
-            "Reveal the password for a single vault item by ID. Audited. "
-            "Use sparingly and ONLY after the user has explicitly asked "
-            "for the secret. Returns {unlocked: false} if locked."
-        ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "item_id": {"type": "string", "description": "Vault item UUID"},
-                "reason": {"type": "string", "description": "Why the agent needs this — written to the audit log"},
-            },
-            "required": ["item_id", "reason"],
-        },
-    },
-    {
-        "name": "vault.status",
-        "description": "Check whether the vault is currently unlocked.",
-        "inputSchema": {"type": "object", "properties": {}},
-    },
-    {
-        "name": "vault.list_folders",
-        "description": "List vault folders (id + name).",
-        "inputSchema": {"type": "object", "properties": {}},
-    },
-    {
-        "name": "vault.create_login",
-        "description": (
-            "ACT-tier: create a new login entry. Requires consent token — "
-            "first call returns {requires_confirmation: true, action_id, "
-            "summary}; the agent must surface a confirmation prompt to the "
-            "user and re-call with confirmation_token=action_id."
-        ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "name": {"type": "string"},
-                "username": {"type": "string"},
-                "password": {"type": "string"},
-                "uri": {"type": "string"},
-                "folder_id": {"type": "string"},
-                "confirmation_token": {"type": "string"},
-            },
-            "required": ["name", "username", "password"],
-        },
-    },
+    {"name": "vault.status",
+     "description": "Check whether the vault is currently unlocked.",
+     "inputSchema": {"type": "object", "properties": {}}},
+    {"name": "vault.search",
+     "description": (
+         "Search the local HomeBrain Vault by free-text query. Returns "
+         "metadata only (name, username, URI). No secrets are revealed."
+     ),
+     "inputSchema": {
+         "type": "object",
+         "properties": {
+             "query": {"type": "string", "description": "Free-text query"},
+         },
+         "required": ["query"],
+     }},
+    {"name": "vault.reveal",
+     "description": (
+         "Reveal the password for a single vault item by ID. Audited and "
+         "consent-gated. Use sparingly and only when the user has explicitly "
+         "asked for the secret."
+     ),
+     "inputSchema": {
+         "type": "object",
+         "properties": {
+             "item_id": {"type": "string", "description": "Vault item UUID"},
+             "reason": {"type": "string",
+                        "description": "Why the agent needs this — written to the audit log"},
+             "confirmation_token": {"type": "string"},
+         },
+         "required": ["item_id", "reason"],
+     }},
+    {"name": "vault.list_folders",
+     "description": "List vault folders (id + name).",
+     "inputSchema": {"type": "object", "properties": {}}},
+    {"name": "vault.create_login",
+     "description": (
+         "Create a new login entry in the vault. Consent-gated — the runtime "
+         "prompts the user for approval automatically."
+     ),
+     "inputSchema": {
+         "type": "object",
+         "properties": {
+             "name": {"type": "string"},
+             "username": {"type": "string"},
+             "password": {"type": "string"},
+             "uri": {"type": "string"},
+             "folder_id": {"type": "string"},
+             "confirmation_token": {"type": "string"},
+         },
+         "required": ["name", "username", "password"],
+     }},
 ]
 
 
-# Optional consent integration — re-uses the shared Consent helper from
-# mcp_common.py. We import lazily so this server keeps working even if the
-# shared library is missing (e.g. older deployments mid-upgrade).
-try:
-    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-    from mcp_common import Consent, consent_required  # type: ignore
-    _CONSENT_OK = True
-except Exception:
-    _CONSENT_OK = False
+DISPATCH = {
+    "vault.status": t_status,
+    "vault.search": t_search,
+    "vault.reveal": t_reveal,
+    "vault.list_folders": t_list_folders,
+    "vault.create_login": t_create_login,
+}
 
 
-def call_tool(name: str, args: dict) -> dict:
-    if name == "vault.status":
-        return {"unlocked": _is_unlocked(), "url": VAULT_URL}
-
-    session = _read_session()
-    if not session or not _is_unlocked():
-        return {"unlocked": False, "hint": "Ask the user to unlock the vault from the HomeBrain dashboard."}
-
-    if name == "vault.search":
-        q = args.get("query", "")
-        rc, out, err = _bw("list", "items", "--search", q, session=session)
-        if rc != 0:
-            return {"error": err.strip() or "search failed"}
-        try:
-            items = json.loads(out)
-        except json.JSONDecodeError:
-            return {"error": "could not parse bw output"}
-        # Strip secrets — never return passwords from search.
-        results = []
-        for it in items:
-            login = it.get("login") or {}
-            uris = [u.get("uri", "") for u in (login.get("uris") or [])]
-            results.append({
-                "id": it.get("id"),
-                "name": it.get("name"),
-                "username": login.get("username"),
-                "uris": uris,
-                "folder_id": it.get("folderId"),
-            })
-        _audit("search", query=q, hits=len(results))
-        return {"unlocked": True, "results": results}
-
-    if name == "vault.reveal":
-        item_id = args.get("item_id", "")
-        reason = args.get("reason", "(unspecified)")
-        rc, out, err = _bw("get", "item", item_id, session=session)
-        if rc != 0:
-            return {"error": err.strip() or "item not found"}
-        try:
-            item = json.loads(out)
-        except json.JSONDecodeError:
-            return {"error": "could not parse bw output"}
-        login = item.get("login") or {}
-        _audit("reveal", item_id=item_id, item_name=item.get("name"), reason=reason)
-        return {
-            "unlocked": True,
-            "id": item.get("id"),
-            "name": item.get("name"),
-            "username": login.get("username"),
-            "password": login.get("password"),
-            "totp_seed_present": bool(login.get("totp")),
-            "notes": item.get("notes"),
-        }
-
-    if name == "vault.list_folders":
-        rc, out, err = _bw("list", "folders", session=session)
-        if rc != 0:
-            return {"error": err.strip() or "list_folders failed"}
-        try:
-            folders = json.loads(out)
-        except json.JSONDecodeError:
-            return {"error": "could not parse bw output"}
-        return {
-            "unlocked": True,
-            "folders": [{"id": f.get("id"), "name": f.get("name")} for f in folders],
-        }
-
-    if name == "vault.create_login":
-        item_name = args.get("name") or "(unnamed)"
-        username = args.get("username") or ""
-        password = args.get("password") or ""
-        uri = args.get("uri") or ""
-        folder_id = args.get("folder_id") or ""
-        confirm = args.get("confirmation_token") or ""
-        chat_id = args.get("_chat_id")
-        summary = (
-            f"Vault: save new login '{item_name}' (user: {username}, "
-            f"uri: {uri or 'none'})"
-        )
-        if _CONSENT_OK and not confirm:
-            action_id = Consent.issue("vault", summary,
-                                      {"name": item_name, "username": username,
-                                       "password": password, "uri": uri,
-                                       "folder_id": folder_id},
-                                      chat_id)
-            return consent_required(action_id, summary)
-        if _CONSENT_OK:
-            redeemed = Consent.verify(confirm, "vault", chat_id)
-            if not redeemed:
-                return {"error": "confirmation_token invalid or expired"}
-            item_name = redeemed["name"]
-            username = redeemed["username"]
-            password = redeemed["password"]
-            uri = redeemed.get("uri", "")
-            folder_id = redeemed.get("folder_id", "")
-
-        # Build the item template via `bw get template item`, populate, encode.
-        rc, tmpl_out, _ = _bw("get", "template", "item", session=session)
-        if rc != 0:
-            return {"error": "could not fetch item template"}
-        try:
-            tmpl = json.loads(tmpl_out)
-        except json.JSONDecodeError:
-            return {"error": "could not parse item template"}
-        tmpl["type"] = 1  # login
-        tmpl["name"] = item_name
-        tmpl["folderId"] = folder_id or None
-        tmpl["login"] = {
-            "username": username, "password": password,
-            "uris": ([{"uri": uri, "match": None}] if uri else []),
-        }
-        encoded = subprocess.run(
-            [VAULT_BW_BIN, "encode"],
-            input=json.dumps(tmpl), capture_output=True, text=True, timeout=10,
-        )
-        if encoded.returncode != 0:
-            return {"error": "bw encode failed"}
-        rc, out, err = _bw("create", "item", encoded.stdout.strip(), session=session)
-        if rc != 0:
-            return {"error": err.strip() or "create failed"}
-        try:
-            created = json.loads(out)
-        except json.JSONDecodeError:
-            return {"error": "could not parse bw output"}
-        _audit("create_login", item_id=created.get("id"),
-               item_name=item_name, username=username,
-               uri=uri, chat_id=chat_id)
-        return {"unlocked": True, "id": created.get("id"), "name": created.get("name")}
-
-    return {"error": f"unknown tool: {name}"}
-
-
-def write_message(obj: dict) -> None:
-    sys.stdout.write(json.dumps(obj) + "\n")
-    sys.stdout.flush()
-
-
-def serve() -> None:
-    """Tiny JSON-RPC 2.0 loop for MCP over stdio. Implements just enough of
-    the spec for `initialize`, `tools/list`, `tools/call`."""
-    for line in sys.stdin:
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            msg = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        method = msg.get("method")
-        msg_id = msg.get("id")
-        params = msg.get("params") or {}
-
-        if method == "initialize":
-            write_message({
-                "jsonrpc": "2.0",
-                "id": msg_id,
-                "result": {
-                    "protocolVersion": "2025-06-18",
-                    "capabilities": {"tools": {}},
-                    "serverInfo": {"name": "homebrain-vault", "version": "0.1.0"},
-                },
-            })
-        elif method == "tools/list":
-            write_message({
-                "jsonrpc": "2.0",
-                "id": msg_id,
-                "result": {"tools": TOOLS},
-            })
-        elif method == "tools/call":
-            tool = params.get("name", "")
-            args = params.get("arguments") or {}
-            result = call_tool(tool, args)
-            write_message({
-                "jsonrpc": "2.0",
-                "id": msg_id,
-                "result": {
-                    "content": [{"type": "text", "text": json.dumps(result)}],
-                    "isError": "error" in result,
-                },
-            })
-        elif method == "notifications/initialized":
-            pass  # one-way notification, no response
-        elif msg_id is not None:
-            write_message({
-                "jsonrpc": "2.0",
-                "id": msg_id,
-                "error": {"code": -32601, "message": f"method not found: {method}"},
-            })
+def dispatch(name: str, args: dict) -> dict:
+    fn = DISPATCH.get(name)
+    if not fn:
+        return err(f"unknown tool: {name}")
+    return fn(args)
 
 
 if __name__ == "__main__":
-    serve()
+    serve("homebrain-vault", "0.2.0", TOOLS, dispatch)


### PR DESCRIPTION
## Summary

Cross-check of all 5 MCP servers found 3 alignment issues (one security) and 2 missing features. All changes keep the consent envelope contract compatible with openclaw/openclaw#78303.

### Commits

1. **refactor(vault-mcp): migrate to mcp_common, fix consent security**
   - Vault was the only server with its own `serve()`, `_audit()`, and raw dict responses
   - Migrated to `mcp_common.serve()`, `ok()`/`err()`/`unavailable()` envelopes, `audit()`
   - **Security fix**: old code had `if _CONSENT_OK:` fallback that silently skipped consent if `mcp_common` import failed (fail-open). Now a hard import (fail-safe: server won't start)
   - **Security fix**: `vault.reveal` (password exposure) had no consent gate — now consent-gated via #78303 envelope
   - Bumps vault 0.1.0 → 0.2.0

2. **fix(email-mcp): align account selection with HA/NC pattern**
   - Email used `_find(name)` requiring exact match — agent had to always specify account even for single-account setups
   - Added `_pick_account()` + `_account_or_err()` with single-account default and helpful multi-account error messages
   - `account` removed from `required` in all tool schemas

3. **feat(nc-mcp): add nc.notes_update** — PUT-based note editing, consent-gated. Bumps NC 0.2.0 → 0.3.0

4. **feat(email-mcp): add email.flag** — IMAP `\Flagged` toggle, consent-gated. Bumps email 0.1.0 → 0.2.0

## Server alignment after this PR

| Server | Version | Tools | Consent | Envelope | Wire | Account pattern |
|---|---|---|---|---|---|---|
| mcp-homeassistant | 0.4.0 | 11 | ✅ | ✅ ok/err | ✅ mcp_common | ✅ _account_or_err |
| mcp-nextcloud | 0.3.0 | 10 | ✅ | ✅ ok/err | ✅ mcp_common | ✅ _account_or_err |
| mcp-email | 0.2.0 | 8 | ✅ | ✅ ok/err | ✅ mcp_common | ✅ _account_or_err |
| mcp-vault | 0.2.0 | 5 | ✅ | ✅ ok/err | ✅ mcp_common | N/A (single vault) |
| mcp-homebrain | 0.1.0 | 7 | ✅ | ✅ ok/err | ✅ mcp_common | N/A (self-tool) |

## Test plan

- [ ] `vault.reveal` returns consent envelope on first call, executes after confirmation_token
- [ ] `vault.create_login` still works (consent flow unchanged, just fail-safe now)
- [ ] `vault.search` returns `ok()` envelope (not raw dict)
- [ ] `email.list_unread` works without `account` param on single-account setup
- [ ] `email.flag` flags/unflags a message
- [ ] `nc.notes_update` edits an existing note
- [ ] All servers start cleanly under OpenClaw

🤖 Generated with [Claude Code](https://claude.com/claude-code)