### PR TITLE
docs(readme): fix Quickstart order and clarify HomeCloud is arch-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The same codebase, two runtime profiles — detected automatically:
 
 | | **HomeBrain** | **HomeCloud** |
 |---|---|---|
-| Target | x86_64 + AMD GPU | Raspberry Pi 4/5 or any x86 box |
+| Target | x86_64 + AMD GPU | Architecture-agnostic (ARM or x86_64) |
 | AI stack | Full (LLM + whisper + OpenClaw) | — |
 | Cloud + smart home | Nextcloud · Home Assistant · Vault | Nextcloud · Home Assistant · Vault |
 | Tunnel | Optional — agent on messenger covers most remote use | Optional |
@@ -68,7 +68,7 @@ If there's a GPU, you get a personal AI agent. If there isn't, you still get a p
 
 Inference runs on Vulkan via Mesa RADV — no ROCm install required. ~29 tok/s generation, ~750 tok/s prompt processing at 131K context. See [BENCHMARKS.md](docs/BENCHMARKS.md).
 
-**HomeCloud** — Raspberry Pi 5 (8 GB) with an SSD, or any lightweight x86 mini-PC.
+**HomeCloud** — architecture-agnostic; runs on ARM or x86_64. Reference build: Raspberry Pi 5 (8 GB) with an SSD, running Raspberry Pi OS (Trixie, 64-bit).
 
 ---
 
@@ -78,14 +78,17 @@ Inference runs on Vulkan via Mesa RADV — no ROCm install required. ~29 tok/s g
 # 1. Bootstrap (Ubuntu 24.04+ / RPi OS 64-bit)
 curl -fsSL https://raw.githubusercontent.com/oalterg/HomeBrain/main/install | sudo bash
 
-# 2. Open the setup wizard in your browser
-#    http://<server-ip>
+# 2. Provision the device
+sudo /opt/homebrain/scripts/provision.sh
 
 # 3. Reboot
 sudo reboot
+
+# 4. Open the setup wizard in your browser to finish guided setup
+#    http://<server-ip>
 ```
 
-The wizard walks you through deployment mode (LAN or tunnel), passwords, and model selection. For headless installs, `provision.sh` accepts everything as arguments — see [Installation docs](#headless-provisioning) below.
+After the reboot, the browser wizard walks you through deployment mode (LAN or tunnel), passwords, and model selection. For headless installs, `provision.sh` accepts everything as arguments — see [Installation docs](#headless-provisioning) below.
 
 ### Headless Provisioning
 


### PR DESCRIPTION
## What

Two README corrections, no code changes.

### 1. Quickstart sequence
The setup-wizard step was listed *before* the reboot, and the `provision.sh` step was missing. Corrected to the actual flow:

1. Bootstrap (`curl … | sudo bash`)
2. Provision (`sudo /opt/homebrain/scripts/provision.sh`)
3. Reboot
4. Open the browser wizard for guided setup

### 2. HomeCloud architecture
HomeCloud was described as x86-leaning. It's architecture-agnostic (ARM or x86_64). Updated the Editions table target and the Reference Hardware line; reference build is RPi 5 + Raspberry Pi OS (Trixie, 64-bit).

## Verification
- All document references in the README cross-checked: every linked file (`docs/BENCHMARKS.md`, `config/versions.json`, `docs/ROADMAP.md`, `docs/TESTING.md`, `AGENTS.md`, `LICENSE`) exists, and the `#headless-provisioning` anchor matches its heading.
- `/opt/homebrain` path matches `INSTALL_DIR` in the bootstrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)