### PR TITLE
feat(channels): Telegram/WhatsApp pairing approval from dashboard

### DIFF
--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1287,7 +1287,8 @@ setup_openclaw() {
 
     local needs_npm_install=true
     if command -v openclaw >/dev/null 2>&1 \
-       && [[ "$installed_oc_version" == "$OPENCLAW_VERSION" ]]; then
+       && [[ "$installed_oc_version" == "$OPENCLAW_VERSION" ]] \
+       && openclaw --version >/dev/null 2>&1; then
         log_info "OpenClaw already at ${OPENCLAW_VERSION}. Skipping npm install."
         needs_npm_install=false
     fi

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -1458,6 +1458,29 @@ def register_integrations(app, limiter) -> None:  # noqa: C901
             "bot_username": validation.get("bot_username", ""),
         })
 
+    def telegram_pair():
+        if not session.get("authenticated"):
+            return jsonify({"error": "unauthenticated"}), 401
+        body = request.get_json(silent=True) or {}
+        code = (body.get("code") or "").strip().upper()
+        if not code or len(code) < 4 or len(code) > 16:
+            return jsonify({"error": "Invalid pairing code"}), 400
+        try:
+            proc = subprocess.run(
+                ["sudo", "-u", "homebrain", "openclaw",
+                 "pairing", "approve", "telegram", code, "--notify"],
+                capture_output=True, text=True, timeout=15,
+            )
+            if proc.returncode == 0:
+                return jsonify({"status": "approved", "output": proc.stdout.strip()})
+            return jsonify({
+                "error": (proc.stderr or proc.stdout or "Approval failed").strip(),
+            }), 400
+        except subprocess.TimeoutExpired:
+            return jsonify({"error": "Pairing approval timed out"}), 504
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
     def telegram_remove():
         if not session.get("authenticated"):
             return jsonify({"error": "unauthenticated"}), 401
@@ -1494,6 +1517,29 @@ def register_integrations(app, limiter) -> None:  # noqa: C901
         )
         return jsonify(result)
 
+    def whatsapp_pair():
+        if not session.get("authenticated"):
+            return jsonify({"error": "unauthenticated"}), 401
+        body = request.get_json(silent=True) or {}
+        code = (body.get("code") or "").strip().upper()
+        if not code or len(code) < 4 or len(code) > 16:
+            return jsonify({"error": "Invalid pairing code"}), 400
+        try:
+            proc = subprocess.run(
+                ["sudo", "-u", "homebrain", "openclaw",
+                 "pairing", "approve", "whatsapp", code, "--notify"],
+                capture_output=True, text=True, timeout=15,
+            )
+            if proc.returncode == 0:
+                return jsonify({"status": "approved", "output": proc.stdout.strip()})
+            return jsonify({
+                "error": (proc.stderr or proc.stdout or "Approval failed").strip(),
+            }), 400
+        except subprocess.TimeoutExpired:
+            return jsonify({"error": "Pairing approval timed out"}), 504
+        except Exception as e:
+            return jsonify({"error": str(e)}), 500
+
     def whatsapp_remove():
         if not session.get("authenticated"):
             return jsonify({"error": "unauthenticated"}), 401
@@ -1507,6 +1553,10 @@ def register_integrations(app, limiter) -> None:  # noqa: C901
                      "telegram_add",
                      limiter.limit("5 per minute")(telegram_add),
                      methods=["POST"])
+    app.add_url_rule("/api/channels/telegram/pair",
+                     "telegram_pair",
+                     limiter.limit("10 per minute")(telegram_pair),
+                     methods=["POST"])
     app.add_url_rule("/api/channels/telegram/remove",
                      "telegram_remove", telegram_remove, methods=["POST"])
     app.add_url_rule("/api/channels/whatsapp/add",
@@ -1517,6 +1567,10 @@ def register_integrations(app, limiter) -> None:  # noqa: C901
                      methods=["POST"])
     app.add_url_rule("/api/channels/whatsapp/qr/wait",
                      "whatsapp_qr_wait", whatsapp_qr_wait, methods=["POST"])
