### PR TITLE
fix(ai): stop MTP compute-buffer eviction — q4 KV + VRAM-settle gate

### DIFF
--- a/config/llama-server.service
+++ b/config/llama-server.service
@@ -19,6 +19,14 @@ Environment="RADV_PERFTEST=rm_kq=1"
 # Wait for GPU device node before starting inference (30 second timeout)
 ExecStartPre=/bin/sh -c 'i=0; until [ -e /dev/dri/renderD128 ] || [ -e /dev/dri/card0 ]; do sleep 1; i=$((i+1)); [ $i -ge 30 ] && exit 1; done'
 
+# VRAM-settle gate. The MTP flagship config sits ~100 MiB under the 16 GB ceiling,
+# so if we allocate while another consumer is busy (whisper mid-transcription) or a
+# previous llama-server instance has not finished releasing VRAM, the Vulkan backend
+# silently shrinks its compute buffer (warns only) and MTP loses its entire speedup.
+# Wait until non-llama VRAM use drains below 300 MiB (whisper idle is ~56 MiB).
+# Bounded to ~120 s, then proceed regardless: degraded-but-running beats not-running.
+ExecStartPre=/bin/sh -c 'for d in /sys/class/drm/card*/device; do [ -r "$d/mem_info_vram_used" ] || continue; [ "$(cat "$d/mem_info_vram_total" 2>/dev/null || echo 0)" -gt 4294967296 ] || continue; c="$d"; break; done; [ -n "$c" ] || exit 0; i=0; while [ $i -lt 60 ]; do u=$(( $(cat "$c/mem_info_vram_used")/1048576 )); if [ "$u" -lt 300 ]; then echo "vram-gate: ${u} MiB in use, clear to start"; exit 0; fi; echo "vram-gate: waiting, ${u} MiB still in use by other GPU consumers"; sleep 2; i=$((i+1)); done; echo "vram-gate: timeout after 120s, proceeding (compute buffer may be constrained)"; exit 0'
+
 ExecStart=__LLAMA_BIN__ \
   --model __LLAMA_MODEL__ \
   --ctx-size __CTX_SIZE__ \

--- a/config/platform_models.json
+++ b/config/platform_models.json
@@ -7,13 +7,14 @@
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF/resolve/main/Qwen3.6-35B-A3B-MTP-UD-Q5_K_XL.gguf",
       "min_size_bytes": 26000000000,
       "context_window": 131072,
-      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --presence-penalty 1.5 --reasoning-budget 8192 -b 4096 -ub 2048 --threads 6 --spec-type draft-mtp --spec-draft-n-max 2 --chat-template-kwargs '{\"preserve_thinking\": true}'",
+      "min_healthy_vram_mb": 15300,
+      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q4_0 --cache-type-v q4_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --presence-penalty 1.5 --reasoning-budget 8192 -b 4096 -ub 2048 --threads 6 --spec-type draft-mtp --spec-draft-n-max 2 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
         "tg_ts": 37.7,
         "tg_ts_prose": 28.5,
         "pp_ts": 575,
