### PR TITLE
fix: apostrophe in jq comment breaks update, add venv rsync exclude

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -97,6 +97,7 @@ rsync -a --delete \
 --exclude='docker-compose.override.yml' \
 --exclude='.git' \
 --exclude='version.json' \
+--exclude='venv' \
 "$TEMP_DIR/extract/" "$INSTALL_DIR/" || { log_error "Rsync failed"; exit 1; }
 
 # Update pinned deps when versions.json changed in this release

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1200,7 +1200,7 @@ patch_openclaw_config() {
         # behind the session, so dropping device-identity here does
         # not weaken our auth posture — it just unblocks the LAN flow.
         .gateway.controlUi.allowInsecureAuth = true |
-        # MCP consent gate: disabled by default so HomeBrain's MCP servers
+        # MCP consent gate: disabled by default so the HomeBrain MCP servers
         # work on stock OpenClaw without our upstream PR. The top-level
         # approvals config is pre-wired for when the PR lands — flip
         # mcp.approvals.enabled to true and channel users get /approve


### PR DESCRIPTION
## Summary
- **Root cause**: Single quote in `HomeBrain's` (utilities.sh:1203) terminated the single-quoted jq filter string mid-expression, causing `jq` to receive a truncated filter → syntax error → `set -e` abort before `install_python_venv_deps` ran
- **Impact**: After rsync deleted the venv (as expected), the script died before recreating it — leaving the manager service unable to start (exit code 203/EXEC: gunicorn binary not found)
- **Fix 1**: Replace `HomeBrain's` → `the HomeBrain` in the jq filter comment
- **Fix 2**: Add `--exclude='venv'` to the rsync `--delete` in update.sh so a mid-update crash can never destroy the running Python environment

## Test plan
- [x] Verified fix on production target (192.168.178.58): venv recreated, service running, login returns 200
- [x] Hotfixed the apostrophe on target so next update won't re-trigger
- [ ] Merge → trigger beta update from dashboard to confirm full update cycle passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)