### PR TITLE
fix(update): block unsafe downgrades in update.sh

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -267,6 +267,32 @@ All items in this section must pass on real hardware before the PR is eligible f
 
 ---
 
+## Update / downgrade guard
+
+`update.sh` refuses to move the stack backwards (Nextcloud cannot start on an
+older image once its data has migrated; a half-applied manager downgrade 500s
+with `'platform' is undefined`). The decision logic lives in `common.sh` and is
+unit-tested with no Docker/network/root required:
+
+```bash
+bash scripts/tests/test_update_guard.sh   # must end with "failed: 0"
+```
+
+On real hardware, verify read-only (no update is executed):
+
+- [ ] Inspect current state: `cat /opt/homebrain/version.json` and
+      `grep -Eo 'nextcloud:[0-9]+\.[0-9]+\.[0-9]+' /opt/homebrain/docker-compose.yml`
+- [ ] **Downgrade is blocked:** from a beta/dev install, trigger a `stable`
+      update to an older tag (e.g. `sudo bash scripts/update.sh stable v1.1.0`).
+      It must abort *before* rsync with "Refusing downgrade: …" and exit 1; the
+      dashboard and Nextcloud stay untouched.
+- [ ] **Forward/equal still works:** a normal `beta`/`dev` → `main` update (or
+      `stable` → newer tag) proceeds as before and the stack comes back healthy.
+- [ ] **Override path:** `sudo ALLOW_DOWNGRADE=1 bash scripts/update.sh stable v1.1.0`
+      logs the override warning and proceeds (only with a backup in hand).
+
+---
+
 ## Sign-off checklist
 
 Complete before merging to `main`:

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -21,6 +21,81 @@ log_warn() { echo "[WARN] $1" >&2; }
 log_error() { echo "[ERROR] $1" >&2; }
 die() { log_error "$1" >&2; exit 1; }
 
