### PR TITLE
fix(ai): ship MTP at ctx 65536 q8 — 131072 evicts compute buffer

### DIFF
--- a/config/platform_models.json
+++ b/config/platform_models.json
@@ -6,15 +6,15 @@
       "filename": "Qwen3.6-35B-A3B-MTP-UD-Q5_K_XL.gguf",
       "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF/resolve/main/Qwen3.6-35B-A3B-MTP-UD-Q5_K_XL.gguf",
       "min_size_bytes": 26000000000,
-      "context_window": 131072,
-      "min_healthy_vram_mb": 15300,
-      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q4_0 --cache-type-v q4_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --presence-penalty 1.5 --reasoning-budget 8192 -b 4096 -ub 2048 --threads 6 --spec-type draft-mtp --spec-draft-n-max 2 --chat-template-kwargs '{\"preserve_thinking\": true}'",
+      "context_window": 65536,
+      "min_healthy_vram_mb": 15500,
+      "extra_flags": "--parallel 1 --jinja -ngl 99 -ot \"blk.(2[0-9]|3[0-9]).ffn_.*exps=CPU\" -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --presence-penalty 1.5 --reasoning-budget 8192 -b 4096 -ub 2048 --threads 6 --spec-type draft-mtp --spec-draft-n-max 2 --chat-template-kwargs '{\"preserve_thinking\": true}'",
       "benchmark": {
         "tg_ts": 37.7,
         "tg_ts_prose": 28.5,
         "pp_ts": 575,
-        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan + RADV_PERFTEST=rm_kq=1, llama.cpp b9381, MTP n_max=2, q4 KV, -ub 2048, ctx 131072, full prod samplers, whisper resident",
-        "notes": "Default. MTP speculative decoding via b9381 (upstream fix for MoE MTP at high ctx — b9186 could not do this). +31% real TG on structured/code/tool output (28.8 -> 37.7), ~neutral on creative prose (28.5). KV is q4_0 (not q8): the q8 config sits at 99.4% VRAM and the moment the KV cache grows past ~25K tokens the Vulkan compute buffer is evicted to GTT and TG collapses 43 -> 31 until restart (see docs/BENCHMARKS.md 'compute-buffer eviction'). q4 KV frees ~640 MiB so the compute buffer stays resident — sustained 43 t/s greedy / ~37 real even after deep-context use, verified by stress test (27K-token prompt then re-measure). Requires -ub 2048 (not 4096): -ub 4096 + MTP OOMs (vk::DeviceLostError). Stable at ~15645/16304 MiB VRAM with whisper resident. Trades ~24% PP (751 -> 575) for the TG gain. Rollback: switch to Qwen3.6-35B-A3B-UD-Q5_K_XL. See docs/BENCHMARKS.md."
+        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan + RADV_PERFTEST=rm_kq=1, llama.cpp b9381, MTP n_max=2, q8 KV, -ub 2048, ctx 65536, full prod samplers, whisper resident",
+        "notes": "Default. MTP speculative decoding via b9381 (upstream fix for MoE MTP at high ctx — b9186 could not do this). Sustained 43 t/s greedy / ~37 real (+31%) on structured/code/tool output, ~neutral on creative prose (28.5). CONTEXT IS 65536, NOT 131072: at 131072 the model+KV-reservation+compute-buffer exceeds 16 GB headroom, and a single deep prompt evicts the ~690 MiB Vulkan compute buffer to GTT — TG collapses 43 -> 31 until restart (q4 KV does not save it; only reducing ctx does). At ctx 65536 the compute buffer stays resident: verified eviction-proof across two consecutive 27K-token stress prompts, VRAM flat at ~15801/16304 MiB. q8 KV (best numerics) — at the 65536 cap q8 beats q4 (same speed). Requires -ub 2048 (not 4096): -ub 4096 + MTP OOMs (vk::DeviceLostError). Trades ~24% PP (751 -> 575) and half the max context for the sustained TG gain. Rollback: switch to Qwen3.6-35B-A3B-UD-Q5_K_XL (base, 131072, ~28.8 t/s). See docs/BENCHMARKS.md."
       },
       "default": true
     },

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -367,9 +367,9 @@ Applied to capture the flagship win:
 
 Deployed via the manager update path (pulls `main`, installs b9381, restarts) + a model switch to the MTP entry. Rollback path: `POST /api/ai/model/switch {"model_id":"Qwen3.6-35B-A3B-UD-Q5_K_XL"}`.
 
