### PR TITLE
feat(provision): idempotently repoint a box to a new Pangolin tunnel

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,3 @@
+- Make provision.sh idempotently repoint a box to a new Pangolin tunnel (update .env + redeploy,
+  not just factory_config). Full gap analysis (G1–G10) + verified prod facts:
+  docs/plans/provision-idempotent-tunnel-repoint.md

--- a/docs/plans/provision-idempotent-tunnel-repoint.md
+++ b/docs/plans/provision-idempotent-tunnel-repoint.md
@@ -1,0 +1,122 @@
+# Make `provision.sh` idempotently repoint a box to a new Pangolin tunnel
+
+**Status:** design / findings — implementation deferred ("later")
+**Date:** 2026-06-06
+**Context:** Operator wants to repoint a live, data-loaded box (e.g. prod RPi5 HomeCloud) to a
+new Pangolin tunnel + domain, keeping Nextcloud/Vault/HA data intact, by running `provision.sh`
+**idempotently** — a single command, no manual `.env` editing or separate redeploy.
+
+## Product goal
+
+`sudo provision.sh` (with new tunnel creds) on an already-set-up box should, by itself:
+1. Update the canonical factory record (`factory_config.txt`).
+2. Propagate the new tunnel creds into the live `.env`.
+3. Bring the new tunnel live and rewrite NC/HA/Vault trusted domains for the new domain.
+4. Preserve all data. Print the new public URLs + a Pangolin resource reminder.
+
+## Current behavior (verified on prod RPi5, beta/`e8d68da`, 2026-06-06)
+
+- Remote mode requires **≥5 positional args**: `NEWT_ID NEWT_SECRET PANGOLIN_DOMAIN PANGOLIN_ENDPOINT FACTORY_PASS [REGISTRAR_URL REGISTRAR_SECRET]`.
+- Writes/overwrites `factory_config.txt` from a **fixed key set**.
+- Runs system setup (deps, venv, docker image pull, systemd units, GPU hardening if `HAS_GPU`).
+- Creates a **temp** `.env` only if none exists (for compose var substitution during pull), then deletes it. **Never modifies an existing real `.env`.**
+- **Never** invokes `deploy.sh` / `redeploy_tunnels.sh`; never touches running tunnel containers.
+- **Never** touches `.setup_complete` or the data bind-mounts → data-safe.
+
+## Why `provision.sh` alone does NOT repoint today (root cause)
+
+The live `newt` container reads tunnel creds from **`/opt/homebrain/.env`, not `factory_config.txt`**.
+NC/HA/Vault trusted domains, `overwrite.cli.url`, Vaultwarden `DOMAIN` are driven from `.env` and
+applied by `configure_nc_ha_proxy_settings` during (re)deploy. `provision.sh` updates only
+`factory_config` and runs no deploy, so the tunnel + domains stay on the OLD values. The repoint
+currently needs a separate `.env` update + `redeploy_tunnels.sh` (today done by the dashboard
+`/api/tunnel` endpoint, `app.py:1484`).
+
+## Gaps to implement
+
+**G1 — Propagate factory creds into the live `.env` (already-set-up box).**
+When `.env` exists, `.setup_complete` present, and remote args supplied, update the tunnel-identity
+keys via `update_env_var`: `NEWT_ID`, `NEWT_SECRET`, `PANGOLIN_ENDPOINT`, `PANGOLIN_DOMAIN`,
+`MANAGER_DOMAIN`, `NEXTCLOUD_TRUSTED_DOMAINS=nc.<dom>`, `HA_TRUSTED_DOMAINS=ha.<dom>`,
+`VAULT_TRUSTED_DOMAINS=vault.<dom>`, `VAULT_DOMAIN=https://vault.<dom>`. Must **not** touch
+`MASTER_PASSWORD`/`MANAGER_PASSWORD`/`MYSQL_*`/`HA_ADMIN_PASSWORD`/`DEPLOYMENT_MODE` or any secret.
+Guard each key on its CLI arg being present, so a bare/local re-run is a true no-op.
+*This exact mapping already exists in `app.py` `/start_setup` (~723-739) and `/api/tunnel` (~1510-1521).
+Factor it into one place — a `common.sh` helper `apply_tunnel_env <id> <secret> <endpoint> <domain>` —
+and call it from provision.sh, the wizard, and `/api/tunnel` to stop the three copies drifting.*
+
+**G2 — Drive a redeploy after updating `.env` (only when already set up).**
+If `.setup_complete` present, run **`redeploy_tunnels.sh`** at the end (NOT `deploy.sh`): it stops the
+old newt, pulls+ups the new tunnel profile, reapplies trusted domains via
+`configure_nc_ha_proxy_settings`, restarts NC/HA/Vault. Prefer it because it has **zero wipe logic**.
+On a fresh box (no `.setup_complete`) keep current behavior — the setup wizard drives deploy; do not
+auto-deploy. Consider a `--apply/--no-apply` flag; recommend auto-redeploy when remote args change an
+already-set-up box, but make it skippable.
+
+**G3 — `FACTORY_PASSWORD` forces a change on tunnel-only re-provision.**
+Remote mode requires arg5. An operator who only wants to swap the tunnel must restate the existing
+factory password; if unknown (this prod box has **no `FACTORY_PASSWORD` at all** — older format),
+provision.sh **generates a new random one**. Fix: make FACTORY_PASS optional in remote mode —
+preserve the existing `factory_config` value when omitted, generate only if truly absent, and surface
+it. Decouple "remote mode" from `argc==5` (detect via presence of newt id/secret/domain).
+
+**G4 — Named flags + defaulting from existing config.**
+Add `--newt-id/--newt-secret/--domain/--endpoint/--factory-pass/--registrar-url/--registrar-secret`;
+any omitted flag defaults from existing `factory_config` then `.env`. Target UX:
+`sudo provision.sh --newt-id X --newt-secret Y --domain miami.homebrain.house` (endpoint + factory
+pass inherited). Keep positional form for back-compat.
+
+**G5 — factory_config rewrite drops legacy keys.**
+Current rewrite emits only the fixed key set, dropping `NC_DOMAIN`/`HA_DOMAIN` that older boxes (incl.
+this prod RPi5) carry. `/api/tunnel/revert` (`app.py:1582-1583`) still reads factory
+`NC_DOMAIN`/`HA_DOMAIN`. Either derive those from `PANGOLIN_DOMAIN` in revert and stop persisting
+them, or have provision.sh also write `NC_DOMAIN=nc.<dom>`/`HA_DOMAIN=ha.<dom>`. Today re-provision
+silently empties them for the revert path.
+
+**G6 — Pre-flight validation before tearing down the working tunnel.**
+`redeploy_tunnels.sh` stops old newt then starts new; wrong creds = remote access lost (LAN/dashboard
+still fine). Add an optional pre-flight that validates the new newt creds against `PANGOLIN_ENDPOINT`
+before switching (or bring new up before removing old). At minimum log a clear "remote access flips —
+verify newt logs" warning.
+
+**G7 — Domain-change side effects to audit (mostly handled by redeploy once G2 lands).**
+- NC `config.php` (`trusted_domains`, `overwrite.cli.url`, `overwriteprotocol`) — ✓ via `configure_nc_ha_proxy_settings`.
+- HA `configuration.yaml` trusted proxies / external URLs — ✓ via `configure_ha_proxy_settings`.
+- Vaultwarden `DOMAIN` env — ✓ recomputed per deploy + vault restart.
+- **OpenClaw/MCP configs embedding public base URLs** (`nc./ha./vault.<dom>`, self-MCP `public_url`,
+  agent channels) — **AUDIT**. N/A on this no-GPU RPi5, but a GPU/x86 box (berlin) may have stored old
+  URLs. Consider a helper that rewrites stored public URLs in `~/.openclaw` + MCP env on domain change.
+
+**G8 — External dependency provision.sh can't do: Pangolin org-side resource map.**
+The new tunnel needs resources for the new domain: root `<dom>`→manager:80, `nc.<dom>`→8080,
+`ha.<dom>`→8123, `vault.<dom>`→8082. Add a post-redeploy reachability probe of the 4 hostnames with a
+clear "configure these resources in Pangolin" message on failure.
+
+**G9 — Registrar re-activation on domain change.**
+If `REGISTRAR_URL` set, a domain change may require re-activation (email flow). Not set on this box.
+Document; consider re-triggering activation when domain changes and registrar present.
+
+**G10 — Idempotency/safety assertions.**
+When triggering redeploy, always prefer `redeploy_tunnels.sh` (no wipe) over `deploy.sh`. Add an early
+assertion: if `.setup_complete` present, never reach deploy.sh's fresh-install wipe branch. Document
+the data-safety contract at the top of provision.sh.
+
+## Verified facts (prod RPi5 — `homebrain.local` / 192.168.1.231, aarch64, 2026-06-06)
+
+- `.setup_complete` present (Dec 21), `install_creds.json` absent → data-safe re-deploy path.
+- Current tunnel: `NEWT_ID=r9anwjl58oet1v9`, `PANGOLIN_DOMAIN=berlin.homebrain.house`, `PANGOLIN_ENDPOINT=https://pangolin.homebrain.house`.
+- `factory_config.txt` lacks `FACTORY_PASSWORD` + registrar (older format; carries legacy `NC_DOMAIN`/`HA_DOMAIN`).
+- `nextcloud-data` 83G (real users incl. `OliAidana`,`admin`), `vault-data` present; all 7 containers up; **no GPU**.
+- Deployed code: channel `beta`, ref `e8d68da`; `/opt/homebrain` is **not** a git repo (tarball deploy) — box code can differ from a dev checkout; verify scripts on the box before relying on them.
+- `redeploy_tunnels.sh`: no destructive ops. `deploy.sh` wipe gate guarded by `.setup_complete` (`deploy.sh:31`).
+
+## Target one-command UX (after G1–G4)
+
+```
+sudo /opt/homebrain/scripts/provision.sh \
+  --newt-id 6y83ddoqx41qrwl \
+  --newt-secret <token> \
+  --domain miami.homebrain.house
+# → updates factory_config + .env, redeploys tunnel, preserves data,
+#   prints new public URLs + Pangolin resource reminder
+```

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -16,22 +16,47 @@ else
     BOOT_CONFIG="/opt/homebrain/factory_config.txt"
 fi
 
