### PR TITLE
docs: remove CLI mention from backup bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ One command installs it. A browser wizard configures it. You own the whole thing
 - **Your messenger becomes the interface** — the agent doubles as a de facto tunnel into your home stack. Ask it for a file and it sends it. Ask it to turn off the lights and it does. No VPN, no port forwarding, no app to install — just message it. For most day-to-day use, the Pangolin tunnel is optional.
 - **One-command setup** — bootstrap, configure through a browser wizard, reboot. That's it.
 - **Encrypted remote access** — for full web UI access to Nextcloud, Home Assistant, and Vault from outside your network, Pangolin tunnels everything end-to-end through your own infrastructure. No static IP, no middleman.
-- **Full backup & restore** — scheduled snapshots with configurable retention, covering Nextcloud files, Home Assistant config, Vault, and AI agent memory. Restore from the dashboard in one click — or from the CLI on a fresh machine. External drive detection built in.
+- **Full backup & restore** — scheduled snapshots with configurable retention, covering Nextcloud files, Home Assistant config, Vault, and AI agent memory. Restore from the dashboard in one click. External drive detection built in.
 
 ---
 


### PR DESCRIPTION
## Summary
- Drop "or from the CLI on a fresh machine" — HomeBrain is dashboard-only, no SSH required

🤖 Generated with [Claude Code](https://claude.com/claude-code)