### PR TITLE
feat(channels): link WhatsApp on stock OpenClaw via plugin + lazy install

### DIFF
--- a/config/openclaw-plugins/homebrain-whatsapp-login/README.md
+++ b/config/openclaw-plugins/homebrain-whatsapp-login/README.md
@@ -1,0 +1,99 @@
+# HomeBrain WhatsApp Login (OpenClaw plugin)
+
+A tiny first-party OpenClaw plugin that exposes the WhatsApp QR login flow as a
+**gateway HTTP route**, so the HomeBrain dashboard can render the QR and poll for
+completion against **stock upstream `openclaw`** — no fork required.
+
+```
+POST /api/channels/login/whatsapp/start  -> { qrDataUrl, ... }
+POST /api/channels/login/whatsapp/wait   -> { qrDataUrl?, ... }
+```
+
+## Why this exists
+
+Upstream OpenClaw ships the WhatsApp login *primitives*
+(`startWebLoginWithQr` / `waitForWebLogin` in `@openclaw/whatsapp`) and the
+`whatsapp_login` *agent tool*, but **not** an HTTP route returning a raw QR data
+URL for a web dashboard. The HomeBrain OpenClaw fork added that route as a *core*
+gateway file (`src/gateway/channel-login-http.ts`), which forced HomeBrain to run
+a custom fork build instead of the npm release.
+
+This plugin re-implements the identical route through the **public plugin SDK**
+(`api.registerHttpRoute`, the same mechanism upstream's `webhooks` / `nostr`
+extensions use), letting HomeBrain install stock `openclaw` from npm and retire
+the fork dependency for channel linking.
+
+`src/integrations.py` (`_gateway_whatsapp_login`) calls these paths unchanged —
+the contract is byte-for-byte compatible with the fork route.
+
+## How it works
+
+- Registered with `auth: "gateway"`. The gateway's plugin-http dispatcher
+  enforces the gateway bearer token **before** invoking the handler, so the
+  handler does no auth itself. HomeBrain injects the token from
+  `~/.openclaw/openclaw.json`.
+- `activation.onStartup: true` so the route is mounted at gateway boot.
+- The WhatsApp login module is loaded lazily on first request; if
+  `@openclaw/whatsapp` is not installed the route returns
+  `404 {"error":"WhatsApp plugin is not installed"}`.
+- **Resolution.** OpenClaw installs each plugin into its own isolated directory
+  and symlinks the `openclaw` package into it (so a plugin can
+  `import "openclaw/..."`), but it does *not* make sibling plugins resolvable
+  from one another. A bare `import("@openclaw/whatsapp/...")` from here therefore
+  cannot find the WhatsApp plugin. We resolve it by **absolute path** instead:
+  `resolveStateDir()` (from `openclaw/plugin-sdk/state-paths`, honoring
+  `OPENCLAW_STATE_DIR` / `OPENCLAW_CONFIG_PATH`) → `<stateDir>/npm/node_modules/
+  @openclaw/whatsapp/dist/login-qr-api.js` (npm-spec installs), with the
+  `<stateDir>/extensions/...` clawhub/local layouts and the bare specifiers as
+  fallbacks. Importing by absolute path is safe: the module's own `openclaw/*`
+  imports resolve through the symlink OpenClaw places in the npm dir, so it binds
+  to the **same `defaultRuntime` singleton** as the gateway (Node dedupes modules
+  by real path).
+- Login is self-contained — it opens its own WhatsApp socket, renders the QR, and
+  persists credentials to the on-disk auth dir. The running WhatsApp channel
+  picks those creds up independently, so driving login from this separate plugin
+  is safe.
+
+## Requirements
+
+- `openclaw >= 2026.5.12` (provides `openclaw/plugin-sdk/core` and the
+  plugin-http-route dispatcher with `match: "prefix"` + `auth: "gateway"`).
+- `@openclaw/whatsapp >= 2026.5.12` installed (provides `dist/login-qr-api.js`).
+
+Both are declared as `peerDependencies`; they are resolved at runtime by the
+OpenClaw plugin loader, so this plugin has no installable dependencies of its own.
+
+## Install (handled by provisioning)
+
+`scripts/utilities.sh::setup_openclaw` installs this from the repo:
+
+```bash
+openclaw plugins install <repo>/config/openclaw-plugins/homebrain-whatsapp-login --force
+```
+
+It is plain ESM JavaScript — no build step.
+
+## The WhatsApp channel plugin (separate from this route)
+
+This plugin only provides the *route*. The actual `@openclaw/whatsapp` channel
+plugin (which owns `startWebLoginWithQr` / `waitForWebLogin`) is **not bundled in
+stock OpenClaw** and is **not pre-installed** at provisioning. The HomeBrain
+dashboard installs it lazily the first time a user links WhatsApp:
+
+- `src/integrations.py::whatsapp_add` runs
+  `openclaw plugins install @openclaw/whatsapp@<pin>` in the background (the
+  install is too slow for the gunicorn worker timeout) and replies
+  `202 {status:"installing"}`; the dashboard polls until it reports
+  `configured`, then requests the QR.
+- The version is pinned in `config/versions.json` under `openclaw_whatsapp` and
+  **must stay peer-compatible** with the `openclaw` pin — a newer WhatsApp build
+  can require a newer host (`peerDependencies.openclaw`, `compat.pluginApi`).
+
+Telegram needs none of this: it is bundled in core OpenClaw.
+
+## Compatibility note
+
+This plugin imports `@openclaw/whatsapp/dist/login-qr-api.js`. That subpath and
+the `startWebLoginWithQr` / `waitForWebLogin` signatures are effectively public
+(the upstream `whatsapp_login` agent tool uses them) but not contractually
+frozen. Re-verify on each pinned OpenClaw bump in `config/versions.json`.