+    app.add_url_rule("/api/channels/whatsapp/pair",
+                     "whatsapp_pair",
+                     limiter.limit("10 per minute")(whatsapp_pair),
+                     methods=["POST"])
     app.add_url_rule("/api/channels/whatsapp/remove",
                      "whatsapp_remove", whatsapp_remove, methods=["POST"])
 

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -971,6 +971,54 @@ def _validate_telegram_token(token: str) -> dict:
         return {"ok": False, "error": str(e)}
 
 
+def _clean_openclaw_error(stderr: str, stdout: str) -> str:
+    """Distil a user-facing message from OpenClaw CLI error output.
+
+    The CLI prints boilerplate around the actual cause, e.g.:
+        [openclaw] Could not start the CLI.
+        [openclaw] Reason: No pending pairing request found for code "X".
+        [openclaw] Debug: set OPENCLAW_DEBUG=1 ...
+        [openclaw] Try: openclaw doctor
+    Prefer the "Reason:" line; otherwise fall back to the first meaningful
+    line, then to the raw text.
+    """
+    text = (stderr or stdout or "").strip()
+    for line in text.splitlines():
+        line = line.strip()
+        marker = "Reason:"
+        if marker in line:
+            return line.split(marker, 1)[1].strip()
+    for line in text.splitlines():
+        line = line.strip()
+        if line and "Could not start the CLI" not in line:
+            return line.removeprefix("[openclaw]").strip()
+    return text or "Approval failed"
+
+
+def _approve_pairing(channel: str, code: str) -> tuple[dict, int]:
+    """Run `openclaw pairing approve <channel> <code>` as the homebrain user.
+
+    Returns (json_body, http_status). Shared by the Telegram and WhatsApp
+    pairing endpoints.
+    """
+    code = (code or "").strip().upper()
+    if not code or not (4 <= len(code) <= 16) or not code.isalnum():
+        return {"error": "Invalid pairing code"}, 400
+    try:
+        proc = subprocess.run(
+            ["sudo", "-u", "homebrain", "openclaw",
+             "pairing", "approve", channel, code, "--notify"],
+            capture_output=True, text=True, timeout=15,
+        )
+    except subprocess.TimeoutExpired:
+        return {"error": "Pairing approval timed out"}, 504
+    except Exception as e:  # pragma: no cover - defensive
+        return {"error": str(e)}, 500
+    if proc.returncode == 0:
+        return {"status": "approved", "output": proc.stdout.strip()}, 200
+    return {"error": _clean_openclaw_error(proc.stderr, proc.stdout)}, 400
+
+
 def _whatsapp_auth_status() -> dict:
     """Check WhatsApp auth state by looking for session files."""
     auth_dir = os.path.join(OPENCLAW_DIR, "whatsapp-auth", "default")
@@ -1462,24 +1510,8 @@ def register_integrations(app, limiter) -> None:  # noqa: C901
         if not session.get("authenticated"):
             return jsonify({"error": "unauthenticated"}), 401
         body = request.get_json(silent=True) or {}
-        code = (body.get("code") or "").strip().upper()
-        if not code or len(code) < 4 or len(code) > 16:
-            return jsonify({"error": "Invalid pairing code"}), 400
-        try:
-            proc = subprocess.run(
-                ["sudo", "-u", "homebrain", "openclaw",
-                 "pairing", "approve", "telegram", code, "--notify"],
-                capture_output=True, text=True, timeout=15,
-            )
-            if proc.returncode == 0:
-                return jsonify({"status": "approved", "output": proc.stdout.strip()})
-            return jsonify({
-                "error": (proc.stderr or proc.stdout or "Approval failed").strip(),
-            }), 400
-        except subprocess.TimeoutExpired:
-            return jsonify({"error": "Pairing approval timed out"}), 504
-        except Exception as e:
-            return jsonify({"error": str(e)}), 500
+        payload, status = _approve_pairing("telegram", body.get("code", ""))
+        return jsonify(payload), status
 
     def telegram_remove():
         if not session.get("authenticated"):
@@ -1521,24 +1553,8 @@ def register_integrations(app, limiter) -> None:  # noqa: C901
         if not session.get("authenticated"):
             return jsonify({"error": "unauthenticated"}), 401
         body = request.get_json(silent=True) or {}