-# --- Input Validation & Mode Detection ---
+# --- Input Validation & Argument Parsing ---
 if [[ $EUID -ne 0 ]]; then echo "Run as root."; exit 1; fi
 
-# Local mode  (0-1 args): provision.sh [FACTORY_PASS]
-# Remote mode (5+ args):  provision.sh <NEWT_ID> <NEWT_SECRET> <PANGOLIN_DOMAIN> <PANGOLIN_ENDPOINT> <FACTORY_PASS> [REGISTRAR_URL] [REGISTRAR_SECRET]
-if [[ $# -ge 5 ]]; then
-    PROVISION_MODE="remote"
-elif [[ $# -le 1 ]]; then
-    PROVISION_MODE="local"
-else
-    echo "Usage (local mode):  $0 [FACTORY_PASS]"
-    echo "Usage (remote mode): $0 <NEWT_ID> <NEWT_SECRET> <PANGOLIN_DOMAIN> <PANGOLIN_ENDPOINT> <FACTORY_PASS> [REGISTRAR_URL] [REGISTRAR_SECRET]"
-    exit 1
-fi
+# Two invocation styles, both supported:
+#
+#   Positional (back-compat):
+#     local:  provision.sh [FACTORY_PASS]
+#     remote: provision.sh <NEWT_ID> <NEWT_SECRET> <PANGOLIN_DOMAIN> <PANGOLIN_ENDPOINT> <FACTORY_PASS> [REGISTRAR_URL] [REGISTRAR_SECRET]
+#
+#   Named flags (idempotent re-provision / tunnel repoint). Any value not given
+#   is inherited from the existing factory_config, so repointing a live box to a
+#   new tunnel is a one-liner:
+#     provision.sh --newt-id ID --newt-secret SECRET --domain DOMAIN \
+#                  [--endpoint URL] [--factory-pass PASS] \
+#                  [--registrar-url URL] [--registrar-secret SECRET] [--local] [--no-apply]
+#
+# Remote vs local is decided in section 2, AFTER merging with the existing
+# factory_config: remote iff NEWT_ID, NEWT_SECRET and PANGOLIN_DOMAIN are all
+# present (and --local was not passed).
+PROV_NEWT_ID="" ; PROV_NEWT_SECRET="" ; PROV_PANGOLIN_DOMAIN=""
+PROV_PANGOLIN_ENDPOINT="" ; PROV_FACTORY_PASS=""
+PROV_REGISTRAR_URL="" ; PROV_REGISTRAR_SECRET=""
+FORCE_LOCAL=false
+APPLY_REDEPLOY=true   # on an already-set-up box, redeploy so the repoint goes live
 
-if [[ "$PROVISION_MODE" == "remote" ]]; then
+if [[ "${1:-}" == --* ]]; then
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --newt-id)          PROV_NEWT_ID="${2:?--newt-id needs a value}"; shift 2;;
+            --newt-secret)      PROV_NEWT_SECRET="${2:?--newt-secret needs a value}"; shift 2;;
+            --domain)           PROV_PANGOLIN_DOMAIN="${2:?--domain needs a value}"; shift 2;;
+            --endpoint)         PROV_PANGOLIN_ENDPOINT="${2:?--endpoint needs a value}"; shift 2;;
+            --factory-pass)     PROV_FACTORY_PASS="${2:?--factory-pass needs a value}"; shift 2;;
+            --registrar-url)    PROV_REGISTRAR_URL="${2:?--registrar-url needs a value}"; shift 2;;
+            --registrar-secret) PROV_REGISTRAR_SECRET="${2:?--registrar-secret needs a value}"; shift 2;;
+            --local)            FORCE_LOCAL=true; shift;;
+            --no-apply)         APPLY_REDEPLOY=false; shift;;
+            *) echo "Unknown flag: $1"; exit 1;;
+        esac
+    done
+elif [[ $# -ge 5 ]]; then
     PROV_NEWT_ID="${1}"
     PROV_NEWT_SECRET="${2}"
     PROV_PANGOLIN_DOMAIN="${3}"
@@ -39,14 +64,13 @@ if [[ "$PROVISION_MODE" == "remote" ]]; then
     PROV_FACTORY_PASS="${5}"
     PROV_REGISTRAR_URL="${6:-}"
     PROV_REGISTRAR_SECRET="${7:-}"
-else
-    PROV_NEWT_ID=""
-    PROV_NEWT_SECRET=""
-    PROV_PANGOLIN_DOMAIN=""
-    PROV_PANGOLIN_ENDPOINT=""
+elif [[ $# -le 1 ]]; then
     PROV_FACTORY_PASS="${1:-}"
-    PROV_REGISTRAR_URL=""
-    PROV_REGISTRAR_SECRET=""
+else
+    echo "Usage (local):  $0 [FACTORY_PASS]"
+    echo "Usage (remote): $0 <NEWT_ID> <NEWT_SECRET> <PANGOLIN_DOMAIN> <PANGOLIN_ENDPOINT> <FACTORY_PASS> [REGISTRAR_URL] [REGISTRAR_SECRET]"
+    echo "Usage (flags):  $0 --newt-id ID --newt-secret SECRET --domain DOMAIN [--endpoint URL] [--factory-pass PASS] [--local] [--no-apply]"
+    exit 1
 fi
 
 # Resilience: Ensure time is correct
@@ -125,8 +149,8 @@ fi
 # Preserve any pre-existing values from a properly-imaged device. CLI args
 # (when provided) take precedence; missing fields fall back to existing file
 # contents. This makes re-running provision.sh idempotent — it never wipes
-# the factory password baked into the OS image.
-echo "Writing factory configuration (mode: ${PROVISION_MODE})..."
+# the factory password baked into the OS image, and an operator can repoint the
+# tunnel by supplying only the changed fields.
 declare -A _FC=( [NEWT_ID]="" [NEWT_SECRET]="" [PANGOLIN_DOMAIN]="" \
                  [PANGOLIN_ENDPOINT]="" [FACTORY_PASSWORD]="" \
                  [REGISTRAR_URL]="" [REGISTRAR_SECRET]="" )
@@ -142,6 +166,18 @@ fi
 [[ -n "$PROV_FACTORY_PASS"      ]] && _FC[FACTORY_PASSWORD]="$PROV_FACTORY_PASS"
 [[ -n "$PROV_REGISTRAR_URL"     ]] && _FC[REGISTRAR_URL]="$PROV_REGISTRAR_URL"
 [[ -n "$PROV_REGISTRAR_SECRET"  ]] && _FC[REGISTRAR_SECRET]="$PROV_REGISTRAR_SECRET"
+
+# Decide deployment mode from the EFFECTIVE (merged) config, not raw argc — this
+# lets `--domain ...` alone (endpoint/creds inherited from factory_config) still
+# resolve to remote.
+if [[ "$FORCE_LOCAL" == "true" ]]; then
+    PROVISION_MODE="local"
+elif [[ -n "${_FC[NEWT_ID]}" && -n "${_FC[NEWT_SECRET]}" && -n "${_FC[PANGOLIN_DOMAIN]}" ]]; then
+    PROVISION_MODE="remote"
+else
+    PROVISION_MODE="local"
+fi
+echo "Writing factory configuration (mode: ${PROVISION_MODE})..."
 
 # Without a factory password the device is unreachable. Generate one if missing
 # and surface it prominently so the operator can record it on the device label.
@@ -258,6 +294,47 @@ chmod 700 "${HOMEBRAIN_HOME:-/home/homebrain}/.openclaw" 2>/dev/null || true
 mkdir -p /var/log/homebrain
 chgrp homebrain /var/log/homebrain 2>/dev/null || true
 chmod 2775 /var/log/homebrain 2>/dev/null || true
+
+# --- 7. Idempotent tunnel repoint (already-provisioned boxes only) ---
+# Everything above only writes the *factory* record (factory_config.txt). The
+# live stack reads tunnel creds + trusted domains from .env, applied to the
+# containers by redeploy_tunnels.sh. On a box that has already completed setup
+# (.setup_complete present) we propagate the new tunnel identity into .env and
+# redeploy, so a SINGLE provision.sh run fully repoints the box to the new
+# domain while keeping all data.
+#
+# Data-safety contract: this path never touches the nextcloud/vault data
+# bind-mounts and uses redeploy_tunnels.sh, which has no wipe logic. deploy.sh's
+# fresh-install wipe branch is gated on the ABSENCE of .setup_complete and is
+# never invoked here. On a fresh box (no .setup_complete) we skip this entirely
+# — the setup wizard drives the first deploy.
+if [[ "$PROVISION_MODE" == "remote" && -f "$INSTALL_DIR/.setup_complete" && -f "$ENV_FILE" ]]; then
+    _dom="${_FC[PANGOLIN_DOMAIN]}"
+    log_info "Already-provisioned box — propagating new tunnel identity into .env (domain: ${_dom})."
+    update_env_var "DEPLOYMENT_MODE"           "remote"
+    update_env_var "NEWT_ID"                   "${_FC[NEWT_ID]}"
+    update_env_var "NEWT_SECRET"               "${_FC[NEWT_SECRET]}"
+    update_env_var "PANGOLIN_ENDPOINT"         "${_FC[PANGOLIN_ENDPOINT]}"
+    update_env_var "PANGOLIN_DOMAIN"           "$_dom"
+    update_env_var "MANAGER_DOMAIN"            "$_dom"
+    update_env_var "NEXTCLOUD_TRUSTED_DOMAINS" "nc.$_dom"
+    update_env_var "HA_TRUSTED_DOMAINS"        "ha.$_dom"
+    update_env_var "VAULT_TRUSTED_DOMAINS"     "vault.$_dom"
+    update_env_var "VAULT_DOMAIN"              "https://vault.$_dom"
+
+    if [[ "$APPLY_REDEPLOY" == "true" ]]; then
+        log_info "Redeploying tunnel to bring the new domain live (data-safe)..."
+        if bash "$INSTALL_DIR/scripts/redeploy_tunnels.sh"; then
+            log_info "Tunnel redeploy complete — services now published under ${_dom}."
+        else
+            log_warn "redeploy_tunnels.sh reported issues; inspect $LOG_DIR/main_setup.log."
+        fi
+        log_warn "Remote access now flips to the new tunnel. Confirm the Pangolin org defines resources:"
+        log_warn "  ${_dom} (root) -> manager:80 · nc.${_dom} -> 8080 · ha.${_dom} -> 8123 · vault.${_dom} -> 8082"
+    else
+        log_info "--no-apply: .env updated but tunnel not redeployed. Run scripts/redeploy_tunnels.sh to apply."
+    fi
+fi
 
 echo "HomeBrain Provisioning Complete."
 echo "======================================================="


### PR DESCRIPTION
## What

Make `provision.sh` self-sufficient for repointing an already-set-up box to a new Pangolin
tunnel/domain, keeping all data — a single idempotent command.

## Why

`provision.sh` previously only wrote `factory_config.txt`; it never touched the live `.env` or
redeployed. The live `newt` reads creds from `.env`, so re-running provision could not actually
repoint a box — the operator had to hand-edit `.env` + run `redeploy_tunnels.sh` (or use the
dashboard `/api/tunnel` path).

## Changes

- **Named-flag interface** (`--newt-id/--newt-secret/--domain/--endpoint/--factory-pass/--registrar-*/--local/--no-apply`) alongside the positional form. Omitted values are inherited from the existing `factory_config`, so a repoint is `--newt-id X --newt-secret Y --domain Z`.
- **Mode derived from merged config**, not raw argc → `--domain` alone resolves to remote and `--factory-pass` is optional on re-provision (existing factory password preserved).
- **Idempotent repoint**: on an already-set-up box (`.setup_complete` present) propagate the new tunnel identity + derived trusted domains into `.env` and run `redeploy_tunnels.sh`.

## Data safety

Never touches the data bind-mounts; uses `redeploy_tunnels.sh` (no wipe logic). `deploy.sh`'s
fresh-install wipe branch is gated on the **absence** of `.setup_complete` and is never reached.

Parser/mode logic validated across 7 invocation styles on bash 5.2. Follow-ups G5–G10 tracked in
`docs/plans/provision-idempotent-tunnel-repoint.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)