+# --- Downgrade Protection ---
+# HomeBrain's update path is one-way. Two things make a downgrade unsafe:
+#   1. Nextcloud migrates its data + config version forward the first time a
+#      newer image boots, then *refuses to start* on an older image
+#      ("update needed" / "version of the data is higher than the docker
+#      image version"). There is no supported automated rollback.
+#   2. The Flask manager's templates and app.py move together; a partially- or
+#      fully-applied downgrade leaves new templates rendered by an old app.py
+#      that lacks the inject_platform() context processor, so every page 500s
+#      with `'platform' is undefined`.
+# The only safe way back is restore.sh from a pre-upgrade backup, so we refuse
+# downgrades up front instead of letting them corrupt state.
+
+# version_lt A B -> exit 0 (true) if version A is strictly older than B.
+# Pure bash dot-segment compare: no `sort -V`, so it behaves identically on the
+# Linux targets and on a macOS dev box running the test suite. Non-numeric
+# trailing junk in a segment (e.g. "0-rc1") is stripped to its leading digits.
+version_lt() {
+    if [ "$1" = "$2" ]; then return 1; fi
+    local IFS=.
+    # shellcheck disable=SC2206  # word-splitting on '.' is intentional here
+    local -a a=($1) b=($2)
+    local i max=${#a[@]}
+    if [ "${#b[@]}" -gt "$max" ]; then max=${#b[@]}; fi
+    for ((i = 0; i < max; i++)); do
+        local ai="${a[i]:-0}" bi="${b[i]:-0}"
+        ai="${ai%%[!0-9]*}"; bi="${bi%%[!0-9]*}"
+        ai=$((10#${ai:-0})); bi=$((10#${bi:-0}))
+        if ((ai < bi)); then return 0; fi
+        if ((ai > bi)); then return 1; fi
+    done
+    return 1
+}
+
+# parse_nc_tag FILE -> echoes the x.y.z Nextcloud version from a docker-compose
+# file (ignores the "-apache" image suffix). Empty if not found.
+parse_nc_tag() {
+    grep -Eo 'nextcloud:[0-9]+\.[0-9]+\.[0-9]+' "$1" 2>/dev/null | head -n1 | cut -d: -f2
+}
+
+# detect_downgrade <inst_channel> <inst_ref> <tgt_channel> <tgt_ref> \
+#                  <inst_nc_tag> <tgt_nc_tag>
+# Echoes a human-readable reason and returns 0 when moving installed->target is
+# a downgrade; returns 1 (silent) otherwise. Pure function — no I/O beyond the
+# reason on stdout — so it is exhaustively unit-tested.
+detect_downgrade() {
+    local inst_channel="$1" inst_ref="$2" tgt_channel="$3" tgt_ref="$4"
+    local inst_nc="$5" tgt_nc="$6"
+
+    # 1. Nextcloud is the unrecoverable one — check it first and report loudest.
+    if [ -n "$inst_nc" ] && [ -n "$tgt_nc" ] && version_lt "$tgt_nc" "$inst_nc"; then
+        echo "Nextcloud ${inst_nc} -> ${tgt_nc} (data already migrated to ${inst_nc}; the older image will refuse to start)"
+        return 0
+    fi
+
+    # 2. HomeBrain release regression. update.sh treats every non-"stable"
+    #    channel (beta, dev, ...) as the bleeding edge: it builds from main,
+    #    which is at or ahead of every stable tag. So any non-stable -> stable
+    #    move is a downgrade by definition. stable -> stable compares the tags.
+    if [ -n "$inst_channel" ]; then
+        if [ "$inst_channel" != "stable" ] && [ "$tgt_channel" = "stable" ]; then
+            echo "${inst_channel} (tracks main) -> stable ${tgt_ref} (main is ahead of every stable release)"
+            return 0
+        fi
+        if [ "$inst_channel" = "stable" ] && [ "$tgt_channel" = "stable" ] \
+            && [ -n "$inst_ref" ] && [ -n "$tgt_ref" ] \
+            && version_lt "${tgt_ref#v}" "${inst_ref#v}"; then
+            echo "release ${inst_ref} -> ${tgt_ref}"
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
 # --- GPU Detection ---
 # HomeBrain's AI stack (llama-server) targets x86_64 with AMD/Nvidia/Intel GPU.
 # aarch64 targets (HomeCloud/RPi) are always treated as no-GPU — their on-die

--- a/scripts/tests/test_update_guard.sh
+++ b/scripts/tests/test_update_guard.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Unit tests for the update.sh downgrade guard. The decision logic lives in
+# common.sh (version_lt / parse_nc_tag / detect_downgrade) precisely so it can
+# be exercised here with no Docker, no network, and no root — runs the same on
+# a Linux target and a macOS dev box.
+#
+#   bash scripts/tests/test_update_guard.sh
+#
+# Exit status: 0 if every case passes, 1 otherwise.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON="$SCRIPT_DIR/../common.sh"
+
+# common.sh mkdir's /var/log/homebrain and probes the GPU at source time; on a
+# dev box that is harmless noise, and we only want the pure helpers. Silence it.
+# shellcheck source=../common.sh disable=SC1091
+source "$COMMON" 2>/dev/null
+
+pass=0
+fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail + 1)); }
+
+# version_lt expectations
+lt()     { if version_lt "$1" "$2"; then ok "$1 < $2"; else bad "$1 < $2 (expected true)"; fi; }
+not_lt() { if version_lt "$1" "$2"; then bad "NOT $1 < $2 (expected false)"; else ok "NOT $1 < $2"; fi; }
+
+# detect_downgrade expectations:
+#   down/safe <label> <inst_ch> <inst_ref> <tgt_ch> <tgt_ref> <inst_nc> <tgt_nc>
+down() { if detect_downgrade "$2" "$3" "$4" "$5" "$6" "$7" >/dev/null; then ok "$1"; else bad "$1 (expected DOWNGRADE)"; fi; }
+safe() { if detect_downgrade "$2" "$3" "$4" "$5" "$6" "$7" >/dev/null; then bad "$1 (expected allowed)"; else ok "$1"; fi; }
+
+echo "== version_lt =="
+lt 32.0.3 32.0.9
+lt 1.1.0 1.2.0
+lt 1.9.0 1.10.0          # numeric, not lexical ordering
+lt 31.0.10 32.0.0
+lt 32.0.3-rc1 32.0.9     # non-numeric trailing junk is stripped
+not_lt 32.0.9 32.0.3
+not_lt 32.0.9 32.0.9     # equal is not strictly-less-than
+not_lt 1.2.0 1.1.0
+not_lt 1.10.0 1.9.0
+
+echo "== parse_nc_tag =="
+tmp="$(mktemp)"
+printf '  nextcloud:\n    image: nextcloud:32.0.9-apache\n' > "$tmp"
+got="$(parse_nc_tag "$tmp")"
+if [ "$got" = "32.0.9" ]; then ok "parse_nc_tag -> 32.0.9"; else bad "parse_nc_tag -> '$got'"; fi
+: > "$tmp"  # no nextcloud line
+got="$(parse_nc_tag "$tmp")"
+if [ -z "$got" ]; then ok "parse_nc_tag -> empty when absent"; else bad "parse_nc_tag -> '$got' (expected empty)"; fi
+rm -f "$tmp"
+
+echo "== detect_downgrade: should BLOCK =="
+# The reported incident: beta (main, NC 32.0.9) -> stable v1.1.0 (NC 32.0.3).
+down "beta->stable + NC regress (user incident)" beta main   stable v1.1.0 32.0.9 32.0.3
+down "beta->stable, NC equal"                    beta main   stable v1.1.0 32.0.9 32.0.9
+down "dev->stable (dev tracks main too)"         dev  main   stable v1.1.0 32.0.9 32.0.9
+down "stable->older stable tag"                  stable v1.2.0 stable v1.1.0 32.0.9 32.0.9
+down "NC regress, no version.json"               ""   ""      stable v1.1.0 32.0.9 32.0.3
+down "NC regress within same stable tag"         stable v1.1.0 stable v1.1.0 32.0.9 32.0.3
+
+echo "== detect_downgrade: should ALLOW =="
+safe "beta->beta, NC equal (routine)"   beta main   beta main   32.0.9 32.0.9
+safe "beta->beta, NC forward"           beta main   beta main   32.0.8 32.0.9
+safe "dev->dev (both track main)"       dev  main   dev  main   32.0.9 32.0.9
+safe "stable->dev (forward to main)"    stable v1.1.0 dev  main  32.0.3 32.0.9
+safe "stable->newer stable tag"         stable v1.1.0 stable v1.2.0 32.0.3 32.0.9
+safe "stable->beta (forward)"           stable v1.1.0 beta main   32.0.3 32.0.9
+safe "stable re-run same tag"           stable v1.1.0 stable v1.1.0 32.0.9 32.0.9
+safe "fresh install (no signals)"       ""   ""      stable v1.1.0 ""     32.0.3
+safe "beta->beta, NC unknown"           beta main   beta main   ""     ""
+
+echo
+echo "passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ]

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -21,6 +21,43 @@ log_info "Channel: ${1:-stable} | Target: ${2:-main}"
 CHANNEL="${1:-stable}"
 TARGET_REF="${2:-main}"
 
+# --- Downgrade guard ------------------------------------------------------
+# Gathers the installed vs. target version signals and aborts the update if it
+# would move the stack backwards (see detect_downgrade in common.sh for why
+# that is unrecoverable). Call with the path to the TARGET docker-compose.yml
+# so we can compare the Nextcloud image tag; an empty/missing path falls back
+# to the release-version signal alone. Honours ALLOW_DOWNGRADE=1 as a
+# deliberate, backup-in-hand override.
+abort_if_downgrade() {
+    local target_compose="${1:-}"
+
+    local inst_channel="" inst_ref=""
+    if [[ -f "$INSTALL_DIR/version.json" ]] && command -v jq >/dev/null 2>&1; then
+        inst_channel=$(jq -r '.channel // empty' "$INSTALL_DIR/version.json" 2>/dev/null || echo "")
+        inst_ref=$(jq -r '.ref // empty' "$INSTALL_DIR/version.json" 2>/dev/null || echo "")
+    fi
+
+    local inst_nc="" tgt_nc=""
+    [[ -f "$INSTALL_DIR/docker-compose.yml" ]] && inst_nc=$(parse_nc_tag "$INSTALL_DIR/docker-compose.yml")
+    [[ -n "$target_compose" && -f "$target_compose" ]] && tgt_nc=$(parse_nc_tag "$target_compose")
+
+    local reason
+    if reason=$(detect_downgrade "$inst_channel" "$inst_ref" "$CHANNEL" "$TARGET_REF" "$inst_nc" "$tgt_nc"); then
+        if [[ "${ALLOW_DOWNGRADE:-0}" == "1" ]]; then
+            log_warn "DOWNGRADE OVERRIDE (ALLOW_DOWNGRADE=1): $reason"
+            log_warn "Proceeding anyway — Nextcloud and/or the dashboard may break. Hope you have a backup."
+            return 0
+        fi
+        log_error "Refusing downgrade: $reason"
+        log_error "HomeBrain updates are one-way: Nextcloud will not start on an older image once"
+        log_error "its data has migrated, and the dashboard breaks on a mixed code tree."
+        log_error "To go back, restore a pre-upgrade backup instead:"
+        log_error "    sudo bash $INSTALL_DIR/scripts/restore.sh"
+        log_error "If you understand the risk and have a backup, re-run with ALLOW_DOWNGRADE=1."
+        exit 1
+    fi
+}
+
 # 0. Self-Update Check
 # Ensure we start clean even if a previous run aborted without cleanup
 SELF_TMP_DIR="/tmp/homebrain_self_update"
@@ -41,6 +78,18 @@ curl -L -f -s --max-time 30 --retry 3 --retry-delay 5 "$BASE_URL/update.sh" -o "
 curl -L -f -s --max-time 30 --retry 3 --retry-delay 5 "$BASE_URL/common.sh" -o "$SELF_TMP_DIR/common.sh" || { log_error "Failed to fetch new common script"; exit 1; }
 
 chmod +x "$SELF_TMP_DIR/update.sh"
+
+# Downgrade guard (Layer 1) — MUST run before the self-update re-exec below.
+# A stable->old update self-updates to the target's update.sh and exec's it;
+# older scripts have no guard, so checking here is the only place that protects
+# the re-exec. Fetch the target docker-compose.yml (one level up from BASE_URL)
+# for the authoritative Nextcloud tag; if that fetch fails we still catch the
+# common beta->stable / older-tag cases from version.json alone.
+RAW_ROOT="${BASE_URL%/scripts}"
+TARGET_COMPOSE="$SELF_TMP_DIR/target-compose.yml"
+curl -L -f -s --max-time 30 --retry 2 --retry-delay 3 "$RAW_ROOT/docker-compose.yml" -o "$TARGET_COMPOSE" \
+    || { log_warn "Could not fetch target docker-compose.yml; checking release version only."; rm -f "$TARGET_COMPOSE"; }
+abort_if_downgrade "$TARGET_COMPOSE"
 
 CURRENT_UPDATE="$SCRIPT_DIR/update.sh"
 CURRENT_COMMON="$SCRIPT_DIR/common.sh"
@@ -73,6 +122,12 @@ curl -L -f -s --max-time 60 --retry 3 --retry-delay 5 "$URL" -o "$TEMP_DIR/updat
 log_info "Extracting..."
 mkdir -p "$TEMP_DIR/extract"
 tar -xzf "$TEMP_DIR/update.tar.gz" --strip-components=1 -C "$TEMP_DIR/extract" || { log_error "Extraction failed"; exit 1; }
+
+# Downgrade guard (Layer 2) — authoritative, network-free re-check now that the
+# real target tree is on disk. Runs before the destructive rsync so a downgrade
+# that slipped past the best-effort Layer 1 fetch still aborts before any data
+# or code is touched.
+abort_if_downgrade "$TEMP_DIR/extract/docker-compose.yml"
 
 # 4. Atomic File Sync
 log_info "Applying file updates, preserving configuration..."


### PR DESCRIPTION
## Problem

A user updated their HomeCloud target on the beta channel, then ran a **stable** update to an old release (`v1.1.0`). The dashboard started 500ing on every page with `jinja2 ... UndefinedError: 'platform' is undefined`, and Nextcloud showed **"update needed"** and would not start.

Root cause: **HomeBrain's update path is one-way, but `update.sh` happily ran any tag — including older ones.** Two independent things break on a downgrade:

1. **Nextcloud** migrates its data + `config.php` version forward the first time a newer image boots (beta ran `nextcloud:32.0.9`). An older image (`v1.1.0` ships `32.0.3`) then refuses to start — *"version of the data is higher than the docker image version, downgrading is not supported."*
2. **The Flask manager** — templates and `app.py` move together. A partially/fully applied downgrade leaves the newer templates (which call `{{ platform.* }}`) rendered by an older `app.py` that predates the `inject_platform()` context processor → `'platform' is undefined` on every route. (`v1.1.0` is internally consistent — neither the processor nor the template refs exist — which is how we know the live tree was a *mix*.)

There is no safe automated rollback; the only way back is `restore.sh` from a pre-upgrade backup. So we refuse downgrades up front.

## Change

A downgrade guard, with the decision logic isolated in `common.sh` as pure, unit-tested functions:

- **`version_lt` / `parse_nc_tag` / `detect_downgrade`** (`common.sh`). A downgrade is flagged when **either**:
  - the **Nextcloud image tag** regresses (the unrecoverable signal), or
  - the **HomeBrain release** regresses — `update.sh` treats every non-`stable` channel (`beta`, `dev`, …) as the bleeding edge built from `main`, so any non-stable→`stable` move is a downgrade, and `stable`→older-tag compares semver.
- **`abort_if_downgrade`** (`update.sh`) runs at **two layers**:
  - **Layer 1 — before the self-update re-exec.** A stable→old update self-updates to the *target's* `update.sh` and `exec`s it; older scripts have no guard, so this is the only place that protects the hand-off. It fetches the target `docker-compose.yml` for the authoritative NC tag (falling back to the release-version signal if the fetch fails).
  - **Layer 2 — after extraction, before the destructive `rsync`.** Network-free, authoritative re-check on the real target tree.
- **`ALLOW_DOWNGRADE=1`** escape hatch for a deliberate, backup-in-hand revert (loud warning, then proceeds).

Forward and equal updates (`beta`/`dev`→`main`, `stable`→newer tag, re-running the same tag) are unaffected. Fresh installs (no `version.json`) are never falsely blocked.

## Testing

- **Unit:** `bash scripts/tests/test_update_guard.sh` → **26/26 pass** (Linux + macOS; pure logic uses no `sort -V`/Docker/network/root). Covers the exact incident, `dev`-channel, NC-only regression with no `version.json`, and all forward/equal cases.
- **Integration:** extracted the real `abort_if_downgrade` and ran it under `set -euo pipefail` against on-disk fixtures — confirmed **block (exit 1)**, **`ALLOW_DOWNGRADE=1` override (exit 0)**, **beta→beta**, and **stable→newer forward** all behave correctly.
- **Real fetch/parse:** replicated the Layer-1 path against GitHub — `v1.1.0`→`32.0.3`, `main`→`32.0.9`, the exact tags behind the incident.
- **shellcheck:** clean for all added code (pre-existing warnings elsewhere untouched).

### Pre-merge hardware check (per docs/TESTING.md → "Update / downgrade guard")

Target is LAN-only and was unreachable from the dev session, so the on-device run is left for the reviewer. Read-only, no update executed:

```bash
cat /opt/homebrain/version.json
# Expect ABORT before rsync with "Refusing downgrade: …", exit 1, stack untouched:
sudo bash /opt/homebrain/scripts/update.sh stable v1.1.0
# Expect normal success:
sudo bash /opt/homebrain/scripts/update.sh beta main
```

## Note for the affected box

This prevents *recurrence*; to recover the already-broken target, roll **forward** to the version its data expects: `sudo bash /opt/homebrain/scripts/update.sh beta main` (restores `app.py`+templates consistency and pulls `nextcloud:32.0.9`, clearing "update needed").

🤖 Generated with [Claude Code](https://claude.com/claude-code)