-        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan + RADV_PERFTEST=rm_kq=1, llama.cpp b9381, MTP n_max=2, q8 KV, -ub 2048, ctx 131072, full prod samplers, whisper resident",
-        "notes": "Default. MTP speculative decoding via b9381 (upstream fix for MoE MTP at high ctx — b9186 could not do this). +31% real TG on structured/code/tool output (28.8 -> 37.7), ~neutral on creative prose (28.5). Requires -ub 2048 (not 4096): -ub 4096 + MTP OOMs (vk::DeviceLostError). Stable at 16205/16304 MiB VRAM with whisper resident (~99 MiB headroom). Trades ~24% PP (751 -> 575) for the TG gain. Rollback: switch to Qwen3.6-35B-A3B-UD-Q5_K_XL. See docs/BENCHMARKS.md."
+        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan + RADV_PERFTEST=rm_kq=1, llama.cpp b9381, MTP n_max=2, q4 KV, -ub 2048, ctx 131072, full prod samplers, whisper resident",
+        "notes": "Default. MTP speculative decoding via b9381 (upstream fix for MoE MTP at high ctx — b9186 could not do this). +31% real TG on structured/code/tool output (28.8 -> 37.7), ~neutral on creative prose (28.5). KV is q4_0 (not q8): the q8 config sits at 99.4% VRAM and the moment the KV cache grows past ~25K tokens the Vulkan compute buffer is evicted to GTT and TG collapses 43 -> 31 until restart (see docs/BENCHMARKS.md 'compute-buffer eviction'). q4 KV frees ~640 MiB so the compute buffer stays resident — sustained 43 t/s greedy / ~37 real even after deep-context use, verified by stress test (27K-token prompt then re-measure). Requires -ub 2048 (not 4096): -ub 4096 + MTP OOMs (vk::DeviceLostError). Stable at ~15645/16304 MiB VRAM with whisper resident. Trades ~24% PP (751 -> 575) for the TG gain. Rollback: switch to Qwen3.6-35B-A3B-UD-Q5_K_XL. See docs/BENCHMARKS.md."
       },
       "default": true
     },

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -356,13 +356,48 @@ The numbers above are greedy (max acceptance, q4 KV). Production runs **q8 KV, `
 - **Net win: 28.81 → 37.70 t/s real (+31%) on the flagship at full 131K context** on *structured/code/tool* output, with one model swap + two flag changes. Greedy upper bound is +48%.
 - **Gain is workload-dependent.** MTP acceptance tracks output predictability: high on code/JSON/tool-calls (the agent's bread-and-butter, +20–31%), but on free-form *prose* a live test generated at **28.5 t/s ≈ base** (≈neutral). MTP never regressed below base in any test — so this is a win-or-neutral change, weighted toward the agent's typical structured traffic.
 - `-ub 2048` vs `-ub 4096` costs ~24% PP on long prompts (≈751 → ≈575 t/s, per the tuning log). For a generation-bound agent the TG gain dominates; for prompt-heavy batch use weigh the PP loss.
-- **VRAM verified, not just projected.** Measured live with the full stack (whisper resident — which itself uses only ~56 MiB on GPU) under sustained generation: **16205 / 16304 MiB, rock-stable, no spikes (≈99 MiB headroom)**. KV is pre-allocated at ctx=131072 so it does not grow at runtime. No `vk::DeviceLostError`. The earlier "~500 MiB whisper" alarm was a one-off transcription compute spike, not resident footprint.
+- **VRAM (initial reading — later found unstable, see "compute-buffer eviction" below).** A fresh start measures 16205 / 16304 MiB. This was *misread* as "rock-stable": KV at 131072 is **not** fully pre-allocated, it grows with use, and at 99.4% occupancy that growth evicts the compute buffer. The ~37.7 real figure here is the **fresh-restart** number; sustained throughput under real use needed the q4-KV fix below. (whisper resident is ~56 MiB; the earlier "~500 MiB whisper" alarm was a one-off transcription spike, not resident footprint.)
 
 ### Production change (applied 2026-05-29)
 
 Applied to capture the flagship win:
 - `versions.json`: `llama_cpp.tag` **b9186 → b9381**.
-- `platform_models.json`: **added** model `Qwen3.6-35B-A3B-MTP-UD-Q5_K_XL` (MTP GGUF, `--spec-type draft-mtp --spec-draft-n-max 2`, `-ub 2048`, q8 KV, `-ot blk.20-39`, ctx 131072, full samplers) and made it the default. The base `Qwen3.6-35B-A3B-UD-Q5_K_XL` entry is **kept** so rollback is a single `/api/ai/model/switch` back to it (no version revert needed).
+- `platform_models.json`: **added** model `Qwen3.6-35B-A3B-MTP-UD-Q5_K_XL` (MTP GGUF, `--spec-type draft-mtp --spec-draft-n-max 2`, `-ub 2048`, `-ot blk.20-39`, ctx 131072, full samplers) and made it the default. The base `Qwen3.6-35B-A3B-UD-Q5_K_XL` entry is **kept** so rollback is a single `/api/ai/model/switch` back to it (no version revert needed).
 - `platform_models.json`: 27B `Qwen3.6-27B-IQ4_XS` `context_window` **49152 → 32768** to bring it under the DeltaNet MTP cliff (+75% TG when 27B is selected). b9381 does **not** fix the DeltaNet cliff — that change is the b9186 analysis and stands.
 
 Deployed via the manager update path (pulls `main`, installs b9381, restarts) + a model switch to the MTP entry. Rollback path: `POST /api/ai/model/switch {"model_id":"Qwen3.6-35B-A3B-UD-Q5_K_XL"}`.
+
+> **Correction (2026-05-30):** the MTP entry originally shipped with **q8 KV**, which proved unstable (see "compute-buffer eviction" below) — the +50% decayed to break-even under real use. The shipped config was changed to **q4_0 KV** (`--cache-type-k/v q4_0`), keeping ctx 131072 and delivering a *sustained* +50% greedy / +31% real. The VRAM-settle gate and `verify_llama_allocation` guard were added in the same change.
+
+### Compute-buffer eviction — why the q8/131072 win wasn't real, and the q4 fix (found 2026-05-29/30)
+
+A follow-up A/B on the **live** server surfaced a trap: the q8/131072 config delivers +50% only for the first few minutes after a restart, then decays to ≈break-even under real use. Two faces of the same root cause (the config sits at **99.4% VRAM, ~100 MiB under the 16,304 MiB ceiling**):
+
+**1. Startup starvation.** If llama-server allocates while VRAM is momentarily tight — whisper mid-transcription, or the previous instance still releasing ~15 GB during a `systemctl restart` — it can't get the full ~3.6 GiB Vulkan compute buffer. It does **not** fail and does **not** reduce `-ngl` (`common_fit_params: failed to fit params to free device memory: n_gpu_layers already set by user to 99, abort`); it **silently shrinks the buffer** (warns only). Confirmed in the degraded server's shutdown log: `Vulkan0 compute buffer size of 776.33 MiB, does not match expectation of 3656.33 MiB`.
+
+**2. Runtime eviction (the dominant one).** Even a cleanly-started server degrades the moment the KV cache grows. KV at 131072 is **not** fully pre-allocated — it grows with context. A single deep prompt pushes total VRAM over the ceiling and the driver evicts the compute buffer to GTT (system RAM over PCIe), where it **stays until restart**. Proven by stress test (restart → 27K-token prompt → re-measure shallow):
+
+| Server state | greedy TG | VRAM |
+|---|---:|---:|
+| fresh restart | **43.5** | 16208 |
+| after one 27K-token prompt | 31.7 | 15518 |
+| every shallow request afterwards | **30.8** (stuck) | 15518 |
+
+**Signature is paradoxical: the degraded server uses *less* VRAM (15518) than the healthy one (16208)** — the ~690 MiB "missing" is the compute buffer, now in GTT. A concurrent request (the server runs `--parallel 1`) triggers the same eviction. This is the real reason the first deploy under-delivered: the "+50%" was a cool-fresh-restart transient.
+
+(Distinct from the *greedy-vs-real* gap, which is MTP draft **acceptance** — compute/sampling — and is VRAM-independent.)
+
+**Fix: headroom.** Moving more experts to CPU (`-ot blk.18-39`, `16-39`) did **not** help — at ctx 131072 the full KV still evicts the buffer regardless of expert placement. Only reducing the KV footprint does. Stress-sweep (fresh → 27K stress → sustained):
+
+| Config | fresh | sustained (post-stress) | VRAM after stress | verdict |
+|---|---:|---:|---:|---|
+| q8 / ctx 131072 (original) | 43.1 | **30.8** | 15518 (evicts) | ❌ decays |
+| q8 / ctx 65536 | 43.1 | **43.0** | 15785 (stable) | ✅ half context |
+| **q4 / ctx 131072** | 43.0 | **43.0** | 15645 (stable) | ✅ **shipped** |
+
+**q4_0 KV** frees ~640 MiB — enough that the compute buffer stays resident through full-context growth — while **keeping the full 131072 window**. Sustained 43 t/s greedy / ~37 real, verified to survive the exact stress that collapses q8. The q4 attention-precision cost is modest and acceptable for the agent workload; q8/65536 is the alternative if max numerics matter more than context length.
+
+**Guards also shipped (defense-in-depth for the startup case):**
+- `config/llama-server.service` — `ExecStartPre` **VRAM-settle gate**: before allocating, wait (≤120 s) until non-llama VRAM use drains below 300 MiB (whisper idle ≈ 56 MiB), so a model-switch's old instance has fully released VRAM first.
+- `scripts/utilities.sh` `verify_llama_allocation()` — after the health check on the model-switch/update path, if the process came up below the model's `min_healthy_vram_mb` watermark, restart (the gate holds the retry until VRAM drains) and re-check, up to 2×; never fails the caller, logs loudly.
+- `config/platform_models.json` — the MTP entry declares `"min_healthy_vram_mb": 15300` (below the ~15645 stable reading, above a starved start). Models without the field skip the check.

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -752,6 +752,7 @@ setup_llama_server() {
     # (they were baked in by generate_llama_service, no need to keep in .env)
     local CTX_SIZE="8192"
     local EXTRA_FLAGS=""
+    local MIN_HEALTHY_VRAM=""
     if [[ -f "$MODELS_FILE" ]] && [[ -n "$MODEL_NAME" ]]; then
         # Derive model id from filename (strip extension)
         local model_id
@@ -761,6 +762,12 @@ setup_llama_server() {
             "$MODELS_FILE" 2>/dev/null || echo "8192")
         EXTRA_FLAGS=$(jq -r --arg id "$model_id" \
             '(.models[] | select(.id == $id) | .extra_flags) // .llama_server.extra_flags // ""' \
+            "$MODELS_FILE" 2>/dev/null || echo "")
+        # Optional: healthy-allocation VRAM watermark. When set, a successful
+        # start that comes up well below this value means the Vulkan compute
+        # buffer was starved by VRAM pressure (see verify_llama_allocation).
+        MIN_HEALTHY_VRAM=$(jq -r --arg id "$model_id" \
+            '(.models[] | select(.id == $id) | .min_healthy_vram_mb) // empty' \
             "$MODELS_FILE" 2>/dev/null || echo "")
     fi
     local MIN_SIZE="${AI_MODEL_MIN_SIZE:-1000000000}"
@@ -781,8 +788,9 @@ setup_llama_server() {
         systemctl daemon-reload
         systemctl enable llama-server
         systemctl restart llama-server
-        wait_for_llama_health "$HEALTH_URL" 600
-        return $?
+        wait_for_llama_health "$HEALTH_URL" 600 || return 1
+        verify_llama_allocation "$HEALTH_URL" "$MIN_HEALTHY_VRAM"
+        return 0
     fi
 
     # --- [2/5] & [3/5] Install binary (platform-specific) ---
@@ -807,8 +815,9 @@ setup_llama_server() {
     systemctl daemon-reload
     systemctl enable --now llama-server
 
-    wait_for_llama_health "$HEALTH_URL" 600
-    return $?
+    wait_for_llama_health "$HEALTH_URL" 600 || return 1
+    verify_llama_allocation "$HEALTH_URL" "$MIN_HEALTHY_VRAM"
+    return 0
 }
 
 # Helper: poll llama-server health endpoint
@@ -833,6 +842,53 @@ wait_for_llama_health() {
     log_error "llama-server did not pass health check within ${timeout}s."
     log_error "Check: journalctl -u llama-server -n 50"
     return 1
+}
+
+# Helper: VRAM currently used on the discrete GPU, in MiB (echoes 0 if unreadable).
+# Picks the first DRM card whose total VRAM exceeds 4 GiB so an integrated GPU
+# (small carve-out) is never mistaken for the inference card.
+_gpu_vram_used_mb() {
+    local d
+    for d in /sys/class/drm/card*/device; do
+        [[ -r "$d/mem_info_vram_used" ]] || continue
+        [[ "$(cat "$d/mem_info_vram_total" 2>/dev/null || echo 0)" -gt 4294967296 ]] || continue
+        echo $(( $(cat "$d/mem_info_vram_used") / 1048576 ))
+        return 0
+    done
+    echo 0
+}
+
+# Helper: guard against silent compute-buffer starvation.
+# The MTP flagship config sits ~100 MiB under the 16 GB ceiling. If llama-server
+# allocates while another GPU consumer is busy (whisper mid-transcription) or a
+# prior instance has not finished releasing VRAM, the Vulkan backend quietly
+# shrinks its compute buffer (warns only) — and MTP loses its entire speedup
+# (~43 -> ~27 t/s) while paradoxically using *less* VRAM. The unit's ExecStartPre
+# VRAM gate prevents this on a clean start; this is the belt-and-braces check on
+# the model-switch / update path (which is how the degraded server first shipped).
+# When the model declares a healthy-allocation watermark, a start that lands well
+# below it is restarted (ExecStartPre holds the retry until VRAM drains).
+# Never fails the caller: a degraded-but-serving model still answers requests.
+verify_llama_allocation() {
+    local health_url="$1" min_vram="$2"
+    [[ -n "$min_vram" && "$min_vram" != "null" && "$min_vram" -gt 0 ]] 2>/dev/null || return 0
+    local attempt used
+    for attempt in 1 2 3; do
+        sleep 5  # let the allocation settle after the health endpoint comes up
+        used=$(_gpu_vram_used_mb)
+        if [[ "$used" -ge "$min_vram" ]]; then
+            log_info "llama-server allocation OK (${used} MiB ≥ ${min_vram} MiB healthy watermark)."
+            return 0
+        fi
+        log_warn "llama-server came up degraded: ${used} MiB < ${min_vram} MiB healthy watermark — Vulkan compute buffer likely starved by VRAM pressure."
+        if [[ "$attempt" -lt 3 ]]; then
+            log_warn "Restarting llama-server (retry ${attempt}/2); ExecStartPre will wait for VRAM to drain first..."
+            systemctl restart llama-server
+            wait_for_llama_health "$health_url" 600 || { log_error "llama-server failed health check during degradation retry."; return 0; }
+        fi
+    done
+    log_warn "llama-server still below the healthy VRAM watermark after retries; serving in a degraded state. Inspect 'journalctl -u llama-server' for 'compute buffer size … does not match expectation' and free GPU memory before the next restart."
+    return 0
 }
 
 # --- Helper: Setup whisper-server (speech-to-text) ---


### PR DESCRIPTION
## Problem

The 35B MTP flagship shipped at **q8 KV / ctx 131072**, sitting at **99.4% VRAM** (~100 MiB under the 16,304 MiB ceiling). Live A/B revealed the deployed **+50% was a cool-fresh-restart transient** — it decays to ~break-even under real use:

| Server state | greedy TG | VRAM |
|---|---:|---:|
| fresh restart | **43.5** | 16208 |
| after one 27K-token prompt | 31.7 | 15518 |
| every shallow request afterwards | **30.8** (stuck till restart) | 15518 |

**Mechanism:** KV at 131072 grows with use (not pre-allocated); once total VRAM crosses the ceiling the Vulkan **compute buffer is evicted to GTT** (system RAM over PCIe) and stays there until restart. A concurrent `--parallel 1` request triggers the same thing. Paradoxical signature: the degraded server uses *less* VRAM (the ~690 MiB compute buffer moved off-GPU). A separate startup variant shrinks the buffer at boot under transient pressure (whisper spike / prior instance still releasing VRAM during a model-switch), confirmed by `Vulkan0 compute buffer size of 776.33 MiB, does not match expectation of 3656.33 MiB`.

## Fix — headroom (stress-verified: fresh → 27K-token prompt → re-measure)

Moving experts to CPU does **not** help at 131072 (full KV still evicts). Only shrinking the KV footprint does:

| Config | fresh | sustained | verdict |
|---|---:|---:|---|
| q8 / 131072 (original) | 43.1 | **30.8** | ❌ decays |
| q8 / 65536 | 43.1 | **43.0** | ✅ half context |
| **q4 / 131072 (this PR)** | 43.0 | **43.0** | ✅ full context |

**q4_0 KV** frees ~640 MiB so the compute buffer stays resident through full-context growth — **sustained 43 t/s greedy / ~37 real**, surviving the exact stress that collapses q8, while keeping the full 131072 window.

## Changes
- `config/platform_models.json`: MTP entry KV `q8_0` → `q4_0`; add `min_healthy_vram_mb: 15300`.
- `config/llama-server.service`: `ExecStartPre` **VRAM-settle gate** — wait (≤120 s) for non-llama VRAM to drain below 300 MiB before allocating (covers reboots and the model-switch release lag).
- `scripts/utilities.sh`: `verify_llama_allocation()` — after health on the switch/update path, if VRAM is below the model watermark, restart (gate holds the retry until VRAM drains) and re-check up to 2×. Never fails the caller; logs loudly.
- `docs/BENCHMARKS.md`: full writeup; corrects the earlier "stable +50%" claim.

## Test
Stress sweep run live on the production target (RX 9060 XT). Will smoke-test on `.58` post-merge via the manager update path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)