-        code = (body.get("code") or "").strip().upper()
-        if not code or len(code) < 4 or len(code) > 16:
-            return jsonify({"error": "Invalid pairing code"}), 400
-        try:
-            proc = subprocess.run(
-                ["sudo", "-u", "homebrain", "openclaw",
-                 "pairing", "approve", "whatsapp", code, "--notify"],
-                capture_output=True, text=True, timeout=15,
-            )
-            if proc.returncode == 0:
-                return jsonify({"status": "approved", "output": proc.stdout.strip()})
-            return jsonify({
-                "error": (proc.stderr or proc.stdout or "Approval failed").strip(),
-            }), 400
-        except subprocess.TimeoutExpired:
-            return jsonify({"error": "Pairing approval timed out"}), 504
-        except Exception as e:
-            return jsonify({"error": str(e)}), 500
+        payload, status = _approve_pairing("whatsapp", body.get("code", ""))
+        return jsonify(payload), status
 
     def whatsapp_remove():
         if not session.get("authenticated"):

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -961,6 +961,19 @@
                     </small>
                 </div>
 
+                <div hidden id="details-telegram-pair" class="conn-form">
+                    <div style="display:grid; grid-template-columns: 1fr; gap:8px;">
+                        <input type="text" id="tg-pair-code" placeholder="Pairing code (e.g. U43BU8JG)" style="text-transform:uppercase;" onkeydown="if (event.key === 'Enter') { event.preventDefault(); channelTelegramPair(); }">
+                    </div>
+                    <div style="margin-top:8px; display:flex; gap:8px;">
+                        <button class="btn-primary" onclick="channelTelegramPair()">Approve</button>
+                        <button onclick="closeForm('details-telegram-pair')" aria-label="Close">&times;</button>
+                    </div>
+                    <small style="display:block; margin-top:6px; color:var(--text-dim);">
+                        Send any message to your bot on Telegram. It will reply with a pairing code &mdash; paste it above to approve.
+                    </small>
+                </div>
+
                 <div hidden id="details-whatsapp" class="conn-form">
                     <div id="wa-qr-container" style="text-align:center; padding:12px 0;">
                         <p id="wa-qr-msg" style="color:var(--text-dim); margin:0 0 8px;">Generating QR code&hellip;</p>
@@ -971,6 +984,19 @@
                     </div>
                     <small style="display:block; margin-top:8px; color:var(--text-dim); text-align:center;">
                         Open <strong>WhatsApp</strong> on your phone &rarr; <strong>Linked Devices</strong> &rarr; <strong>Link a Device</strong> &rarr; scan this QR.
+                    </small>
+                </div>
+
+                <div hidden id="details-whatsapp-pair" class="conn-form">
+                    <div style="display:grid; grid-template-columns: 1fr; gap:8px;">
+                        <input type="text" id="wa-pair-code" placeholder="Pairing code" style="text-transform:uppercase;" onkeydown="if (event.key === 'Enter') { event.preventDefault(); channelWhatsAppPair(); }">
+                    </div>
+                    <div style="margin-top:8px; display:flex; gap:8px;">
+                        <button class="btn-primary" onclick="channelWhatsAppPair()">Approve</button>
+                        <button onclick="closeForm('details-whatsapp-pair')" aria-label="Close">&times;</button>
+                    </div>
+                    <small style="display:block; margin-top:6px; color:var(--text-dim);">
+                        Send any message to your agent on WhatsApp. If it replies with a pairing code, paste it above to approve.
                     </small>
                 </div>
             </div>
@@ -1441,6 +1467,7 @@
                         if (!ch.configured) {
                             buttons.push(`<button class="btn-primary" onclick="openDetails('details-telegram','tg-token')">Link&hellip;</button>`);
                         } else {
+                            buttons.push(`<button class="btn-primary" onclick="openDetails('details-telegram-pair','tg-pair-code')">Pair&hellip;</button>`);
                             buttons.push(`<button onclick="channelRemove('telegram')">Unlink</button>`);
                         }
                     }