-> **Correction (2026-05-30):** the MTP entry originally shipped with **q8 KV**, which proved unstable (see "compute-buffer eviction" below) — the +50% decayed to break-even under real use. The shipped config was changed to **q4_0 KV** (`--cache-type-k/v q4_0`), keeping ctx 131072 and delivering a *sustained* +50% greedy / +31% real. The VRAM-settle gate and `verify_llama_allocation` guard were added in the same change.
+> **Correction (2026-05-30):** the MTP entry originally shipped at **ctx 131072**, which proved unstable (see "compute-buffer eviction" below) — the +50% decayed to break-even under real use. A first attempt dropped KV to q4_0 (still 131072); it tested stable on a clean box but **still evicts** once the GPU has accumulated session state (VRAM fragmentation / GTT pressure) — 131072 is simply not robustly stable for MTP on this 16 GB card. The shipped config is **q8 KV at ctx 65536**, verified eviction-proof across two consecutive 27K-token stress prompts. The VRAM-settle gate and `verify_llama_allocation` guard were added in the same change. Trade accepted: half the max context for a *sustained* (non-decaying) +50%.
 
-### Compute-buffer eviction — why the q8/131072 win wasn't real, and the q4 fix (found 2026-05-29/30)
+### Compute-buffer eviction — why the 131072 win wasn't real, and the ctx-65536 fix (found 2026-05-29/30)
 
 A follow-up A/B on the **live** server surfaced a trap: the q8/131072 config delivers +50% only for the first few minutes after a restart, then decays to ≈break-even under real use. Two faces of the same root cause (the config sits at **99.4% VRAM, ~100 MiB under the 16,304 MiB ceiling**):
 
@@ -387,17 +387,21 @@ A follow-up A/B on the **live** server surfaced a trap: the q8/131072 config del
 
 (Distinct from the *greedy-vs-real* gap, which is MTP draft **acceptance** — compute/sampling — and is VRAM-independent.)
 
-**Fix: headroom.** Moving more experts to CPU (`-ot blk.18-39`, `16-39`) did **not** help — at ctx 131072 the full KV still evicts the buffer regardless of expert placement. Only reducing the KV footprint does. Stress-sweep (fresh → 27K stress → sustained):
+**Fix: reduce context (not KV type, not expert placement).** Moving more experts to CPU (`-ot blk.18-39`, `16-39`) did **not** help — at ctx 131072 the full KV/attention reservation still evicts the buffer regardless of expert placement. Dropping KV to q4_0 at 131072 looked stable on a freshly-drained box but **evicts once the session accumulates GPU state** (it was stable in an early sweep, then evicted an hour later under identical flags — the only variable was transient driver/VRAM state). The robust lever is **context length**, because llama.cpp sizes the KV reservation and attention scratch to `n_ctx` at load — smaller ctx leaves real headroom. Stress-sweep (fresh → 27K stress → sustained; later runs are on a session-fragmented GPU = worst case):
 
 | Config | fresh | sustained (post-stress) | VRAM after stress | verdict |
 |---|---:|---:|---:|---|
 | q8 / ctx 131072 (original) | 43.1 | **30.8** | 15518 (evicts) | ❌ decays |
-| q8 / ctx 65536 | 43.1 | **43.0** | 15785 (stable) | ✅ half context |
-| **q4 / ctx 131072** | 43.0 | **43.0** | 15645 (stable) | ✅ **shipped** |
+| q4 / ctx 131072 | 43.0 | **30.9** | 14902 (evicts) | ❌ decays under real conditions |
+| q4 / ctx 49152 | 34.8 | **43.0** | 15339 (stable) | ✅ |
+| q4 / ctx 65536 | 43.1 | **43.1** | 15492 (stable) | ✅ |
+| **q8 / ctx 65536** | 43.1 | **43.1** | 15811 (stable) | ✅ **shipped** — survives 2× 27K stress, best numerics |
 