--- a/config/openclaw-plugins/homebrain-whatsapp-login/index.js
+++ b/config/openclaw-plugins/homebrain-whatsapp-login/index.js
@@ -1,0 +1,225 @@
+/**
+ * HomeBrain WhatsApp Login — OpenClaw plugin
+ * ------------------------------------------------------------------
+ * Exposes the WhatsApp QR login flow as a gateway HTTP route so the
+ * HomeBrain Flask dashboard can render the QR in a plain <img> and poll
+ * for completion — no LLM turn, no MEDIA: directive, no reverse-proxy
+ * round-trip.
+ *
+ * WHY THIS EXISTS
+ *   Upstream OpenClaw ships the WhatsApp *login primitives*
+ *   (`startWebLoginWithQr` / `waitForWebLogin` in @openclaw/whatsapp) and
+ *   the `whatsapp_login` *agent tool*, but NOT an HTTP route that returns
+ *   a raw QR data URL. The HomeBrain fork added that route as a core
+ *   gateway file (src/gateway/channel-login-http.ts). This plugin
+ *   re-implements the exact same route via the public plugin SDK
+ *   (`api.registerHttpRoute`), so HomeBrain can install stock upstream
+ *   `openclaw` from npm and drop the fork entirely.
+ *
+ * CONTRACT (kept byte-for-byte compatible with the fork route so the
+ * dashboard's existing calls in src/integrations.py work unchanged):
+ *   POST /api/channels/login/whatsapp/start  -> { qrDataUrl, ... }
+ *   POST /api/channels/login/whatsapp/wait   -> { qrDataUrl?, ... }
+ *
+ * AUTH
+ *   Registered with auth:"gateway". The gateway's plugin-http dispatcher
+ *   enforces the gateway bearer token BEFORE invoking this handler, so the
+ *   handler itself performs no auth (unlike the fork's core route, which
+ *   had to authorize inline). HomeBrain injects the gateway token from
+ *   ~/.openclaw/openclaw.json.
+ *
+ * STATE MODEL
+ *   The login flow is self-contained: it opens its own WhatsApp socket,
+ *   renders the QR, and persists credentials to the on-disk auth dir. The
+ *   running WhatsApp channel picks those creds up independently, so driving
+ *   login from this separate plugin is safe — the only shared in-memory
+ *   state (the active-QR map) lives within this module instance, which is
+ *   exactly the start->wait pairing we need.
+ */
+
+import { definePluginEntry } from "openclaw/plugin-sdk/core";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const CHANNEL_LOGIN_PREFIX = "/api/channels/login/";
+
+// ---- tiny HTTP helpers (ported from the fork's http-common.ts) ----------
+
+function sendJson(res, status, body) {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(JSON.stringify(body));
+}
+
+function sendText(res, status, body) {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "text/plain; charset=utf-8");
+  res.end(body);
+}
+
+function sendMethodNotAllowed(res, allow = "POST") {
+  res.setHeader("Allow", allow);
+  sendText(res, 405, "Method Not Allowed");
+}
+
+function readJsonBody(req) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString()) || {});
+      } catch {
+        resolve({});
+      }
+    });
+    req.on("error", () => resolve({}));
+  });
+}
+
+// ---- lazy WhatsApp login module ----------------------------------------
+// Loaded on first request so the gateway never fails at startup when the
+// @openclaw/whatsapp channel plugin is not installed (it returns 404 instead).
+//
+// RESOLUTION — the subtle part. OpenClaw installs each plugin into its OWN
+// isolated directory and symlinks the *openclaw* package into it so the plugin
+// can `import "openclaw/..."`. It does NOT make sibling plugins resolvable from
+// one another. So a bare `import("@openclaw/whatsapp/...")` from THIS plugin's
+// dir will not find the WhatsApp plugin — they live in separate trees.
+//
+// We therefore resolve @openclaw/whatsapp by absolute path. npm-spec channel
+// plugins install into `<stateDir>/npm/node_modules/<pkg>`; clawhub/local
+// installs land under `<stateDir>/extensions/`. We compute <stateDir> with
+// OpenClaw's own `resolveStateDir` (imported lazily so an older host that lacks
+// the subpath only loses the fallback, not the whole plugin), which honors
+// OPENCLAW_STATE_DIR / OPENCLAW_CONFIG_PATH exactly as the gateway does.
+//
+// Importing the WhatsApp login module by absolute path is safe: its own
+// `openclaw/*` imports resolve through the openclaw symlink OpenClaw places in
+// the npm dir, so it binds to the SAME `defaultRuntime` singleton as the
+// gateway (Node dedupes modules by real path).
+
+let whatsappLoginModule;
+
+async function tryImportLogin(specifier) {
+  try {
+    const mod = await import(specifier);
+    return mod && typeof mod.startWebLoginWithQr === "function" ? mod : null;
+  } catch {
+    return null;
+  }
+}
+
+async function whatsappLoginCandidates() {
+  const files = [];
+  try {
+    const { resolveStateDir } = await import("openclaw/plugin-sdk/state-paths");
+    const stateDir = resolveStateDir();
+    const rel = path.join("@openclaw", "whatsapp", "dist", "login-qr-api.js");
+    files.push(
+      // npm-spec install (deterministic, what HomeBrain provisioning uses).
+      path.join(stateDir, "npm", "node_modules", rel),
+      // clawhub / local-dir installs land in the extensions dir.
+      path.join(stateDir, "extensions", rel),
+      path.join(stateDir, "extensions", "whatsapp", "dist", "login-qr-api.js"),
+    );
+  } catch {
+    // state-paths not available on this host — rely on the bare fallback below.
+  }
+  return files;
+}
+
+async function loadWhatsAppLogin() {
+  if (whatsappLoginModule !== undefined) return whatsappLoginModule;
+
+  // 1) Absolute paths derived from OpenClaw's state dir (the real location).
+  for (const file of await whatsappLoginCandidates()) {
+    if (!existsSync(file)) continue;
+    const mod = await tryImportLogin(pathToFileURL(file).href);
+    if (mod) return (whatsappLoginModule = mod);
+  }
+
+  // 2) Bare specifiers — harmless forward-compat in case a future host wires
+  //    peer-plugin resolution, or @openclaw/whatsapp is otherwise on our path.
+  for (const spec of [
+    "@openclaw/whatsapp/dist/login-qr-api.js",
+    "@openclaw/whatsapp/login-qr-api.js",
+  ]) {
+    const mod = await tryImportLogin(spec);
+    if (mod) return (whatsappLoginModule = mod);
+  }
+
+  whatsappLoginModule = null;
+  return whatsappLoginModule;
+}
+
+// ---- route handler ------------------------------------------------------
+
+async function handleWhatsAppLogin(req, res) {
+  const requestUrl = new URL(req.url ?? "/", "http://localhost");
+
+  if (req.method !== "POST") {
+    sendMethodNotAllowed(res, "POST");
+    return;
+  }
+
+  // action is e.g. "whatsapp/start" / "whatsapp/wait" (mirrors the fork).
+  const action = requestUrl.pathname.startsWith(CHANNEL_LOGIN_PREFIX)
+    ? requestUrl.pathname.slice(CHANNEL_LOGIN_PREFIX.length)
+    : "";
+
+  if (action !== "whatsapp/start" && action !== "whatsapp/wait") {
+    sendText(res, 404, "unknown channel login action");
+    return;
+  }
+
+  const mod = await loadWhatsAppLogin();
+  if (!mod) {
+    sendJson(res, 404, { ok: false, error: "WhatsApp plugin is not installed" });
+    return;
+  }
+
+  const body = await readJsonBody(req);
+
+  try {
+    if (action === "whatsapp/start") {
+      const result = await mod.startWebLoginWithQr({
+        force: body.force === true,
+        timeoutMs: typeof body.timeoutMs === "number" ? body.timeoutMs : 30_000,
+      });
+      sendJson(res, 200, result);
+    } else {
+      const result = await mod.waitForWebLogin({
+        timeoutMs: typeof body.timeoutMs === "number" ? body.timeoutMs : 120_000,
+        currentQrDataUrl:
+          typeof body.currentQrDataUrl === "string" ? body.currentQrDataUrl : undefined,
+      });
+      sendJson(res, 200, result);
+    }
+  } catch (err) {
+    sendJson(res, 500, {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+// ---- plugin entry -------------------------------------------------------
+
+export default definePluginEntry({
+  id: "homebrain-whatsapp-login",
+  name: "HomeBrain WhatsApp Login",
+  description:
+    "Gateway HTTP route for WhatsApp QR linking, consumed by the HomeBrain dashboard.",
+  register(api) {
+    api.registerHttpRoute({
+      // Prefix match so /api/channels/login/whatsapp/{start,wait} both hit
+      // this handler; the handler routes on the trailing action segment.
+      path: "/api/channels/login/whatsapp",
+      match: "prefix",
+      auth: "gateway",
+      handler: handleWhatsAppLogin,
+    });
+  },
+});

--- a/config/openclaw-plugins/homebrain-whatsapp-login/openclaw.plugin.json
+++ b/config/openclaw-plugins/homebrain-whatsapp-login/openclaw.plugin.json
@@ -1,0 +1,8 @@
+{
+  "id": "homebrain-whatsapp-login",
+  "name": "HomeBrain WhatsApp Login",
+  "description": "Gateway HTTP route (POST /api/channels/login/whatsapp/{start,wait}) for WhatsApp QR linking, consumed by the HomeBrain dashboard. Replaces the equivalent core route from the OpenClaw fork so HomeBrain can run stock upstream OpenClaw.",
+  "activation": {
+    "onStartup": true
+  }
+}

--- a/config/openclaw-plugins/homebrain-whatsapp-login/package.json
+++ b/config/openclaw-plugins/homebrain-whatsapp-login/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@homebrain/whatsapp-login",
+  "version": "0.1.0",
+  "private": true,
+  "description": "HomeBrain plugin: exposes the WhatsApp QR login flow as a gateway HTTP route so the dashboard can drive channel linking on stock upstream OpenClaw — no fork required.",
+  "type": "module",
+  "license": "MIT",
+  "openclaw": {
+    "extensions": [
+      "./index.js"
+    ]
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.5.12",
+    "@openclaw/whatsapp": ">=2026.5.12"
+  }
+}

--- a/config/versions.json
+++ b/config/versions.json
@@ -9,6 +9,10 @@
   "openclaw": {
     "version": "2026.5.12"
   },
+  "openclaw_whatsapp": {
+    "_comment": "WhatsApp is a separate channel plugin (not bundled in openclaw). Pin MUST stay peer-compatible with openclaw.version above: @openclaw/whatsapp declares peerDependencies.openclaw and compat.pluginApi (e.g. 2026.5.28 requires openclaw>=2026.5.28). Bump this in lockstep with openclaw.version. Telegram is bundled in core and needs no pin.",
+    "version": "2026.5.12"
+  },
   "vaultwarden": {
     "tag": "1.35.8"
   }

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -225,6 +225,47 @@ default Vault bootstrap.
 - [ ] Proton account: `docker compose --profile proton-bridge up -d`
       starts Bridge; `imap_host=127.0.0.1`, `imap_port=12143` works.
 
+### Channel linking — Telegram + WhatsApp (stock upstream OpenClaw)
+
+HomeBrain runs **stock npm `openclaw`** (no fork). Telegram is bundled in core;
+WhatsApp is a separate plugin installed on demand. The WhatsApp QR *route* is
+provided by the first-party `homebrain-whatsapp-login` plugin
+(`config/openclaw-plugins/`). Revert any fork systemd-unit swap first
+(see the openclaw-fork-swap runbook) so the gateway runs the npm build.
+
+**Plugin route (provisioned):**
+
+- [ ] `homebrain-whatsapp-login` is installed:
+      `openclaw plugins list` shows it, and it lives under
+      `~/.openclaw/extensions/`.
+- [ ] On a fresh box the WhatsApp channel plugin is **absent**:
+      `~/.openclaw/npm/node_modules/@openclaw/whatsapp` does not exist.
+
+**Telegram (bundled — no install):**
+
+- [ ] Paste a bot token → row flips to configured; daemon restarts.
+- [ ] Send `/pair` from the bot, approve the code in the dashboard
+      (`openclaw pairing approve telegram <code> --notify`) → DM works.
+
+**WhatsApp (lazy channel-plugin install + QR):**
+
+- [ ] Click **Link WhatsApp** on a fresh box → dashboard shows
+      "Installing WhatsApp support…" (the `/api/channels/whatsapp/add`
+      endpoint returns `202 {status:"installing"}`).
+- [ ] Within ~60 s `~/.openclaw/npm/node_modules/@openclaw/whatsapp/package.json`
+      appears; its `version` equals `config/versions.json:openclaw_whatsapp.version`
+      and is peer-compatible with the `openclaw` pin.
+- [ ] After install the dashboard auto-advances to the QR; raw route check:
+      `curl -s -H "Authorization: Bearer $(jq -r .gateway.auth.token ~/.openclaw/openclaw.json)" \
+       -X POST 127.0.0.1:18789/api/channels/login/whatsapp/start` returns
+      JSON containing `qrDataUrl`.
+- [ ] Before the channel plugin is installed, the same curl returns
+      `404 {"error":"WhatsApp plugin is not installed"}` (graceful, not a 500).
+- [ ] Scan the QR with WhatsApp → linked; `~/.openclaw/whatsapp-auth/default/creds.json`
+      gains a `me.id`; the channel row flips to linked.
+- [ ] Re-clicking **Link WhatsApp** after install returns `configured`
+      immediately (no second install; flock prevents overlapping installs).
+
 ### Cross-cutting
 
 - [ ] All `*.token`, `vault.session`, `email_accounts.json` are mode 0600

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -182,31 +182,42 @@ if command -v jq >/dev/null 2>&1 && [[ -f "$INSTALL_DIR/config/versions.json" ]]
             log_info "OpenClaw: ${old_openclaw_ver} → ${new_openclaw_ver}. Updating..."
             bash "$UPDATE_DEPS_SCRIPT" openclaw || log_warn "OpenClaw update failed — check logs."
         else
-            # Config drift catch-all: the openclaw npm package didn't change but the
-            # patch_openclaw_config jq pipeline in utilities.sh may have (new schema
-            # keys, refreshed allowedOrigins, etc.). Re-patch the existing
-            # openclaw.json and only bounce the daemon when the file actually
-            # changes — the npm install is skipped because the version matched.
+            # Plugin + config drift catch-all. The openclaw npm package didn't
+            # change, but two things still might have and are otherwise ONLY
+            # applied by setup_openclaw (which the version-bump branch above runs
+            # and this one does not):
+            #   1. The bundled HomeBrain plugins under config/openclaw-plugins/
+            #      (e.g. the WhatsApp QR login route). Without re-installing them
+            #      here, a new/changed plugin would rsync into the install dir but
+            #      never register with the gateway.
+            #   2. The patch_openclaw_config jq pipeline in utilities.sh (new
+            #      schema keys, refreshed allowedOrigins, etc.).
+            # Snapshot openclaw.json first, then (re)install plugins (which mutate
+            # plugins.entries) and re-patch config; restart the daemon only when
+            # the file actually changed so a freshly-registered route/schema is
+            # picked up without a needless bounce.
             # After self-update re-exec $SCRIPT_DIR points at /tmp/homebrain_self_update
             # which only has update.sh + common.sh. utilities.sh lives in the rsynced
-            # install dir, so always source from there.
+            # install dir, so always source from there — and pass the plugins root
+            # explicitly, because sourcing it resets SCRIPT_DIR to this script's $0.
             UTILS_FILE="$INSTALL_DIR/scripts/utilities.sh"
             if command -v openclaw >/dev/null 2>&1 && [[ -f "$UTILS_FILE" ]]; then
                 CFG="${HOMEBRAIN_HOME:-/home/homebrain}/.openclaw/openclaw.json"
                 if [[ -f "$CFG" ]]; then
-                    log_info "Refreshing openclaw.json against current utilities.sh..."
-                    cp "$CFG" "${CFG}.preupdate"
+                    log_info "Refreshing openclaw plugins + config against current install..."
                     # shellcheck disable=SC1090
                     source "$UTILS_FILE"
                     load_env 2>/dev/null || true
                     load_versions 2>/dev/null || true
+                    cp "$CFG" "${CFG}.preupdate"
+                    install_homebrain_openclaw_plugins "$INSTALL_DIR/config/openclaw-plugins"
                     if patch_openclaw_config "$CFG" "${AI_MODEL_ID:-}" "${OC_CTX_SIZE:-}"; then
                         if ! cmp -s "${CFG}.preupdate" "$CFG"; then
-                            log_info "openclaw.json changed — restarting daemon to apply."
+                            log_info "openclaw plugins/config changed — restarting daemon to apply."
                             run_as_admin systemctl --user restart openclaw-gateway >/dev/null 2>&1 \
                                 || log_warn "openclaw-gateway restart failed — check logs."
                         else
-                            log_info "openclaw.json already matches expected shape — no daemon restart."
+                            log_info "openclaw plugins/config already current — no daemon restart."
                         fi
                     fi
                     rm -f "${CFG}.preupdate"

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1301,7 +1301,11 @@ run_as_admin() {
 # configSchema, like ours) enables it in plugins.entries. Idempotent via
 # --force. Runs as the homebrain user so it writes to ~/.openclaw.
 install_homebrain_openclaw_plugins() {
-    local plugins_root="${SCRIPT_DIR}/../config/openclaw-plugins"
+    # Optional $1 overrides the plugins root. Callers that source this file from
+    # a different working tree (e.g. update.sh, where sourcing resets SCRIPT_DIR
+    # to that script's $0 — the self-update temp dir after re-exec) MUST pass the
+    # root explicitly, else the SCRIPT_DIR-relative default misses the tree.
+    local plugins_root="${1:-${SCRIPT_DIR}/../config/openclaw-plugins}"
     [[ -d "$plugins_root" ]] || return 0
     local dir pid
     for dir in "$plugins_root"/*/; do

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1292,6 +1292,28 @@ run_as_admin() {
         "$@"
 }
 
+# Install HomeBrain-owned OpenClaw plugins from the repo
+# (config/openclaw-plugins/). These add dashboard-facing functionality that
+# stock upstream OpenClaw does not expose as a gateway HTTP route — currently
+# the WhatsApp QR login flow consumed by src/integrations.py — WITHOUT forking
+# OpenClaw itself. Each plugin dir carries an openclaw.plugin.json manifest;
+# `openclaw plugins install` stages it and (for plugins with no required
+# configSchema, like ours) enables it in plugins.entries. Idempotent via
+# --force. Runs as the homebrain user so it writes to ~/.openclaw.
+install_homebrain_openclaw_plugins() {
+    local plugins_root="${SCRIPT_DIR}/../config/openclaw-plugins"
+    [[ -d "$plugins_root" ]] || return 0
+    local dir pid
+    for dir in "$plugins_root"/*/; do
+        [[ -f "${dir}openclaw.plugin.json" ]] || continue
+        pid=$(basename "$dir")
+        log_info "Installing HomeBrain OpenClaw plugin: ${pid}"
+        if ! run_as_admin openclaw plugins install "${dir%/}" --force >/dev/null 2>&1; then
+            log_warn "Failed to install HomeBrain plugin '${pid}'. Dashboard features that depend on it may be unavailable until the next setup run."
+        fi
+    done
+}
+
 setup_openclaw() {
     log_info "=== Setting up OpenClaw AI Assistant ==="
     load_env
@@ -1393,12 +1415,19 @@ setup_openclaw() {
         fi
     fi
 
-    # Channel plugins (matrix, nextcloud-talk, telegram, signal, etc.)
-    # are intentionally NOT pre-installed here. The agent's `channels`
-    # self-config tool installs them on demand from the official-external
-    # catalog when the user actually wants a given messenger — which keeps
-    # fresh provisioning fast and avoids cluttering the OpenClaw UI with
-    # never-configured channel cards.
+    # Channel plugins: Telegram ships INSIDE core OpenClaw, so it needs no
+    # install. WhatsApp is a separate `@openclaw/whatsapp` plugin that is NOT
+    # bundled and is intentionally NOT pre-installed here — keeping fresh
+    # provisioning fast and avoiding never-configured channel cards. On stock
+    # upstream OpenClaw the install is HomeBrain's responsibility (the fork's
+    # `channels` self-config tool is absent): the dashboard installs it lazily
+    # and pinned on first link — `openclaw plugins install @openclaw/whatsapp@<v>`
+    # where <v> is config/versions.json:openclaw_whatsapp.version, kept peer-
+    # compatible with the openclaw pin — in src/integrations.py. That install is
+    # backgrounded (too slow for the gunicorn worker timeout) and the dashboard
+    # polls through an "installing" state. The WhatsApp QR login *route* is
+    # provided separately by the homebrain-whatsapp-login plugin installed below,
+    # independent of the channel plugin.
 
     # --- [2/3] Write config ---
     log_info "[2/3] Writing config..."
@@ -1424,6 +1453,13 @@ setup_openclaw() {
     chown -R "${HOMEBRAIN_USER}:${HOMEBRAIN_USER}" "${HOMEBRAIN_HOME}/.openclaw"
     chmod 600 "$config_dest"
     log_info "Config written to $config_dest"
+
+    # Install HomeBrain-owned plugins (e.g. the WhatsApp QR login HTTP route)
+    # AFTER the config write above: `openclaw plugins install` mutates
+    # plugins.entries in openclaw.json, so running it before the first-install
+    # template copy would clobber the enablement. The daemon start below then
+    # picks up the freshly-registered routes.
+    install_homebrain_openclaw_plugins
 
     # --- [3/3] Register and start daemon ---
     log_info "[3/3] Registering and starting daemon..."

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -75,6 +75,21 @@ CHANNEL_ORDER = ["telegram", "whatsapp"]
 TELEGRAM_API_BASE = "https://api.telegram.org/bot"
 OPENCLAW_GATEWAY_BASE = "http://127.0.0.1:18789"
 
+# WhatsApp is a separate OpenClaw channel plugin (Telegram is bundled in core,
+# WhatsApp is not). On stock upstream OpenClaw it must be installed on demand —
+# see _install_whatsapp_plugin_locked(). It installs as an npm-spec plugin into
+# <OPENCLAW_DIR>/npm/node_modules/@openclaw/whatsapp.
+VERSIONS_FILE = os.path.join(INSTALL_DIR, "config", "versions.json")
+WHATSAPP_PLUGIN_PKG = "@openclaw/whatsapp"
+WHATSAPP_PLUGIN_DIR = os.path.join(
+    OPENCLAW_DIR, "npm", "node_modules", "@openclaw", "whatsapp")
+# Floor used only if config/versions.json is unreadable. Keep peer-compatible
+# with the pinned openclaw version (see config/versions.json:openclaw_whatsapp).
+_DEFAULT_WHATSAPP_VERSION = "2026.5.12"
+# Cross-worker lock so concurrent dashboard requests (3 gunicorn workers) don't
+# launch overlapping npm installs into the same dir.
+_WHATSAPP_INSTALL_LOCK = "/tmp/homebrain-whatsapp-install.lock"
+
 
 # ---------------------------------------------------------------------------
 # Helpers — env, files, derivation
@@ -1034,6 +1049,89 @@ def _whatsapp_auth_status() -> dict:
     return {"linked": False}
 
 
+# --- WhatsApp channel-plugin install (stock OpenClaw) ----------------------
+# Telegram ships inside core OpenClaw; WhatsApp does not — it's a separate
+# `@openclaw/whatsapp` channel plugin. The homebrain-whatsapp-login plugin
+# (installed at provision) provides the QR *route*, but it 404s with
+# "WhatsApp plugin is not installed" until the channel plugin itself is present.
+# We install it lazily the first time the user links WhatsApp.
+
+def _whatsapp_plugin_installed() -> bool:
+    """True once @openclaw/whatsapp is on disk (fast; just a file check)."""
+    return os.path.exists(os.path.join(WHATSAPP_PLUGIN_DIR, "package.json"))
+
+
+def _whatsapp_plugin_spec() -> str:
+    """`@openclaw/whatsapp@<pinned>` — pinned so we never pull a newer build
+    whose peerDependencies/compat.pluginApi outrun the installed openclaw
+    (e.g. 2026.5.28 requires openclaw>=2026.5.28). Prefer the dedicated pin,
+    fall back to the openclaw version, then to a safe floor."""
+    version = ""
+    try:
+        with open(VERSIONS_FILE) as f:
+            data = json.load(f)
+        version = (data.get("openclaw_whatsapp", {}).get("version")
+                   or data.get("openclaw", {}).get("version") or "")
+    except (OSError, json.JSONDecodeError, AttributeError):
+        version = ""
+    if not version:
+        version = _DEFAULT_WHATSAPP_VERSION
+    return f"{WHATSAPP_PLUGIN_PKG}@{version}" if version else WHATSAPP_PLUGIN_PKG
+
+
+def _install_whatsapp_plugin_locked() -> None:
+    """Install the WhatsApp channel plugin as the homebrain user.
+
+    Runs `openclaw plugins install @openclaw/whatsapp@<pin>` (an npm fetch +
+    dependency build that routinely takes 20-60 s — far past the gunicorn
+    worker timeout), so this is only ever called from a background thread.
+    A non-blocking flock dedupes overlapping installs across gunicorn workers;
+    if another worker holds it we simply return (it's doing the work)."""
+    import fcntl
+    try:
+        fd = open(_WHATSAPP_INSTALL_LOCK, "w")
+    except OSError:
+        return
+    try:
+        try:
+            fcntl.flock(fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return  # another worker is already installing
+        if _whatsapp_plugin_installed():
+            return
+        spec = _whatsapp_plugin_spec()
+        logging.info("installing WhatsApp channel plugin: %s", spec)
+        try:
+            proc = subprocess.run(
+                ["sudo", "-u", "homebrain", "openclaw", "plugins", "install", spec],
+                capture_output=True, text=True, timeout=300,
+            )
+            if proc.returncode == 0 and _whatsapp_plugin_installed():
+                logging.info("WhatsApp channel plugin installed")
+            else:
+                logging.warning(
+                    "WhatsApp plugin install failed (rc=%s): %s",
+                    proc.returncode,
+                    _clean_openclaw_error(proc.stderr, proc.stdout),
+                )
+        except subprocess.TimeoutExpired:
+            logging.warning("WhatsApp plugin install timed out")
+        except Exception as e:  # pragma: no cover - defensive
+            logging.warning("WhatsApp plugin install error: %s", e)
+    finally:
+        try:
+            fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+        except Exception:
+            pass
+        fd.close()
+
+
+def _ensure_whatsapp_plugin_async() -> None:
+    """Kick off the install in the background and return immediately. The
+    thread self-dedupes via flock, so calling this on every retry is safe."""
+    threading.Thread(target=_install_whatsapp_plugin_locked, daemon=True).start()
+
+
 def _gateway_token() -> str | None:
     """Read the OpenClaw gateway bearer token from openclaw.json."""
     data = _read_openclaw_config()
@@ -1523,6 +1621,18 @@ def register_integrations(app, limiter) -> None:  # noqa: C901
     def whatsapp_add():
         if not session.get("authenticated"):
             return jsonify({"error": "unauthenticated"}), 401
+        # WhatsApp needs its channel plugin on disk. Provisioning does not
+        # pre-install it, so the first link triggers a one-time install. That
+        # install is too slow to run inline (gunicorn worker timeout), so we
+        # do it in the background and tell the client to retry — the dashboard
+        # polls this endpoint through the "installing" state before asking for
+        # the QR. Once present, configuring is fast.
+        if not _whatsapp_plugin_installed():
+            _ensure_whatsapp_plugin_async()
+            return jsonify({
+                "status": "installing",
+                "message": "Installing WhatsApp support (one-time, may take a minute)…",
+            }), 202
         _write_openclaw_channel("whatsapp", {
             "enabled": True,
             "dmPolicy": "pairing",

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -1583,14 +1583,31 @@
             msg.innerText = 'Enabling WhatsApp channel...';
             img.hidden = true;
             openDetails('details-whatsapp');
-            // Ensure channel config exists
-            try {
-                await fetch('/api/channels/whatsapp/add', {
-                    method: 'POST', credentials: 'include',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: '{}',
-                });
-            } catch (e) { /* ok if already exists */ }
+            // Ensure the channel plugin is installed and the channel is
+            // configured. The first time WhatsApp is linked the server installs
+            // the @openclaw/whatsapp channel plugin in the background and replies
+            // 202 {status:'installing'} — poll through that state (up to ~2 min)
+            // before asking for the QR. Once installed this returns immediately.
+            let configured = false;
+            for (let i = 0; i < 40 && !configured; i++) {
+                try {
+                    const ar = await fetch('/api/channels/whatsapp/add', {
+                        method: 'POST', credentials: 'include',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: '{}',
+                    });
+                    const ad = await ar.json().catch(() => ({}));
+                    if (ar.ok && ad.status === 'configured') { configured = true; break; }
+                    if (ar.status === 202 || ad.status === 'installing') {
+                        msg.innerText = ad.message || 'Installing WhatsApp support (one-time)…';
+                    }
+                } catch (e) { /* transient — retry */ }
+                await new Promise(r => setTimeout(r, 3000));
+            }
+            if (!configured) {
+                msg.innerText = 'WhatsApp setup is taking longer than expected. Please try again in a moment.';
+                return;
+            }
             // Request QR from gateway
             msg.innerText = 'Generating QR code...';
             try {


### PR DESCRIPTION
## Why

HomeBrain provisions **stock upstream `openclaw`** from npm, but the WhatsApp QR linking flow depended on a private OpenClaw **fork** (a core gateway route `POST /api/channels/login/whatsapp/{start,wait}`). Until that fork merges upstream, every box needs a 12-min custom build + a fragile systemd-unit swap. This removes that dependency.

(The separate agent self-config fork is intentionally left untouched — this PR only addresses the *linking* dependency.)

## What

1. **First-party plugin** `config/openclaw-plugins/homebrain-whatsapp-login/` — registers the QR route through the **public plugin SDK** (`api.registerHttpRoute`, `auth:"gateway"`), byte-for-byte compatible with the fork route, so `src/integrations.py` is unchanged on the call side. Installed at provision (`scripts/utilities.sh::setup_openclaw`).
2. **Lazy WhatsApp channel-plugin install** — `@openclaw/whatsapp` is **not bundled** in stock openclaw (Telegram **is**). `whatsapp_add` installs it on first link via a **flock-deduped background thread** and returns `202 {status:"installing"}`; the dashboard polls through that state before requesting the QR. (An npm install is too slow to run inline under the gevent `--timeout 30` worker — the same constraint that made `reconcile` async.)
3. **Version pin** — `config/versions.json:openclaw_whatsapp` must stay peer-compatible with the `openclaw` pin (newer WhatsApp builds raise `peerDependencies.openclaw` / `compat.pluginApi`, e.g. `2026.5.28` requires `openclaw>=2026.5.28`).

## The subtle part: module resolution

OpenClaw installs each plugin into its **own isolated dir** and symlinks the `openclaw` package into it — but it does **not** make sibling plugins resolvable from one another. So the login plugin can't bare-`import("@openclaw/whatsapp/...")`. It resolves by **absolute path** from `resolveStateDir()` → `<stateDir>/npm/node_modules/@openclaw/whatsapp/dist/login-qr-api.js`. Importing by absolute path is safe: the module's own `openclaw/*` imports resolve through the npm-dir openclaw symlink, binding it to the **same `defaultRuntime` singleton** as the gateway (Node dedupes by realpath). Verified offline by simulating the install layout.

## Testing

- ✅ Static: `node --check` (plugin), `py_compile` (integrations.py), `bash -n` (utilities.sh), JSON validation, dashboard JS parse, `scripts/tests/test_update_guard.sh` (26/26).
- ✅ Resolution mechanism proven offline against the real `openclaw@2026.5.12` + `@openclaw/whatsapp@2026.5.12` npm packages (simulated `<stateDir>/npm` layout + openclaw symlink).
- ⏳ **Hardware E2E on `.58` not yet run** — author was off the home LAN this session (SSH unreachable; Pangolin exposes only the authed dashboard). Runbook added in `docs/TESTING.md` → "Channel linking — Telegram + WhatsApp (stock upstream OpenClaw)". **Must pass before merge** per repo policy (touches provisioning + dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)