@@ -1449,6 +1476,7 @@
                             buttons.push(`<button class="btn-primary" onclick="channelWhatsAppLink()">Link&hellip;</button>`);
                         } else {
                             buttons.push(`<button onclick="channelWhatsAppLink()">Re-link&hellip;</button>`);
+                            buttons.push(`<button onclick="openDetails('details-whatsapp-pair','wa-pair-code')">Pair&hellip;</button>`);
                             buttons.push(`<button onclick="channelRemove('whatsapp')">Unlink</button>`);
                         }
                     }
@@ -1482,6 +1510,52 @@
                     document.getElementById('tg-token').value = '';
                 } else {
                     msg.innerText = d.error || 'Failed';
+                }
+            } catch (e) { msg.innerText = 'Error: ' + e; }
+            channelRefresh();
+        }
+
+        async function channelTelegramPair() {
+            const code = document.getElementById('tg-pair-code').value.trim();
+            if (!code) return;
+            const msg = document.getElementById('channel-msg');
+            msg.innerText = 'Approving pairing...';
+            try {
+                const r = await fetch('/api/channels/telegram/pair', {
+                    method: 'POST', credentials: 'include',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ code }),
+                });
+                const d = await r.json();
+                if (r.ok) {
+                    msg.innerText = 'Paired! You can now chat with your agent on Telegram.';
+                    closeForm('details-telegram-pair');
+                    document.getElementById('tg-pair-code').value = '';
+                } else {
+                    msg.innerText = d.error || 'Pairing failed';
+                }
+            } catch (e) { msg.innerText = 'Error: ' + e; }
+            channelRefresh();
+        }
+
+        async function channelWhatsAppPair() {
+            const code = document.getElementById('wa-pair-code').value.trim();
+            if (!code) return;
+            const msg = document.getElementById('channel-msg');
+            msg.innerText = 'Approving pairing...';
+            try {
+                const r = await fetch('/api/channels/whatsapp/pair', {
+                    method: 'POST', credentials: 'include',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ code }),
+                });
+                const d = await r.json();
+                if (r.ok) {
+                    msg.innerText = 'Paired! You can now chat with your agent on WhatsApp.';
+                    closeForm('details-whatsapp-pair');
+                    document.getElementById('wa-pair-code').value = '';
+                } else {
+                    msg.innerText = d.error || 'Pairing failed';
                 }
             } catch (e) { msg.innerText = 'Error: ' + e; }
             channelRefresh();


### PR DESCRIPTION
## Problem

After linking Telegram (bot token) or WhatsApp from the dashboard, OpenClaw's `dmPolicy=pairing` still gates inbound DMs. Chatting with the agent returned **"OpenClaw: access not configured"** plus a pairing code, with the only documented way to approve being the `openclaw pairing approve` CLI — not self-service from the dashboard.

A secondary failure: on the fork-build target, `/usr/local/bin/openclaw` pointed at a cleaned-up dev path, so the CLI (and thus any pairing approval) was silently broken while `command -v openclaw` still succeeded.

## Changes

- **`/api/channels/{telegram,whatsapp}/pair`** — auth-gated, rate-limited (10/min) endpoints that run `openclaw pairing approve <channel> <code> --notify` as the `homebrain` user. Input is validated (alphanumeric, 4–16 chars); no `shell=True`; channel is a hardcoded literal.
- Shared `_approve_pairing()` + `_clean_openclaw_error()` helpers so both channels use one code path and the user sees only OpenClaw's `Reason:` line instead of CLI boilerplate.
- **Dashboard UI** — "Pair…" button on configured Telegram/WhatsApp rows, opening a pairing-code form with `channelTelegramPair()` / `channelWhatsAppPair()`.
- **`setup_openclaw()`** now probes `openclaw --version` (not just `command -v`) before skipping reinstall, so a broken CLI wrapper triggers a clean npm reinstall.

## E2E verification (live on .58)

- Login → `/api/channels/status` → 200, both channels configured.
- Bad/too-short and non-alphanumeric codes → 400 `Invalid pairing code`.
- Well-formed code with no pending request → 400 with clean single-line reason.
- Unauthenticated → 401.
- Real Telegram pairing approved; sender persisted to `credentials/telegram-default-allowFrom.json`; agent now replies on Telegram.
- Deployed dashboard serves all pairing UI elements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)