-**q4_0 KV** frees ~640 MiB — enough that the compute buffer stays resident through full-context growth — while **keeping the full 131072 window**. Sustained 43 t/s greedy / ~37 real, verified to survive the exact stress that collapses q8. The q4 attention-precision cost is modest and acceptable for the agent workload; q8/65536 is the alternative if max numerics matter more than context length.
+At the 65536 cap, q8 KV matches q4 on speed while keeping best numerics, so q8 is shipped. `context_window` is set to 65536; 64K is ample for the home/agent workload. (If a future config genuinely needs 131072, the only stable option there is the **base** model — no MTP, ~28.8 t/s — since it has no compute buffer to evict.)
 
-**Guards also shipped (defense-in-depth for the startup case):**
+**Guards also shipped (defense-in-depth for the startup-starvation case):**
 - `config/llama-server.service` — `ExecStartPre` **VRAM-settle gate**: before allocating, wait (≤120 s) until non-llama VRAM use drains below 300 MiB (whisper idle ≈ 56 MiB), so a model-switch's old instance has fully released VRAM first.
 - `scripts/utilities.sh` `verify_llama_allocation()` — after the health check on the model-switch/update path, if the process came up below the model's `min_healthy_vram_mb` watermark, restart (the gate holds the retry until VRAM drains) and re-check, up to 2×; never fails the caller, logs loudly.
-- `config/platform_models.json` — the MTP entry declares `"min_healthy_vram_mb": 15300` (below the ~15645 stable reading, above a starved start). Models without the field skip the check.
+- `config/platform_models.json` — the MTP entry declares `"min_healthy_vram_mb": 15500` (below the ~15801 stable reading, above a starved start). Models without the field skip the check.
+
+> Note: the gate/watermark guard the *startup-starvation* face. The *runtime eviction* face is fixed structurally by the ctx-65536 headroom above (there is no resident-buffer to evict once it fits with margin) — guards can't fix runtime eviction, only the config can.


### PR DESCRIPTION
Follow-up to #95.

## Why
The q4_0/131072 config merged in #95 tested stable on a freshly-drained GPU but **still evicts** the Vulkan compute buffer to GTT once the session accumulates state (VRAM fragmentation / GTT pressure): a single deep prompt drops sustained TG **43 → 31** until restart (verified — same flags stable early, evicting an hour later; only variable was transient driver/VRAM state). **131072 is not robustly stable for MTP on this 16 GB card** — llama.cpp sizes the KV reservation + attention scratch to `n_ctx` at load, so the headroom isn't there regardless of KV type or `-ot` placement.

## Fix — reduce context (the robust lever)
| Config | sustained (post-27K-stress) | verdict |
|---|---:|---|
| q8 / 131072 (orig) | 30.8 | ❌ evicts |
| q4 / 131072 (#95) | 30.9 | ❌ evicts under real conditions |
| q4 / 65536 | 43.1 | ✅ |
| **q8 / 65536 (this PR)** | **43.1** | ✅ survives 2× 27K stress, VRAM flat ~15801 |

At the 65536 cap, q8 matches q4 on speed while keeping best numerics → q8 ships. 64K is ample for the agent; trade is half the max context for a **sustained** (non-decaying) +50%.

## Changes
- `config/platform_models.json`: MTP entry KV `q4_0` → `q8_0`; `context_window` 131072 → 65536; `min_healthy_vram_mb` 15300 → 15500.
- `docs/BENCHMARKS.md`: correct the q4/131072 "fix"; document the ctx sweep + the `n_ctx`-sizing mechanism.

(The ExecStartPre VRAM-settle gate and `verify_llama_allocation` from #95 stay — they guard the startup-starvation face; this config fixes the runtime-eviction face.)

## Test
Verified live on the production target (RX 9060 XT): q8/65536 held 43 t/s sustained through two consecutive 27K-token stress prompts with VRAM flat. Will smoke-test post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)