### PR TITLE
perf(ai): enable 35B MTP via llama.cpp b9381 (+31% structured TG); fix 27B MTP cliff

### DIFF
--- a/config/platform_models.json
+++ b/config/platform_models.json
@@ -1,6 +1,22 @@
 {
-  "default": "Qwen3.6-35B-A3B-UD-Q5_K_XL",
+  "default": "Qwen3.6-35B-A3B-MTP-UD-Q5_K_XL",
   "models": [
+    {
+      "id": "Qwen3.6-35B-A3B-MTP-UD-Q5_K_XL",
+      "filename": "Qwen3.6-35B-A3B-MTP-UD-Q5_K_XL.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF/resolve/main/Qwen3.6-35B-A3B-MTP-UD-Q5_K_XL.gguf",
+      "min_size_bytes": 26000000000,
+      "context_window": 131072,
+      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --presence-penalty 1.5 --reasoning-budget 8192 -b 4096 -ub 2048 --threads 6 --spec-type draft-mtp --spec-draft-n-max 2 --chat-template-kwargs '{\"preserve_thinking\": true}'",
+      "benchmark": {
+        "tg_ts": 37.7,
+        "tg_ts_prose": 28.5,
+        "pp_ts": 575,
+        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan + RADV_PERFTEST=rm_kq=1, llama.cpp b9381, MTP n_max=2, q8 KV, -ub 2048, ctx 131072, full prod samplers, whisper resident",
+        "notes": "Default. MTP speculative decoding via b9381 (upstream fix for MoE MTP at high ctx — b9186 could not do this). +31% real TG on structured/code/tool output (28.8 -> 37.7), ~neutral on creative prose (28.5). Requires -ub 2048 (not 4096): -ub 4096 + MTP OOMs (vk::DeviceLostError). Stable at 16205/16304 MiB VRAM with whisper resident (~99 MiB headroom). Trades ~24% PP (751 -> 575) for the TG gain. Rollback: switch to Qwen3.6-35B-A3B-UD-Q5_K_XL. See docs/BENCHMARKS.md."
+      },
+      "default": true
+    },
     {
       "id": "Qwen3.6-35B-A3B-UD-Q4_K_M",
       "filename": "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
@@ -41,7 +57,7 @@
         "pp_ts": 751,
         "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan + RADV_PERFTEST=rm_kq=1, llama.cpp b8996"
       },
-      "default": true
+      "default": false
     },
     {
       "id": "Qwen3.6-35B-A3B-UD-Q6_K",
@@ -91,13 +107,13 @@
       "filename": "Qwen3.6-27B-IQ4_XS.gguf",
       "url": "https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF/resolve/main/Qwen3.6-27B-IQ4_XS.gguf",
       "min_size_bytes": 15000000000,
-      "context_window": 49152,
+      "context_window": 32768,
       "extra_flags": "-ngl 99 --parallel 1 --jinja -fa on --cache-type-k q4_0 --cache-type-v q4_0 -t 6 -b 4096 -ub 2048 --temp 1.0 --top-k 20 --top-p 0.95 --min-p 0 --spec-type draft-mtp --spec-draft-n-max 2 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
-        "tg128_ts": 25.55,
-        "pp512_ts": 435,
-        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, DDR4, Vulkan + RADV_PERFTEST=rm_kq=1, llama.cpp b9186, ngl=99, MTP n_max=2",
-        "notes": "Hybrid DeltaNet SSM+attn (16/64 standard attn layers, 48 DeltaNet). RS must stay GPU-local — nkvo breaks DeltaNet fused kernel (garbage output). ngl<99 drops to ~2 t/s; partial offload defeats DeltaNet GPU fusion. ctv/ctk with fa is mandatory on AMD Vulkan. Phase-3 ctx sweep with q4_0 KV: 32K/40K/48K all hold peak TG ~17.17 t/s; 56K throttles (-2.4%); 64K is the -13% cliff. Phase-4 MTP (b9186 PR #22673, unsloth MTP-GGUF with draft head): n_max=2 lifts TG from 17.24 to 25.55 t/s (+48.2%) with 61.9% draft acceptance, all three interleaved baselines stable at 17.21-17.26. n_max=3 ~25.14 (+45.9%); n_max=4 23.23 (+34.7%); n_max=6 collapses to 10.56 (-39%). --spec-draft-p-split and --spec-draft-n-min are no-ops for draft-mtp (verified)."
+        "tg128_ts": 30.0,
+        "pp512_ts": 430,
+        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, DDR4, Vulkan + RADV_PERFTEST=rm_kq=1, llama.cpp b9186/b9381, ngl=99, MTP n_max=2, ctx 32768",
+        "notes": "Hybrid DeltaNet SSM+attn (16/64 standard attn layers, 48 DeltaNet). RS must stay GPU-local — nkvo breaks DeltaNet fused kernel (garbage output). ngl<99 drops to ~2 t/s; partial offload defeats DeltaNet GPU fusion. ctv/ctk with fa is mandatory on AMD Vulkan. MTP CLIFF: the draft-mtp speculative path accelerates ONLY at ctx <= ~34816 (cliff between 34816 and 36864); above it TG snaps back to the ~17.5 baseline. ctx was 49152 (over the cliff, MTP gave ~+2%); lowered to 32768 to capture the full MTP gain: ~17.1 -> ~30 t/s (+75%) with n_max=2, q4_0 KV. Crossing any of {ctx>~35K, n_max>=3, q8 KV} silently disables speculation. NOT fixed by b9381 (DeltaNet-specific; the MoE 35B cliff WAS fixed by b9381). See docs/BENCHMARKS.md '27B cliff localization'."
       },
       "default": false
     }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "llama_cpp": {
-    "tag": "b9186",
-    "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9186/llama-b9186-bin-ubuntu-vulkan-x64.tar.gz"
+    "tag": "b9381",
+    "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9381/llama-b9381-bin-ubuntu-vulkan-x64.tar.gz"
   },
   "whisper_cpp": {
     "git_ref": "v1.8.4"

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -9,7 +9,7 @@
 | RAM       | 32 GB DDR4 |
 | Backend   | Vulkan (RADV / GFX1200) |
 | OS        | Ubuntu 24.04 (x86_64) |
-| llama.cpp | b8996 (upgraded from b8951; non-Q5_K_XL/Q4 rows in this table still measured on b8951) |
+| llama.cpp | **b9186** in production (history: b8951 → b8996 → b9186; the Results-table rows below were measured on b8951/b8996). b9297 and b9381 evaluated 2026-05-28 — see version + MTP sections. |
 | RADV env  | `RADV_PERFTEST=rm_kq=1` (set via systemd drop-in) |
 | Mesa      | 25.2.8 (Ubuntu 25.10) |
 | Kernel    | Linux 6.17 |
@@ -167,6 +167,8 @@ Hardware: RX 9060 XT + Ryzen 5 5600, Vulkan + RADV_PERFTEST=rm_kq=1, llama.cpp b
 
 Three interleaved baselines (17.21 / 17.25 / 17.26) and two n=3 reruns (both 25.14) confirm stability. Adopted **n_max=2** in `platform_models.json`.
 
+> **⚠️ Correction (2026-05-28):** The two conclusions below ("27B win" and "35B MTP net negative") were both measured *at one fixed context per model* and are now known to be context-dependent artifacts. The 27B "+48%" figure was taken below the MTP context cliff; the 35B "net negative" sweep was run entirely at production ctx=131072, above it. See [MTP re-investigation — the context-size cliff](#mtp-re-investigation--the-context-size-cliff-b9186-2026-05-28) for the corrected picture. The raw numbers in the two tables below are still valid *at the context they were measured at*; the generalized verdicts are not.
+
 ### 35B-A3B (MoE) — MTP is net negative in every config
 
 Cross-product of quant × CPU-expert-offload depth × KV cache, with and without MTP n=2. Each row is the mean of 3 runs; baselines were re-measured between MTP runs to control for thermal drift.
@@ -200,3 +202,167 @@ Cross-product of quant × CPU-expert-offload depth × KV cache, with and without
 - 27B IQ4_XS: switch to MTP-GGUF + `--spec-type draft-mtp --spec-draft-n-max 2`. Stored as Phase-4 in `platform_models.json`.
 - 35B-A3B (all quants): **do not enable MTP.** Keep current configs.
 - llama.cpp tag bumped to b9186 in `versions.json` (first tagged release with the merged PR).
+
+## MTP re-investigation — the context-size cliff (b9186, 2026-05-28)
+
+Follow-up to the question: *can MTP be enhanced by sweeping `--spec-draft-n-max`, or is VRAM-headroom pressure holding it below the unsloth-advertised speedup?* And separately: *does 35B-A3B Q5_K_XL MTP really never help?*
+
+Method: `scripts/bench-upgrade.sh` — for each cell, restart llama-server clean (waiting for VRAM to drain <500 MiB), warm up, then 3× deterministic 512-token `/completion` probes with a raw chat-template prompt (bypasses thinking mode), reading `timings.predicted_per_second`. Server flags held at production-realistic `-fa on --cache-type-k q4_0 --cache-type-v q4_0 -t 6 -b 4096 -ub 2048`. Same hardware, b9186, docker stack up.
+
+### Answer 1 — it is NOT VRAM headroom. It is a context-size cliff.
+
+27B-MTP (n=2, predictable prompt), context swept while everything else held constant:
+
+| ctx | TG (t/s) | VRAM used | Headroom |
+|----:|---------:|----------:|---------:|
+| 8K  | **29.89** | 16,032 | 272 MiB |
+| 16K | **29.96** | 15,884 | 420 MiB |
+| 32K | **29.96** | 16,222 | **82 MiB** |
+| 49K (prod) | **17.45** | 15,722 | **582 MiB** |
+
+This kills the VRAM-pressure hypothesis outright: the **32K cell ran at the tightest headroom of the whole sweep (82 MiB) yet held full speed (29.96)**, while the 49K cell had *7× more* headroom (582 MiB) and collapsed to 17.45. More free VRAM, worse throughput — the opposite of a headroom effect. The break is a hard cliff somewhere between 32K and 49K of allocated context.
+
+### Answer 2 — n_max sweeping can't rescue a cell that's already over the cliff.
+
+27B-MTP n_max sweep, all at the production ctx=49152 (predictable prompt):
+
+| `--spec-draft-n-max` | TG (t/s) |
+|---|---:|
+| 1 | 15.89 |
+| 2 | 17.43 |
+| 3 | 16.81 |
+| 4 | 16.77 |
+
+Everything sits in the 16–17 band — no n_max value recovers the lost speed, because the limiter is the context the verify pass runs over, not the draft depth. (Below the cliff the n_max curve from the original sweep still applies: n=2 is the sweet spot, n≥6 collapses.)
+
+### Why the production 27B sees almost no MTP benefit
+
+Production runs the 27B at **ctx=49152 — above the cliff.** Re-measuring base vs MTP n=2 at that exact context, across prompt types:
+
+| Prompt | Base | MTP n=2 | Δ |
+|--------|-----:|--------:|---:|
+| predictable | 17.15 | 17.50 | +2.0% |
+| code        | 17.14 | 18.71 | +9.2% |
+| creative    | 17.14 | 16.27 | −5.1% |
+
+Net ≈ break-even. The original sweep's "+48% (25.55 t/s)" was real but measured *below* the cliff; at the shipped 49K context the MTP head is essentially dead weight (and slightly negative on unpredictable output). **The +75% that MTP can deliver only materializes at ctx≤32K** (17.15 base → ~29.96 with MTP).
+
+### Answer 3 — 35B-A3B Q5_K_XL MTP DOES help, below the cliff
+
+The earlier "MTP net negative in every config" sweep was run entirely at production ctx=131072. Re-run at ctx=32768 (Q5_K_XL, `-ot blk.20-39`, q4 KV, predictable prompt):
+
+| Config | TG (t/s) | Δ vs base |
+|--------|---------:|----------:|
+| base       | 28.65 | — |
+| MTP n=2    | 34.76 | **+21.3%** |
+| MTP n=3    | 36.13 | **+26.1%** |
+
+Same offload, same KV, same prompt as the negative rows in the prior section — the *only* change is context (131K → 32K), and MTP flips from −2.5% to +26%. So the prior "MoE architecture defeats MTP / CPU-expert step is serial" hypothesis was wrong: **it was the context, not the MoE.** Below the cliff, MTP helps the 35B too, and unlike the 27B it keeps climbing to n=3.
+
+### Unifying conclusion
+
+> **Update (later same day):** the conclusion in this paragraph holds **on b9186**, but the 35B half of it was a llama.cpp bug, not a hardware limit. On **b9381** the MoE cliff is gone and 35B MTP scales to 131K (+31% in production). The DeltaNet 27B cliff is real and remains on b9381. See [b9381 fixes MoE MTP](#b9381-fixes-moe-mtp--the-flagship-gets-31-2026-05-28). Read the paragraph below as the b9186 picture.
+
+On b9186, MTP speedup is **gated by allocated context length, not by VRAM headroom and not by dense-vs-MoE architecture.** Below ~32K context, MTP delivers large gains on both models (27B +75%, 35B +26%); at the contexts we actually ship (27B 49K, 35B 131K) the speculative verify pass — whose cost scales with sequence length (DeltaNet SSM state for the 27B, attention for the 35B) — eats the draft savings and MTP regresses to break-even or worse. Tuning `--spec-draft-n-max` only moves the needle *below* the cliff; over it, no draft-depth setting helps. (The 35B "attention" half of this turned out to be the fixable bug; the 27B DeltaNet half is genuine.)
+
+### Actionable implications (not yet applied)
+
+- **27B IQ4_XS:** ships `--spec-type draft-mtp --spec-draft-n-max 2` at ctx=49152 — i.e. it pays for the MTP GGUF and gets ≈+2% for it (49152 is over the cliff). Dropping `context_window` 49152 → 32768 (keeping n_max=2 + q4 KV) unlocks **+75% TG (17.1 → ~30 t/s)** at the cost of 16K context. For the home-automation agent 32K is likely ample; **worth a decision.** Do **not** also raise n_max or switch to q8 KV — either change re-crosses the speculative ceiling and collapses TG back to ~17. If 49K context must stay, MTP buys nothing there and the plain IQ4_XS GGUF would do. See [27B cliff localization & parameter tuning](#27b-cliff-localization--parameter-tuning-b9186-2026-05-28).
+- **35B-A3B:** *(superseded — this was the b9186 finding)* On b9186 MTP only paid off at ctx≤32K. On **b9381 the cliff is fixed** and MTP gives +31% at the full 131K production context — see [b9381 fixes MoE MTP](#b9381-fixes-moe-mtp--the-flagship-gets-31-2026-05-28). The flagship default should move to b9381 + MTP-GGUF + n=2 + `-ub 2048` (pending sign-off).
+
+### 27B cliff localization & parameter tuning (b9186, 2026-05-28)
+
+Follow-up: locate the cliff precisely and find the params that maximize TG at the maximum context that still accelerates. Script: `scripts/bench-27b-cliff.sh` (Pass 1 = ctx sweep, Pass 2 = edge + tuning). All cells MTP, predictable prompt, 3 runs.
+
+**Pass 1 — where does it break?** (MTP n=2, q4 KV, ub2048)
+
+| ctx | TG (t/s) | headroom | |
+|----:|---------:|---------:|--|
+| 32768 | **29.99** | 118 MiB | accelerated |
+| 33792 | **29.96** | 85 MiB | accelerated |
+| 34816 | **29.92** | 58 MiB | accelerated |
+| 36864 | 17.52 | 93 MiB | **collapsed → baseline** |
+| 40960 | 17.47 | 737 MiB | collapsed |
+| 45056 | 17.49 | 661 MiB | collapsed |
+| 49152 | 17.47 | 584 MiB | collapsed |
+
+The cliff sits **between 34816 and 36864 tokens**. Past it, MTP TG snaps to the plain-baseline ~17.5 t/s (27B base measured 17.1 at ctx=40960 — i.e. MTP gives essentially nothing over the cliff). Headroom is irrelevant: the collapsed 40K–49K cells had 6–8× more free VRAM than the still-accelerated 34816 cell.
+
+**Pass 2 — tuning at/below the cliff**
+
+| Config (ctx=32768 unless noted) | TG (t/s) | Note |
+|---|---:|---|
+| n_max=1 | 25.67 | underspeculates |
+| **n_max=2** | **29.99** | **optimal** |
+| n_max=3 | 16.91 | **collapsed** |
+| n_max=4 | 16.78 | collapsed |
+| n=2, KV q8_0 | 17.21 | **collapsed** — q8 KV kills acceleration |
+| n=3, KV q8_0 | 16.87 | collapsed |
+| n=3, code prompt | 19.80 | (n=3 already collapsed; realistic-prompt sanity) |
+
+**Mechanism.** The acceleration is governed by a **fixed speculative budget** that is consumed jointly by (context length) + (draft depth `n_max`) + (KV-cache bytes-per-token). Cross any of the three thresholds and llama.cpp silently stops speculating and falls back to plain autoregressive decode (~17.5 t/s):
+- raising ctx past ~35K (at n=2, q4) → collapse;
+- raising n_max to ≥3 (at ctx=32768, q4) → collapse;
+- switching KV q4→q8 (which doubles cache bytes, at ctx=32768, n=2) → collapse.
+
+This unifies every "cliff" observation: it is not VRAM headroom, not the MoE-vs-dense split, and not prompt content — it is a single allocation ceiling. **The fast operating point is the corner just under that ceiling: ctx ≤ ~34816, n_max=2, KV q4_0** → ~30 t/s (+75% over the 17.1 baseline). For a round, comfortably-margined production value use **ctx=32768**.
+
+### Version check — b9186 vs b9297 vs b9381 (latest)
+
+Two newer releases were A/B'd against the shipped b9186 under server-realistic, production-identical flags (`scripts/bench-version.sh`, same harness as the production rows: TG = 256-tok gen on a short prompt, PP = ~1.5k-tok prompt). b9186 baselines reproduce the documented production figures (35B 29.15 TG, 27B 17.13 TG), confirming the harness.
+
+| Build | 35B Q5_K_XL (ctx 131K, prod) | 27B IQ4_XS (ctx 49K, prod) |
+|---|---|---|
+| | TG / PP | TG / PP |
+| b9186 (shipped) | 29.15 / 599 | 17.13 / 430 |
+| **b9381 (latest)** | 29.41 / 584 | 17.20 / 428 |
+| Δ | **+0.9% / −2.5%** | **+0.4% / −0.4%** |
+
+- b9297 (built to `~/bench-upgrade/b9297/`) showed the same flat picture — the movement seen in an earlier llama-bench-only pass did not translate to server throughput.
+- **For the *vanilla* (non-MTP) path, b9381 is performance-neutral**: every delta is inside run-to-run noise (TG stdev ≤ 0.1).
+
+**But this is not the whole story.** b9381 also *fixes MoE MTP at high context* — a change that is worth far more than any vanilla delta. See [b9381 fixes MoE MTP — the flagship gets +31%](#b9381-fixes-moe-mtp--the-flagship-gets-31-2026-05-28) below. The version decision turns on whether we want that win, not on vanilla throughput. The latest binary is staged at `~/bench-upgrade/b9381/`.
+
+## b9381 fixes MoE MTP — the flagship gets +31% (2026-05-28)
+
+Re-running the MTP experiment on the latest binary (b9381) instead of b9186 changes the 35B conclusion completely. **The "MTP context cliff" for the MoE model was a llama.cpp bug, fixed upstream between b9186 and b9381.** On b9381 the 35B-A3B has *no cliff through 131K*:
+
+| ctx | base (b9381, q4/ub2048, greedy) | MTP n=2 | MTP n=3 |
+|----:|--------------------------------:|--------:|--------:|
+| 32768 | 29.17 | 34.43 (+18%) | 35.21 (+21%) |
+| 49152 | 29.38 | 39.03 (+33%) | 35.17 (+20%) |
+| **131072** | 29.37 | **38.81 (+32%)** | 34.97 (+19%) |
+
+Compare b9186, where 35B MTP at 131K was *negative*. The DeltaNet **27B is not fixed** — on b9381 it still collapses past ~35K (MTP n=2 @ 49152 = 18 t/s, and PP even degrades to ~55 t/s). So the upstream fix is specific to the MoE/attention speculative path, not the DeltaNet SSM path.
+
+### Deployable production config (validated, production-faithful)
+
+The numbers above are greedy (max acceptance, q4 KV). Production runs **q8 KV, `-ub 4096`, and `temp=1.0`** sampling. Re-measured under the *exact* production flags on b9381 (3 runs, real = the prod sampler with `presence_penalty 1.5` on a natural code-gen prompt):
+
+| Config (ctx 131072, prod samplers) | greedy TG | **real TG** | VRAM | Δ real |
+|---|---:|---:|---:|---:|
+| base, q8, `-ub 4096` | 28.81 | 28.71 | 15470 | — |
+| MTP n=2, q8, **`-ub 4096`** | — | — | — | **OOM** (`vk::DeviceLostError`) |
+| base, q8, `-ub 2048` | 28.94 | 28.81 | 15604 | — |
+| **MTP n=2, q8, `-ub 2048`** | 42.93 | **37.70** | 16202 | **+30.9%** |
+| base, q4, `-ub 2048` | 28.71 | 28.62 | 15984 | — |
+| MTP n=2, q4, `-ub 2048` | 43.02 | 36.81 | 16210 | +28.6% |
+| MTP n=3, q4, `-ub 2048` | 42.26 | 31.46 | 16021 | +9.9%¹ |
+
+¹ n=3 wins on greedy but loses on the real sampler — at `temp=1.0` the deeper draft's acceptance drops faster than the extra-token payoff. **n=2 is optimal in production.**
+
+**Findings**
+- MTP at the *current* production config (q8 + `-ub 4096`) **OOMs** — the MTP draft head needs ~600 MiB that the `-ub 4096` compute buffer is already using. Dropping to **`-ub 2048` frees exactly enough** and keeps q8 KV (best numerics). Fits at 16202 / 16304 MiB.
+- **Net win: 28.81 → 37.70 t/s real (+31%) on the flagship at full 131K context** on *structured/code/tool* output, with one model swap + two flag changes. Greedy upper bound is +48%.
+- **Gain is workload-dependent.** MTP acceptance tracks output predictability: high on code/JSON/tool-calls (the agent's bread-and-butter, +20–31%), but on free-form *prose* a live test generated at **28.5 t/s ≈ base** (≈neutral). MTP never regressed below base in any test — so this is a win-or-neutral change, weighted toward the agent's typical structured traffic.
+- `-ub 2048` vs `-ub 4096` costs ~24% PP on long prompts (≈751 → ≈575 t/s, per the tuning log). For a generation-bound agent the TG gain dominates; for prompt-heavy batch use weigh the PP loss.
+- **VRAM verified, not just projected.** Measured live with the full stack (whisper resident — which itself uses only ~56 MiB on GPU) under sustained generation: **16205 / 16304 MiB, rock-stable, no spikes (≈99 MiB headroom)**. KV is pre-allocated at ctx=131072 so it does not grow at runtime. No `vk::DeviceLostError`. The earlier "~500 MiB whisper" alarm was a one-off transcription compute spike, not resident footprint.
+
+### Production change (applied 2026-05-29)
+
+Applied to capture the flagship win:
+- `versions.json`: `llama_cpp.tag` **b9186 → b9381**.
+- `platform_models.json`: **added** model `Qwen3.6-35B-A3B-MTP-UD-Q5_K_XL` (MTP GGUF, `--spec-type draft-mtp --spec-draft-n-max 2`, `-ub 2048`, q8 KV, `-ot blk.20-39`, ctx 131072, full samplers) and made it the default. The base `Qwen3.6-35B-A3B-UD-Q5_K_XL` entry is **kept** so rollback is a single `/api/ai/model/switch` back to it (no version revert needed).
+- `platform_models.json`: 27B `Qwen3.6-27B-IQ4_XS` `context_window` **49152 → 32768** to bring it under the DeltaNet MTP cliff (+75% TG when 27B is selected). b9381 does **not** fix the DeltaNet cliff — that change is the b9186 analysis and stands.
+
+Deployed via the manager update path (pulls `main`, installs b9381, restarts) + a model switch to the MTP entry. Rollback path: `POST /api/ai/model/switch {"model_id":"Qwen3.6-35B-A3B-UD-Q5_K_XL"}`.

--- a/scripts/bench-27b-cliff.sh
+++ b/scripts/bench-27b-cliff.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# 27B MTP cliff localization + tuning
+# Pass 1: fine ctx sweep to locate where MTP acceleration cuts out (between 32K and 49K)
+# Pass 2 (PASS=2): tune KV-type / -ub / n_max around the located cliff
+set +e
+
+PASS="${1:-1}"
+LLAMA_DIR="$HOME/ai-runtime/llama-server"
+BENCH_DIR="$HOME/bench-upgrade"
+MODEL_DIR="$HOME/models"
+PORT=8099
+RESULTS="$BENCH_DIR/cliff-pass${PASS}.jsonl"
+
+MTP_27B="$MODEL_DIR/Qwen3.6-27B-MTP-IQ4_XS.gguf"
+BASE_27B="$MODEL_DIR/Qwen3.6-27B-IQ4_XS.gguf"
+
+VRAM_PATH=""
+for p in /sys/class/drm/card1/device/mem_info_vram_used /sys/class/drm/card0/device/mem_info_vram_used; do
+    [ -f "$p" ] && VRAM_PATH="$p" && break
+done
+
+log() { echo "[$(date +%H:%M:%S)] $*"; }
+vram_mb() { echo $(( $(cat "$VRAM_PATH") / 1048576 )); }
+
+mkdir -p "$BENCH_DIR"
+> "$RESULTS"
+
+stop_all() {
+    pkill -x llama-server 2>/dev/null || true
+    sleep 3
+    pkill -9 -x llama-server 2>/dev/null || true
+    sleep 2
+    local i=0
+    while [ "$(vram_mb)" -gt 500 ] && [ "$i" -lt 25 ]; do sleep 1; i=$((i+1)); done
+}
+
+# Predictable probe (high MTP acceptance) — reuse existing if present
+PROBE="$BENCH_DIR/probe_predictable.json"
+if [ ! -f "$PROBE" ]; then
+python3 -c "
+import json
+print(json.dumps({
+    'prompt': '<|im_start|>user\nRepeat the following pattern exactly 100 times: apple banana cherry dog elephant frog grape hat ice jam kite lemon mango nest orange pear queen rose sun tree umbrella vine water xray yak zebra<|im_end|>\n<|im_start|>assistant\n',
+    'n_predict': 512, 'temperature': 0.0, 'top_p': 1.0, 'cache_prompt': False
+}))
+" > "$PROBE"
+fi
+
+probe() {
+    local resp
+    resp=$(curl -sf --max-time 180 -H "Content-Type: application/json" -d @"$PROBE" \
+        "http://127.0.0.1:$PORT/completion" 2>/dev/null)
+    [ -z "$resp" ] && { echo "0 0"; return 1; }
+    python3 -c "
+import sys, json
+r = json.loads(sys.stdin.read())
+t = r.get('timings', {})
+tg = t.get('predicted_per_second', 0)
+n = t.get('predicted_n', 0)
+print(f'{tg} {n}')
+" <<< "$resp" 2>/dev/null || echo "0 0"
+}
+
+run_cell() {
+    local label="$1" model="$2" ctx="$3" kv="$4" ub="$5"; shift 5
+    local extra=("$@")
+    stop_all
+    log "--- $label | ctx=$ctx kv=$kv ub=$ub ${extra[*]} ---"
+    RADV_PERFTEST=rm_kq=1 "$LLAMA_DIR/llama-server" \
+        --model "$model" --ctx-size "$ctx" \
+        --host 127.0.0.1 --port "$PORT" --parallel 1 -ngl 99 \
+        -fa on --cache-type-k "$kv" --cache-type-v "$kv" \
+        -t 6 -b 4096 -ub "$ub" "${extra[@]}" \
+        > "$BENCH_DIR/server.log" 2>&1 &
+    local pid=$! i=0
+    while [ "$i" -lt 200 ]; do
+        kill -0 "$pid" 2>/dev/null || { log "  DIED"; tail -3 "$BENCH_DIR/server.log"; return 1; }
+        curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 && break
+        sleep 1; i=$((i+1))
+    done
+    [ "$i" -ge 200 ] && { log "  TIMEOUT"; kill "$pid" 2>/dev/null; return 1; }
+    local vram=$(vram_mb)
+    log "  Healthy (${i}s, VRAM ${vram} MiB, headroom $((16304 - vram)) MiB)"
+    curl -sf --max-time 60 -H "Content-Type: application/json" -d @"$PROBE" \
+        "http://127.0.0.1:$PORT/completion" >/dev/null 2>&1
+    local tg_vals=""
+    for run in 1 2 3; do
+        read tg_ts tg_n <<< "$(probe)"
+        log "    Run $run: $tg_ts t/s ($tg_n tok)"
+        tg_vals="$tg_vals $tg_ts"
+    done
+    python3 -c "
+import json, statistics
+vals=[float(x) for x in '$tg_vals'.split() if float(x)>0]
+r={'label':'$label','ctx':$ctx,'kv':'$kv','ub':$ub,'vram_mb':$vram,'headroom_mb':$((16304-vram)),
+   'tg_avg':round(statistics.mean(vals),2) if vals else 0,
+   'tg_stdev':round(statistics.stdev(vals),2) if len(vals)>1 else 0,'runs':len(vals)}
+open('$RESULTS','a').write(json.dumps(r)+'\n')
+print(f\"  => {r['tg_avg']:.2f} ± {r['tg_stdev']:.2f} t/s (headroom {r['headroom_mb']} MiB)\")
+"
+    kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+}
+
+log "27B MTP cliff investigation — PASS $PASS (b9186)"
+
+if [ "$PASS" = "1" ]; then
+    # Locate the cliff: fine ctx sweep, MTP n=2, q4 KV, ub2048
+    for ctx in 32768 36864 40960 45056 49152; do
+        run_cell "MTP-n2-c${ctx}" "$MTP_27B" "$ctx" q4_0 2048 --spec-type draft-mtp --spec-draft-n-max 2
+    done
+    # Base sanity at the cliff zone (expect ~17 flat)
+    run_cell "base-c40960" "$BASE_27B" 40960 q4_0 2048
+else
+    # PASS 2 — cliff is at exactly 32768 (Pass 1). Pin the edge + tune for max perf at/below it.
+    # (A) Edge: does ANY ctx between 32768 and 36864 still accelerate?
+    run_cell "MTP-n2-c33792" "$MTP_27B" 33792 q4_0 2048 --spec-type draft-mtp --spec-draft-n-max 2
+    run_cell "MTP-n2-c34816" "$MTP_27B" 34816 q4_0 2048 --spec-type draft-mtp --spec-draft-n-max 2
+    # (B) n_max sweep at 32768 (never tested BELOW the cliff before; 35B liked n=3)
+    run_cell "MTP-n1-c32768" "$MTP_27B" 32768 q4_0 2048 --spec-type draft-mtp --spec-draft-n-max 1
+    run_cell "MTP-n3-c32768" "$MTP_27B" 32768 q4_0 2048 --spec-type draft-mtp --spec-draft-n-max 3
+    run_cell "MTP-n4-c32768" "$MTP_27B" 32768 q4_0 2048 --spec-type draft-mtp --spec-draft-n-max 4
+    # (C) KV q8 at 32768 — better attention numerics; does it still fit and hold speed?
+    run_cell "MTP-n2-c32768-q8" "$MTP_27B" 32768 q8_0 2048 --spec-type draft-mtp --spec-draft-n-max 2
+    run_cell "MTP-n3-c32768-q8" "$MTP_27B" 32768 q8_0 2048 --spec-type draft-mtp --spec-draft-n-max 3
+    # (D) realistic prompt at best config (code) — predictable is upper bound
+    PROBE="$BENCH_DIR/probe_code.json"
+    run_cell "MTP-n3-c32768-code" "$MTP_27B" 32768 q4_0 2048 --spec-type draft-mtp --spec-draft-n-max 3
+    PROBE="$BENCH_DIR/probe_predictable.json"
+fi
+
+log "Results in $RESULTS"
+python3 -c "
+import json
+rows=[json.loads(l) for l in open('$RESULTS')]
+print('| Label | Ctx | KV | ub | TG | Headroom |')
+print('|---|--:|--|--:|--:|--:|')
+for r in rows:
+    print(f\"| {r['label']} | {r['ctx']} | {r['kv']} | {r['ub']} | {r['tg_avg']:.2f} ± {r['tg_stdev']:.2f} | {r['headroom_mb']} |\")
+"
+
+# Restart production (sweep killed it)
+log "Restarting production 35B Q5_K_XL..."
+stop_all
+RADV_PERFTEST=rm_kq=1 nohup "$LLAMA_DIR/llama-server" \
+    --model "$MODEL_DIR/Qwen3.6-35B-A3B-UD-Q5_K_XL.gguf" \
+    --ctx-size 131072 --host 127.0.0.1 --port 8001 \
+    --parallel 1 --jinja -ngl 99 \
+    -ot "blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU" \
+    -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 \
+    --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 \
+    --presence-penalty 1.5 --reasoning-budget 8192 \
+    -b 4096 -ub 4096 --threads 6 \
+    --chat-template-kwargs '{"preserve_thinking": true}' \
+    > /tmp/llama-server-restart.log 2>&1 &
+log "Production restarting (PID $!). Done."

--- a/scripts/bench-35b-mtp-fit.sh
+++ b/scripts/bench-35b-mtp-fit.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Find a DEPLOYABLE 35B MTP config at ctx=131072 on b9381 (q8+ub4096 OOMs).
+# Tries q8/ub2048 (best numerics) and q4/ub2048 (known to fit). Greedy + real (temp=1.0) TG.
+set +e
+BENCH_DIR="$HOME/bench-upgrade"; MODEL_DIR="$HOME/models"; PORT=8099
+RESULTS="$BENCH_DIR/mtp35b-fit.jsonl"; BIN="$BENCH_DIR/b9381/llama-b9381"
+BASE_35B="$MODEL_DIR/Qwen3.6-35B-A3B-UD-Q5_K_XL.gguf"
+MTP_35B="$MODEL_DIR/Qwen3.6-35B-A3B-MTP-UD-Q5_K_XL.gguf"
+VRAM_PATH=/sys/class/drm/card1/device/mem_info_vram_used
+[ -f "$VRAM_PATH" ] || VRAM_PATH=/sys/class/drm/card0/device/mem_info_vram_used
+log() { echo "[$(date +%H:%M:%S)] $*"; }
+vram_mb() { echo $(( $(cat "$VRAM_PATH") / 1048576 )); }
+mkdir -p "$BENCH_DIR"; > "$RESULTS"
+stop_all() { pkill -x llama-server 2>/dev/null||true; sleep 3; pkill -9 -x llama-server 2>/dev/null||true; sleep 2; local i=0; while [ "$(vram_mb)" -gt 500 ]&&[ "$i" -lt 25 ]; do sleep 1; i=$((i+1)); done; }
+
+GREEDY="$BENCH_DIR/probe_greedy35.json"; REAL="$BENCH_DIR/probe_real35.json"
+[ -f "$GREEDY" ] || python3 -c "import json;print(json.dumps({'prompt':'<|im_start|>user\nList the integers from 1 to 200 separated by commas.<|im_end|>\n<|im_start|>assistant\n','n_predict':512,'temperature':0.0,'top_p':1.0,'cache_prompt':False}))" > "$GREEDY"
+[ -f "$REAL" ] || python3 -c "import json;print(json.dumps({'prompt':'<|im_start|>user\nWrite a detailed Python module that implements a thermostat controller with hysteresis, scheduling, and a small test suite. Include docstrings.<|im_end|>\n<|im_start|>assistant\n','n_predict':512,'cache_prompt':False}))" > "$REAL"
+
+measure() { local resp; resp=$(curl -sf --max-time 240 -H "Content-Type: application/json" -d @"$1" "http://127.0.0.1:$PORT/completion" 2>/dev/null); [ -z "$resp" ]&&{ echo "0 0"; return 1; }; python3 -c "
+import sys,json; r=json.loads(sys.stdin.read()); t=r.get('timings',{}); print(f\"{t.get('predicted_per_second',0)} {t.get('predicted_n',0)}\")" <<< "$resp" 2>/dev/null||echo "0 0"; }
+
+run_cell() {
+    local label="$1" model="$2" kv="$3" ub="$4"; shift 4; local spec=("$@")
+    stop_all; log "--- $label | kv=$kv ub=$ub ${spec[*]} ---"
+    RADV_PERFTEST=rm_kq=1 "$BIN/llama-server" --model "$model" --ctx-size 131072 \
+        --host 127.0.0.1 --port "$PORT" --parallel 1 --jinja -ngl 99 \
+        -ot "blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU" -fa on \
+        --cache-type-k "$kv" --cache-type-v "$kv" \
+        --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --presence-penalty 1.5 \
+        --reasoning-budget 8192 -b 4096 -ub "$ub" --threads 6 \
+        --chat-template-kwargs '{"preserve_thinking": true}' "${spec[@]}" \
+        > "$BENCH_DIR/server.log" 2>&1 &
+    local pid=$! i=0
+    while [ "$i" -lt 240 ]; do
+        kill -0 "$pid" 2>/dev/null || { log "  DIED (likely OOM)"; grep -iE "DeviceLost|alloc|out of|error" "$BENCH_DIR/server.log"|tail -2; \
+            python3 -c "open('$RESULTS','a').write('{\"label\":\"$label\",\"kv\":\"$kv\",\"ub\":$ub,\"status\":\"DIED\"}\n')"; return 1; }
+        curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 && break
+        sleep 1; i=$((i+1))
+    done
+    [ "$i" -ge 240 ]&&{ log "  TIMEOUT"; kill "$pid" 2>/dev/null; return 1; }
+    local vram=$(vram_mb); log "  Healthy (${i}s, VRAM ${vram} MiB, headroom $((16304-vram)))"
+    curl -sf --max-time 240 -d @"$GREEDY" "http://127.0.0.1:$PORT/completion" >/dev/null 2>&1
+    local g_vals="" r_vals=""
+    for run in 1 2 3; do
+        read g _ <<< "$(measure "$GREEDY")"; read r _ <<< "$(measure "$REAL")"
+        log "    run $run: greedy=$g real=$r"; g_vals="$g_vals $g"; r_vals="$r_vals $r"
+    done
+    python3 -c "
+import json,statistics
+g=[float(x) for x in '$g_vals'.split() if float(x)>0]; r=[float(x) for x in '$r_vals'.split() if float(x)>0]
+o={'label':'$label','kv':'$kv','ub':$ub,'vram_mb':$vram,
+   'greedy_avg':round(statistics.mean(g),2) if g else 0,'greedy_sd':round(statistics.stdev(g),2) if len(g)>1 else 0,
+   'real_avg':round(statistics.mean(r),2) if r else 0,'real_sd':round(statistics.stdev(r),2) if len(r)>1 else 0}
+open('$RESULTS','a').write(json.dumps(o)+'\n')
+print(f\"  => greedy {o['greedy_avg']:.2f} real {o['real_avg']:.2f} (VRAM {$vram})\")"
+    kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+}
+
+log "35B MTP deployable-config search (b9381, ctx131072, prod samplers)"
+# q8 KV at ub2048 — does freeing the compute buffer let MTP fit with best numerics?
+run_cell "base-q8-ub2048"  "$BASE_35B" q8_0 2048
+run_cell "MTPn2-q8-ub2048" "$MTP_35B"  q8_0 2048 --spec-type draft-mtp --spec-draft-n-max 2
+# q4 KV at ub2048 — known to fit; confirm real gain + n3
+run_cell "base-q4-ub2048"  "$BASE_35B" q4_0 2048
+run_cell "MTPn2-q4-ub2048" "$MTP_35B"  q4_0 2048 --spec-type draft-mtp --spec-draft-n-max 2
+run_cell "MTPn3-q4-ub2048" "$MTP_35B"  q4_0 2048 --spec-type draft-mtp --spec-draft-n-max 3
+
+log "========================================"
+python3 -c "
+import json
+rows=[json.loads(l) for l in open('$RESULTS')]
+print('| Config | greedy TG | real TG | VRAM | status |')
+print('|--|--:|--:|--:|--|')
+for r in rows:
+    if r.get('status')=='DIED': print(f\"| {r['label']} | — | — | — | OOM |\"); continue
+    print(f\"| {r['label']} | {r['greedy_avg']:.2f} | {r['real_avg']:.2f} | {r['vram_mb']} | ok |\")
+"
+log "Results in $RESULTS"
+log ""; log "Restarting production..."; stop_all
+RADV_PERFTEST=rm_kq=1 nohup "$HOME/ai-runtime/llama-server/llama-server" \
+    --model "$BASE_35B" --ctx-size 131072 --host 127.0.0.1 --port 8001 \
+    --parallel 1 --jinja -ngl 99 -ot "blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU" \
+    -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 \
+    --min-p 0.0 --presence-penalty 1.5 --reasoning-budget 8192 -b 4096 -ub 4096 --threads 6 \
+    --chat-template-kwargs '{"preserve_thinking": true}' > /tmp/llama-server-restart.log 2>&1 &
+log "Production restarting (PID $!). Done."

--- a/scripts/bench-35b-mtp-prod.sh
+++ b/scripts/bench-35b-mtp-prod.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Production-faithful confirmation: does 35B-A3B MTP help on b9381 with the REAL
+# production config (q8 KV, ub4096, -ot 20-39, ctx 131072, full prod samplers)?
+# Measures greedy (upper-bound acceptance) AND prod-sampler (realistic) TG.
+set +e
+
+BENCH_DIR="$HOME/bench-upgrade"
+MODEL_DIR="$HOME/models"
+PORT=8099
+RESULTS="$BENCH_DIR/mtp35b-prod.jsonl"
+BIN="$BENCH_DIR/b9381/llama-b9381"
+BASE_35B="$MODEL_DIR/Qwen3.6-35B-A3B-UD-Q5_K_XL.gguf"
+MTP_35B="$MODEL_DIR/Qwen3.6-35B-A3B-MTP-UD-Q5_K_XL.gguf"
+
+VRAM_PATH=""
+for p in /sys/class/drm/card1/device/mem_info_vram_used /sys/class/drm/card0/device/mem_info_vram_used; do
+    [ -f "$p" ] && VRAM_PATH="$p" && break
+done
+log() { echo "[$(date +%H:%M:%S)] $*"; }
+vram_mb() { echo $(( $(cat "$VRAM_PATH") / 1048576 )); }
+mkdir -p "$BENCH_DIR"; > "$RESULTS"
+stop_all() {
+    pkill -x llama-server 2>/dev/null || true; sleep 3
+    pkill -9 -x llama-server 2>/dev/null || true; sleep 2
+    local i=0; while [ "$(vram_mb)" -gt 500 ] && [ "$i" -lt 25 ]; do sleep 1; i=$((i+1)); done
+}
+
+# greedy probe (deterministic, max acceptance) — predictable pattern
+GREEDY="$BENCH_DIR/probe_greedy35.json"
+python3 -c "
+import json
+print(json.dumps({'prompt':'<|im_start|>user\nList the integers from 1 to 200 separated by commas.<|im_end|>\n<|im_start|>assistant\n',
+                  'n_predict':512,'temperature':0.0,'top_p':1.0,'cache_prompt':False}))
+" > "$GREEDY"
+# realistic probe — natural task, NO sampler override (uses server prod sampler temp=1.0 etc.)
+REAL="$BENCH_DIR/probe_real35.json"
+python3 -c "
+import json
+print(json.dumps({'prompt':'<|im_start|>user\nWrite a detailed Python module that implements a thermostat controller with hysteresis, scheduling, and a small test suite. Include docstrings.<|im_end|>\n<|im_start|>assistant\n',
+                  'n_predict':512,'cache_prompt':False}))
+" > "$REAL"
+
+measure() {
+    local probe="$1" resp
+    resp=$(curl -sf --max-time 240 -H "Content-Type: application/json" -d @"$probe" \
+        "http://127.0.0.1:$PORT/completion" 2>/dev/null)
+    [ -z "$resp" ] && { echo "0 0"; return 1; }
+    python3 -c "
+import sys, json
+r=json.loads(sys.stdin.read()); t=r.get('timings',{})
+print(f\"{t.get('predicted_per_second',0)} {t.get('predicted_n',0)}\")
+" <<< "$resp" 2>/dev/null || echo "0 0"
+}
+
+run_cell() {
+    local label="$1" model="$2"; shift 2
+    local spec=("$@")
+    stop_all
+    log "--- $label ${spec[*]} ---"
+    RADV_PERFTEST=rm_kq=1 "$BIN/llama-server" \
+        --model "$model" --ctx-size 131072 --host 127.0.0.1 --port "$PORT" \
+        --parallel 1 --jinja -ngl 99 -ot "blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU" \
+        -fa on --cache-type-k q8_0 --cache-type-v q8_0 \
+        --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 \
+        --presence-penalty 1.5 --reasoning-budget 8192 \
+        -b 4096 -ub 4096 --threads 6 \
+        --chat-template-kwargs '{"preserve_thinking": true}' \
+        "${spec[@]}" > "$BENCH_DIR/server.log" 2>&1 &
+    local pid=$! i=0
+    while [ "$i" -lt 240 ]; do
+        kill -0 "$pid" 2>/dev/null || { log "  DIED"; tail -6 "$BENCH_DIR/server.log"; \
+            python3 -c "open('$RESULTS','a').write('{\"label\":\"$label\",\"status\":\"DIED\"}\n')"; return 1; }
+        curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 && break
+        sleep 1; i=$((i+1))
+    done
+    [ "$i" -ge 240 ] && { log "  TIMEOUT"; kill "$pid" 2>/dev/null; return 1; }
+    local vram=$(vram_mb)
+    log "  Healthy (${i}s, VRAM ${vram} MiB)"
+    curl -sf --max-time 240 -d @"$GREEDY" "http://127.0.0.1:$PORT/completion" >/dev/null 2>&1
+    local g_vals="" r_vals=""
+    for run in 1 2 3; do
+        read g _ <<< "$(measure "$GREEDY")"
+        read r _ <<< "$(measure "$REAL")"
+        log "    run $run: greedy=$g  real=$r t/s"
+        g_vals="$g_vals $g"; r_vals="$r_vals $r"
+    done
+    # MTP acceptance from log
+    local acc; acc=$(grep -oiE 'accept[^ ]*[=: ][0-9.]+' "$BENCH_DIR/server.log" | tail -1)
+    [ -n "$acc" ] && log "    $acc"
+    python3 -c "
+import json, statistics
+g=[float(x) for x in '$g_vals'.split() if float(x)>0]
+r=[float(x) for x in '$r_vals'.split() if float(x)>0]
+o={'label':'$label','vram_mb':$vram,
+   'greedy_avg':round(statistics.mean(g),2) if g else 0,
+   'greedy_sd':round(statistics.stdev(g),2) if len(g)>1 else 0,
+   'real_avg':round(statistics.mean(r),2) if r else 0,
+   'real_sd':round(statistics.stdev(r),2) if len(r)>1 else 0}
+open('$RESULTS','a').write(json.dumps(o)+'\n')
+print(f\"  => greedy {o['greedy_avg']:.2f}  real {o['real_avg']:.2f}  (VRAM {$vram} MiB)\")
+"
+    kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+}
+
+log "35B MTP production-faithful confirmation (b9381, q8 KV, ub4096, ctx131072, prod samplers)"
+run_cell "base"     "$BASE_35B"
+run_cell "MTP-n2"   "$MTP_35B" --spec-type draft-mtp --spec-draft-n-max 2
+run_cell "MTP-n3"   "$MTP_35B" --spec-type draft-mtp --spec-draft-n-max 3
+run_cell "MTP-n4"   "$MTP_35B" --spec-type draft-mtp --spec-draft-n-max 4
+
+log "========================================"
+python3 -c "
+import json
+rows=[json.loads(l) for l in open('$RESULTS')]
+base_g=next((r['greedy_avg'] for r in rows if r.get('label')=='base'),0)
+base_r=next((r['real_avg'] for r in rows if r.get('label')=='base'),0)
+print('| Config | greedy TG | Δ | real TG | Δ | VRAM |')
+print('|--|--:|--:|--:|--:|--:|')
+for r in rows:
+    if r.get('status')=='DIED': print(f\"| {r['label']} | DIED | | | | |\"); continue
+    dg=f\"{(r['greedy_avg']-base_g)/base_g*100:+.1f}%\" if base_g else ''
+    dr=f\"{(r['real_avg']-base_r)/base_r*100:+.1f}%\" if base_r else ''
+    print(f\"| {r['label']} | {r['greedy_avg']:.2f} | {dg} | {r['real_avg']:.2f} | {dr} | {r['vram_mb']} |\")
+"
+log "Results in $RESULTS"
+
+# restart production (b9186, unchanged)
+log ""; log "Restarting production..."
+stop_all
+RADV_PERFTEST=rm_kq=1 nohup "$HOME/ai-runtime/llama-server/llama-server" \
+    --model "$BASE_35B" --ctx-size 131072 --host 127.0.0.1 --port 8001 \
+    --parallel 1 --jinja -ngl 99 -ot "blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU" \
+    -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 \
+    --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 \
+    --presence-penalty 1.5 --reasoning-budget 8192 \
+    -b 4096 -ub 4096 --threads 6 \
+    --chat-template-kwargs '{"preserve_thinking": true}' \
+    > /tmp/llama-server-restart.log 2>&1 &
+log "Production restarting (PID $!). Done."

--- a/scripts/bench-upgrade.sh
+++ b/scripts/bench-upgrade.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# MTP deep-dive: sweep n_max, prompts, VRAM headroom
+# Tests 27B-IQ4_XS MTP and 35B-A3B Q5_K_XL MTP
+
+set +e
+
+TAG="${1:-b9186}"
+LLAMA_DIR="$HOME/ai-runtime/llama-server"
+BENCH_DIR="$HOME/bench-upgrade"
+MODEL_DIR="$HOME/models"
+PORT=8099
+RESULTS="$BENCH_DIR/mtp-sweep.jsonl"
+
+VRAM_PATH=""
+for p in /sys/class/drm/card1/device/mem_info_vram_used /sys/class/drm/card0/device/mem_info_vram_used; do
+    [ -f "$p" ] && VRAM_PATH="$p" && break
+done
+
+log() { echo "[$(date +%H:%M:%S)] $*"; }
+vram_mb() { echo $(( $(cat "$VRAM_PATH") / 1048576 )); }
+
+mkdir -p "$BENCH_DIR"
+> "$RESULTS"
+
+stop_all() {
+    pkill -x llama-server 2>/dev/null || true
+    sleep 3
+    pkill -9 -x llama-server 2>/dev/null || true
+    sleep 2
+    local i=0
+    while [ "$(vram_mb)" -gt 500 ] && [ "$i" -lt 20 ]; do sleep 1; i=$((i+1)); done
+}
+
+# --- Generate probe files ---
+# Probe A: highly predictable (repetitive pattern) — should get HIGH acceptance
+python3 -c "
+import json
+print(json.dumps({
+    'prompt': '<|im_start|>user\nRepeat the following pattern exactly 100 times: apple banana cherry dog elephant frog grape hat ice jam kite lemon mango nest orange pear queen rose sun tree umbrella vine water xray yak zebra<|im_end|>\n<|im_start|>assistant\n',
+    'n_predict': 512, 'temperature': 0.0, 'top_p': 1.0, 'cache_prompt': False
+}))
+" > "$BENCH_DIR/probe_predictable.json"
+
+# Probe B: code (moderately predictable) — should get MEDIUM acceptance
+python3 -c "
+import json
+print(json.dumps({
+    'prompt': '<|im_start|>user\nWrite a Python function that implements merge sort with detailed comments on every line. Include a main block that tests it with a list of 50 random numbers.<|im_end|>\n<|im_start|>assistant\n',
+    'n_predict': 512, 'temperature': 0.0, 'top_p': 1.0, 'cache_prompt': False
+}))
+" > "$BENCH_DIR/probe_code.json"
+
+# Probe C: creative (unpredictable) — should get LOW acceptance
+python3 -c "
+import json
+print(json.dumps({
+    'prompt': '<|im_start|>user\nWrite an original short story about a detective who discovers their own reflection has been committing crimes. Make it surprising and unpredictable.<|im_end|>\n<|im_start|>assistant\n',
+    'n_predict': 512, 'temperature': 0.0, 'top_p': 1.0, 'cache_prompt': False
+}))
+" > "$BENCH_DIR/probe_creative.json"
+
+# --- Probe function using /completion (bypasses chat template + thinking) ---
+probe() {
+    local probe_file="$1"
+    local resp
+    resp=$(curl -sf --max-time 180 \
+        -H "Content-Type: application/json" \
+        -d @"$probe_file" \
+        "http://127.0.0.1:$PORT/completion" 2>/dev/null)
+
+    if [ -z "$resp" ]; then
+        echo "0 0 0"
+        return 1
+    fi
+
+    python3 -c "
+import sys, json
+r = json.loads(sys.stdin.read())
+t = r.get('timings', {})
+tg = t.get('predicted_per_second', 0)
+n = t.get('predicted_n', 0)
+# n_accepted from MTP stats if available
+print(f'{tg} {n}')
+" <<< "$resp" 2>/dev/null || echo "0 0"
+}
+
+# --- Start server and run probes ---
+run_cell() {
+    local label="$1" model="$2" ctx="$3" probe_name="$4" probe_file="$5"
+    shift 5
+    local extra_flags=("$@")
+
+    stop_all
+
+    log "--- $label | ctx=$ctx | probe=$probe_name ---"
+
+    local bin_dir="$LLAMA_DIR"
+
+    RADV_PERFTEST=rm_kq=1 "$bin_dir/llama-server" \
+        --model "$model" \
+        --ctx-size "$ctx" \
+        --host 127.0.0.1 --port "$PORT" \
+        --parallel 1 -ngl 99 \
+        -fa on --cache-type-k q4_0 --cache-type-v q4_0 \
+        -t 6 -b 4096 -ub 2048 \
+        "${extra_flags[@]}" \
+        > "$BENCH_DIR/server.log" 2>&1 &
+    local pid=$!
+
+    # Wait healthy
+    local i=0
+    while [ "$i" -lt 180 ]; do
+        kill -0 "$pid" 2>/dev/null || { log "  DIED"; tail -3 "$BENCH_DIR/server.log"; return 1; }
+        curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 && break
+        sleep 1; i=$((i+1))
+    done
+    [ "$i" -ge 180 ] && { log "  TIMEOUT"; kill "$pid" 2>/dev/null; return 1; }
+
+    local vram=$(vram_mb)
+    log "  Healthy (${i}s, VRAM: ${vram} MiB, headroom: $((16304 - vram)) MiB)"
+
+    # Warmup
+    curl -sf --max-time 60 \
+        -H "Content-Type: application/json" \
+        -d @"$probe_file" \
+        "http://127.0.0.1:$PORT/completion" >/dev/null 2>&1
+
+    # 3 measured runs
+    local tg_vals=""
+    for run in 1 2 3; do
+        read tg_ts tg_n <<< "$(probe "$probe_file")"
+        log "    Run $run: $tg_ts t/s ($tg_n tok)"
+        tg_vals="$tg_vals $tg_ts"
+    done
+
+    # Extract MTP acceptance from server log (if available)
+    local accept_info
+    accept_info=$(grep -o 'accept=[0-9.]*' "$BENCH_DIR/server.log" | tail -1 || echo "")
+    [ -n "$accept_info" ] && log "    MTP $accept_info"
+
+    # Summarize
+    python3 -c "
+import json, statistics
+vals = [float(x) for x in '$tg_vals'.split() if float(x) > 0]
+result = {
+    'label': '$label',
+    'probe': '$probe_name',
+    'ctx': $ctx,
+    'vram_mb': $vram,
+    'headroom_mb': $((16304 - vram)),
+    'tg_avg': round(statistics.mean(vals), 2) if vals else 0,
+    'tg_stdev': round(statistics.stdev(vals), 2) if len(vals) > 1 else 0,
+    'runs': len(vals)
+}
+with open('$RESULTS', 'a') as f:
+    f.write(json.dumps(result) + '\n')
+avg = result['tg_avg']
+sd = result['tg_stdev']
+print(f'  => {avg:.2f} ± {sd:.2f} t/s  (VRAM {$vram} MiB, headroom {$((16304 - vram))} MiB)')
+"
+
+    kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+}
+
+# ============================================================
+log "MTP Deep Dive (llama.cpp $TAG)"
+log "========================================"
+
+MTP_27B="$MODEL_DIR/Qwen3.6-27B-MTP-IQ4_XS.gguf"
+BASE_27B="$MODEL_DIR/Qwen3.6-27B-IQ4_XS.gguf"
+MTP_35B="$MODEL_DIR/Qwen3.6-35B-A3B-MTP-UD-Q5_K_XL.gguf"
+BASE_35B="$MODEL_DIR/Qwen3.6-35B-A3B-UD-Q5_K_XL.gguf"
+
+# ============================================================
+# PART 1: 27B — Prompt sweep (base vs MTP, 3 prompt types)
+# ============================================================
+log ""
+log "===== PART 1: 27B Prompt Sweep ====="
+
+for probe_name in predictable code creative; do
+    probe_file="$BENCH_DIR/probe_${probe_name}.json"
+
+    # Base (no MTP)
+    run_cell "27B-base" "$BASE_27B" 49152 "$probe_name" "$probe_file"
+
+    # MTP n=2
+    run_cell "27B-MTP-n2" "$MTP_27B" 49152 "$probe_name" "$probe_file" \
+        --spec-type draft-mtp --spec-draft-n-max 2
+done
+
+# ============================================================
+# PART 2: 27B — n_max sweep (best prompt from part 1)
+# ============================================================
+log ""
+log "===== PART 2: 27B n_max Sweep (predictable prompt) ====="
+
+for nmax in 1 2 3 4; do
+    run_cell "27B-MTP-n${nmax}" "$MTP_27B" 49152 "predictable" "$BENCH_DIR/probe_predictable.json" \
+        --spec-type draft-mtp --spec-draft-n-max "$nmax"
+done
+
+# ============================================================
+# PART 3: 27B — VRAM headroom sweep (ctx size)
+# ============================================================
+log ""
+log "===== PART 3: 27B VRAM Headroom (MTP n=2, predictable) ====="
+
+for ctx in 8192 16384 32768 49152; do
+    run_cell "27B-MTP-ctx${ctx}" "$MTP_27B" "$ctx" "predictable" "$BENCH_DIR/probe_predictable.json" \
+        --spec-type draft-mtp --spec-draft-n-max 2
+done
+
+# ============================================================
+# PART 4: 35B Q5_K_XL — MTP test
+# ============================================================
+log ""
+log "===== PART 4: 35B Q5_K_XL MTP ====="
+
+# Base
+run_cell "35B-base" "$BASE_35B" 32768 "predictable" "$BENCH_DIR/probe_predictable.json" \
+    -ot "blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU"
+
+# MTP n=2
+run_cell "35B-MTP-n2" "$MTP_35B" 32768 "predictable" "$BENCH_DIR/probe_predictable.json" \
+    -ot "blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU" \
+    --spec-type draft-mtp --spec-draft-n-max 2
+
+# MTP n=3
+run_cell "35B-MTP-n3" "$MTP_35B" 32768 "predictable" "$BENCH_DIR/probe_predictable.json" \
+    -ot "blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU" \
+    --spec-type draft-mtp --spec-draft-n-max 3
+
+# ============================================================
+# SUMMARY
+# ============================================================
+log ""
+log "========================================"
+log "Full results in $RESULTS"
+
+python3 << 'PYEOF'
+import json
+from collections import defaultdict
+
+with open("/home/homebrain/bench-upgrade/mtp-sweep.jsonl") as f:
+    rows = [json.loads(l) for l in f]
+
+print()
+print("| Label | Probe | Ctx | TG (t/s) | VRAM | Headroom |")
+print("|-------|-------|-----|----------|------|----------|")
+for r in rows:
+    print(f"| {r['label']:20s} | {r['probe']:12s} | {r['ctx']:5d} | {r['tg_avg']:6.2f} ± {r['tg_stdev']:4.2f} | {r['vram_mb']:5d} | {r['headroom_mb']:5d} |")
+print()
+
+# Compute MTP gains
+base_by_probe = {}
+for r in rows:
+    if 'base' in r['label'] and '27B' in r['label']:
+        base_by_probe[r['probe']] = r['tg_avg']
+
+print("27B MTP gains by prompt type:")
+for r in rows:
+    if 'MTP-n2' in r['label'] and '27B' in r['label'] and r['probe'] in base_by_probe:
+        base = base_by_probe[r['probe']]
+        if base > 0:
+            gain = ((r['tg_avg'] - base) / base) * 100
+            print(f"  {r['probe']:12s}: {base:.2f} → {r['tg_avg']:.2f} ({gain:+.1f}%)")
+PYEOF
+
+# --- Restart production ---
+log ""
+log "Restarting production..."
+stop_all
+
+Q5_XL="$MODEL_DIR/Qwen3.6-35B-A3B-UD-Q5_K_XL.gguf"
+RADV_PERFTEST=rm_kq=1 nohup "$LLAMA_DIR/llama-server" \
+    --model "$Q5_XL" \
+    --ctx-size 131072 --host 127.0.0.1 --port 8001 \
+    --parallel 1 --jinja -ngl 99 \
+    -ot "blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU" \
+    -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 \
+    --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 \
+    --presence-penalty 1.5 --reasoning-budget 8192 \
+    -b 4096 -ub 4096 --threads 6 \
+    --chat-template-kwargs '{"preserve_thinking": true}' \
+    > /tmp/llama-server-restart.log 2>&1 &
+
+log "Production restarting (PID $!). Done."

--- a/scripts/bench-version.sh
+++ b/scripts/bench-version.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Version A/B: b9186 (prod) vs b9381 (latest) on production-realistic configs.
+# Measures TG (short prompt, 256 tok) and PP@2k (long prompt). Plus 35B MTP re-test on b9381.
+set +e
+
+BENCH_DIR="$HOME/bench-upgrade"
+MODEL_DIR="$HOME/models"
+PORT=8099
+RESULTS="$BENCH_DIR/version-ab.jsonl"
+
+BASE_35B="$MODEL_DIR/Qwen3.6-35B-A3B-UD-Q5_K_XL.gguf"
+MTP_35B="$MODEL_DIR/Qwen3.6-35B-A3B-MTP-UD-Q5_K_XL.gguf"
+BASE_27B="$MODEL_DIR/Qwen3.6-27B-IQ4_XS.gguf"
+MTP_27B="$MODEL_DIR/Qwen3.6-27B-MTP-IQ4_XS.gguf"
+
+BIN_9186="$HOME/ai-runtime/llama-server"
+BIN_9381="$BENCH_DIR/b9381/llama-b9381"
+
+VRAM_PATH=""
+for p in /sys/class/drm/card1/device/mem_info_vram_used /sys/class/drm/card0/device/mem_info_vram_used; do
+    [ -f "$p" ] && VRAM_PATH="$p" && break
+done
+log() { echo "[$(date +%H:%M:%S)] $*"; }
+vram_mb() { echo $(( $(cat "$VRAM_PATH") / 1048576 )); }
+mkdir -p "$BENCH_DIR"; > "$RESULTS"
+
+stop_all() {
+    pkill -x llama-server 2>/dev/null || true; sleep 3
+    pkill -9 -x llama-server 2>/dev/null || true; sleep 2
+    local i=0; while [ "$(vram_mb)" -gt 500 ] && [ "$i" -lt 25 ]; do sleep 1; i=$((i+1)); done
+}
+
+# --- Probe files ---
+TG_PROBE="$BENCH_DIR/probe_predictable.json"   # short prompt, reused
+PP_PROBE="$BENCH_DIR/probe_pp2k.json"
+python3 -c "
+import json
+body = 'The home automation system manages lights, climate, security, and energy across many rooms. ' * 90
+print(json.dumps({'prompt': '<|im_start|>user\n'+body+'\nSummarize.<|im_end|>\n<|im_start|>assistant\n',
+                  'n_predict': 16, 'temperature': 0.0, 'top_p': 1.0, 'cache_prompt': False}))
+" > "$PP_PROBE"
+
+# measure: returns "tg_per_s pp_per_s prompt_n predicted_n"
+measure() {
+    local probe="$1" resp
+    resp=$(curl -sf --max-time 240 -H "Content-Type: application/json" -d @"$probe" \
+        "http://127.0.0.1:$PORT/completion" 2>/dev/null)
+    [ -z "$resp" ] && { echo "0 0 0 0"; return 1; }
+    python3 -c "
+import sys, json
+r = json.loads(sys.stdin.read()); t = r.get('timings', {})
+print(f\"{t.get('predicted_per_second',0)} {t.get('prompt_per_second',0)} {t.get('prompt_n',0)} {t.get('predicted_n',0)}\")
+" <<< "$resp" 2>/dev/null || echo "0 0 0 0"
+}
+
+run_cell() {
+    local tag="$1" bindir="$2" label="$3" model="$4" ctx="$5" kv="$6" ub="$7"; shift 7
+    local extra=("$@")
+    stop_all
+    log "--- [$tag] $label | ctx=$ctx kv=$kv ub=$ub ${extra[*]} ---"
+    RADV_PERFTEST=rm_kq=1 "$bindir/llama-server" \
+        --model "$model" --ctx-size "$ctx" --host 127.0.0.1 --port "$PORT" \
+        --parallel 1 -ngl 99 -fa on --cache-type-k "$kv" --cache-type-v "$kv" \
+        -t 6 -b 4096 -ub "$ub" "${extra[@]}" > "$BENCH_DIR/server.log" 2>&1 &
+    local pid=$! i=0
+    while [ "$i" -lt 240 ]; do
+        kill -0 "$pid" 2>/dev/null || { log "  DIED"; tail -4 "$BENCH_DIR/server.log"; return 1; }
+        curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 && break
+        sleep 1; i=$((i+1))
+    done
+    [ "$i" -ge 240 ] && { log "  TIMEOUT"; kill "$pid" 2>/dev/null; return 1; }
+    local vram=$(vram_mb)
+    log "  Healthy (${i}s, VRAM ${vram} MiB)"
+    # warmups
+    curl -sf --max-time 240 -H "Content-Type: application/json" -d @"$TG_PROBE" "http://127.0.0.1:$PORT/completion" >/dev/null 2>&1
+    curl -sf --max-time 240 -H "Content-Type: application/json" -d @"$PP_PROBE" "http://127.0.0.1:$PORT/completion" >/dev/null 2>&1
+    local tg_vals="" pp_vals=""
+    for run in 1 2 3; do
+        read tg _ _ _ <<< "$(measure "$TG_PROBE")"
+        read _ pp pn _ <<< "$(measure "$PP_PROBE")"
+        log "    run $run: TG=$tg t/s  PP=$pp t/s (pn=$pn)"
+        tg_vals="$tg_vals $tg"; pp_vals="$pp_vals $pp"
+    done
+    python3 -c "
+import json, statistics
+tg=[float(x) for x in '$tg_vals'.split() if float(x)>0]
+pp=[float(x) for x in '$pp_vals'.split() if float(x)>0]
+r={'tag':'$tag','label':'$label','ctx':$ctx,'kv':'$kv','ub':$ub,'vram_mb':$vram,
+   'tg_avg':round(statistics.mean(tg),2) if tg else 0,
+   'tg_stdev':round(statistics.stdev(tg),2) if len(tg)>1 else 0,
+   'pp_avg':round(statistics.mean(pp),1) if pp else 0,
+   'pp_stdev':round(statistics.stdev(pp),1) if len(pp)>1 else 0}
+open('$RESULTS','a').write(json.dumps(r)+'\n')
+print(f\"  => TG {r['tg_avg']:.2f}  PP {r['pp_avg']:.1f}  (VRAM {$vram} MiB)\")
+"
+    kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+}
+
+log "Version A/B + 35B MTP re-test"
+log "============================="
+
+# ===== Version A/B on production-realistic configs (no MTP) =====
+for spec in "b9186:$BIN_9186" "b9381:$BIN_9381"; do
+    tag="${spec%%:*}"; bin="${spec#*:}"
+    log ""
+    log "===== $tag — production configs ====="
+    # 35B Q5_K_XL production config (ctx 131072, q8 KV, -ot 20-39, ub4096)
+    run_cell "$tag" "$bin" "35B-Q5KXL-prod" "$BASE_35B" 131072 q8_0 4096 \
+        -ot "blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU"
+    # 27B IQ4_XS production config (ctx 49152, q4 KV, ub2048)
+    run_cell "$tag" "$bin" "27B-IQ4XS-prod" "$BASE_27B" 49152 q4_0 2048
+done
+
+# ===== 35B MTP re-test on b9381 (does latest move the cliff / fix MoE MTP at high ctx?) =====
+log ""
+log "===== b9381 — 35B-A3B MTP across contexts ====="
+for ctx in 32768 49152 131072; do
+    run_cell "b9381" "$BIN_9381" "35B-base-c${ctx}" "$BASE_35B" "$ctx" q4_0 2048 \
+        -ot "blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU"
+    run_cell "b9381" "$BIN_9381" "35B-MTPn2-c${ctx}" "$MTP_35B" "$ctx" q4_0 2048 \
+        -ot "blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU" --spec-type draft-mtp --spec-draft-n-max 2
+    run_cell "b9381" "$BIN_9381" "35B-MTPn3-c${ctx}" "$MTP_35B" "$ctx" q4_0 2048 \
+        -ot "blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU" --spec-type draft-mtp --spec-draft-n-max 3
+done
+
+# ===== 27B MTP re-test on b9381 (did the cliff move past 32768?) =====
+log ""
+log "===== b9381 — 27B MTP cliff probe ====="
+for ctx in 32768 49152; do
+    run_cell "b9381" "$BIN_9381" "27B-MTPn2-c${ctx}" "$MTP_27B" "$ctx" q4_0 2048 \
+        --spec-type draft-mtp --spec-draft-n-max 2
+done
+
+log ""
+log "========================================"
+python3 -c "
+import json
+rows=[json.loads(l) for l in open('$RESULTS')]
+print('| Tag | Label | Ctx | KV | TG (t/s) | PP (t/s) | VRAM |')
+print('|--|--|--:|--|--:|--:|--:|')
+for r in rows:
+    print(f\"| {r['tag']} | {r['label']} | {r['ctx']} | {r['kv']} | {r['tg_avg']:.2f} ± {r['tg_stdev']:.2f} | {r['pp_avg']:.0f} ± {r['pp_stdev']:.0f} | {r['vram_mb']} |\")
+"
+log "Results in $RESULTS"
+
+# ===== restart production =====
+log ""; log "Restarting production..."
+stop_all
+RADV_PERFTEST=rm_kq=1 nohup "$BIN_9186/llama-server" \
+    --model "$BASE_35B" --ctx-size 131072 --host 127.0.0.1 --port 8001 \
+    --parallel 1 --jinja -ngl 99 -ot "blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU" \
+    -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 \
+    --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 \
+    --presence-penalty 1.5 --reasoning-budget 8192 \
+    -b 4096 -ub 4096 --threads 6 \
+    --chat-template-kwargs '{"preserve_thinking": true}' \
+    > /tmp/llama-server-restart.log 2>&1 &
+log "Production restarting (PID $!). Done."


### PR DESCRIPTION
## Summary
Re-benchmarked MTP speculative decoding on the RX 9060 XT after finding that **llama.cpp b9381 fixes MoE MTP at high context** (b9186 could not speculate past ~32K on the MoE 35B). Applies the two resulting production changes.

### 35B-A3B (flagship default)
- New default entry `Qwen3.6-35B-A3B-MTP-UD-Q5_K_XL`: MTP GGUF + `--spec-type draft-mtp --spec-draft-n-max 2`, `-ub 2048` (4096 + MTP OOMs), q8 KV, `-ot blk.20-39`, ctx 131072.
- **Real TG 28.8 → 37.7 t/s (+31%)** on code/tool/structured output; ~neutral on free-form prose; never below base.
- VRAM verified live with whisper resident: **16205/16304 MiB, stable (~99 MiB headroom)**, no `vk::DeviceLostError`.
- Base `Qwen3.6-35B-A3B-UD-Q5_K_XL` entry **kept** → rollback is one `model/switch`.

### 27B IQ4_XS
- `context_window` 49152 → 32768. The DeltaNet MTP path only accelerates at ctx ≤ ~34816 (cliff between 34816 and 36864). Production was over the cliff (~+2%); at 32768 MTP gives **~17 → ~30 t/s (+75%)**. b9381 does **not** fix the DeltaNet cliff.

### versions.json
- llama.cpp **b9186 → b9381**. Vanilla throughput is neutral vs b9186; the value is the MoE MTP fix.

## Trade-offs
- `-ub 2048` (vs 4096) costs ~24% PP on long prompts; the TG gain dominates for the interactive agent.
- 35B headroom is ~99 MiB — comfortable and verified stable, but monitor under heavy concurrent load.

## Validation
Full methodology, cliff localization, speculative-budget mechanism, version A/B, and the production-faithful VRAM verification are in `docs/BENCHMARKS.md`. Harness scripts under `scripts/bench-*.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)