### PR TITLE
fix(tunnel): repoint follow-ups (G5 revert bug, G6 newt check, G8 resource guide)

### DIFF
--- a/docs/plans/provision-idempotent-tunnel-repoint.md
+++ b/docs/plans/provision-idempotent-tunnel-repoint.md
@@ -1,6 +1,7 @@
 # Make `provision.sh` idempotently repoint a box to a new Pangolin tunnel
 
-**Status:** design / findings — implementation deferred ("later")
+**Status:** G1–G4 shipped (PR #100). G5/G6/G8 shipped (PR #102). G7/G9 deferred (rationale below).
+G10 already satisfied. Related: vault DB-identity fix (PR #101).
 **Date:** 2026-06-06
 **Context:** Operator wants to repoint a live, data-loaded box (e.g. prod RPi5 HomeCloud) to a
 new Pangolin tunnel + domain, keeping Nextcloud/Vault/HA data intact, by running `provision.sh`
@@ -109,6 +110,28 @@ the data-safety contract at the top of provision.sh.
 - `nextcloud-data` 83G (real users incl. `OliAidana`,`admin`), `vault-data` present; all 7 containers up; **no GPU**.
 - Deployed code: channel `beta`, ref `e8d68da`; `/opt/homebrain` is **not** a git repo (tarball deploy) — box code can differ from a dev checkout; verify scripts on the box before relying on them.
 - `redeploy_tunnels.sh`: no destructive ops. `deploy.sh` wipe gate guarded by `.setup_complete` (`deploy.sh:31`).
+
+## Resolution log
+
+- **G1–G4** — shipped in PR #100 (named flags, merged-config mode detection, .env propagation +
+  redeploy on already-set-up boxes).
+- **G5** — fixed in PR #102: `revert_tunnel_provider` now derives trusted domains from factory
+  `PANGOLIN_DOMAIN` (+ vault domain/manager domain) instead of the dropped `NC_DOMAIN`/`HA_DOMAIN`.
+  Confirmed those were the only consumers of the legacy keys.
+- **G6** — addressed in PR #102 via `verify_newt_connected` (post-redeploy check; warns if the new
+  tunnel didn't come up rather than pre-flighting, which is impractical with a single newt container).
+- **G8** — addressed in PR #102 via `print_pangolin_resource_guide`, which prints the resource→target
+  map with **correct** targets (container internal ports / bridge gateway). This also corrected a wrong
+  hint in the original PR #100 reminder (`nc -> 8080`) that led an operator to misconfigure nc as
+  `nextcloud:8080` (should be `nextcloud:80`) and get a 404.
+- **G7** — deferred: only affects GPU/x86 boxes running OpenClaw (which may have stored old public
+  URLs); cannot be E2E-verified without a GPU target, and the box this work was driven on has no GPU.
+- **G9** — deferred: registrar re-activation only applies when `REGISTRAR_URL` is set; not configured
+  on the target, so it would be untested speculation.
+- **G10** — already satisfied: the repoint path uses `redeploy_tunnels.sh` (no wipe logic) and
+  deploy.sh's wipe branch is gated on the absence of `.setup_complete`; documented in provision.sh §7.
+- Related: **PR #101** persists `VAULT_DB_USER`/`VAULT_DB_NAME` in `provision_vault.sh` (vaultwarden
+  crash-loop root cause found live).
 
 ## Target one-command UX (after G1–G4)
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -328,6 +328,51 @@ is_local_mode() {
     return 1
 }
 
+# Best-effort confirmation that newt established the Pangolin tunnel after a
+# (re)deploy. A wrong NEWT_ID/SECRET/ENDPOINT leaves the box reachable on the
+# LAN but silently unreachable remotely, so we surface that loudly rather than
+# letting the operator discover it via a dead public URL. Returns non-zero (and
+# warns) if no successful connection shows up in newt's recent logs.
+verify_newt_connected() {
+    local cid
+    cid=$(docker compose $(get_compose_args) ps -q newt 2>/dev/null || true)
+    if [[ -z "$cid" ]]; then
+        log_warn "newt container not running — remote tunnel is down (LAN access unaffected)."
+        return 1
+    fi
+    local i
+    for i in 1 2 3 4 5 6; do
+        if docker logs --since 5m "$cid" 2>&1 | grep -q "Tunnel connection to server established"; then
+            log_info "newt tunnel connection to Pangolin confirmed."
+            return 0
+        fi
+        sleep 5
+    done
+    log_warn "newt did NOT report a successful tunnel connection within ~30s."
+    log_warn "Verify NEWT_ID / NEWT_SECRET / PANGOLIN_ENDPOINT — the box is still reachable on the LAN."
+    log_warn "Logs: docker logs ${cid}"
+    return 1
+}
+
+# Print the Pangolin org-side resources the operator must create for a tunnel
+# domain. provision.sh cannot configure the Pangolin server, and the targets are
+# easy to get wrong: newt runs on the homebrain_default Docker network, so it
+# reaches the service containers by NAME on their INTERNAL ports — NOT the host-
+# published ports (nc's host 8080 maps to container :80; vault's 8082 is even
+# loopback-only). The manager is a host process, reached via the bridge gateway.
+print_pangolin_resource_guide() {
+    local dom="$1"
+    local gw
+    gw=$(docker network inspect homebrain_default \
+            --format '{{(index .IPAM.Config 0).Gateway}}' 2>/dev/null || true)
+    gw="${gw:-172.18.0.1}"
+    log_warn "Pangolin resources to configure for https://${dom} (targets are HTTP; TLS ends at the edge):"
+    log_warn "  ${dom} (root, manager) -> ${gw}:80        (host process — use the bridge gateway, not a name)"
+    log_warn "  nc.${dom}              -> nextcloud:80     (container internal port — NOT host 8080)"
+    log_warn "  ha.${dom}              -> homeassistant:8123"
+    log_warn "  vault.${dom}           -> vaultwarden:80   (host 8082 is loopback-only — use the name)"
+}
+
 wait_for_healthy() {
     local service_name="$1"
     local timeout_seconds="$2"

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -329,8 +329,11 @@ if [[ "$PROVISION_MODE" == "remote" && -f "$INSTALL_DIR/.setup_complete" && -f "
         else
             log_warn "redeploy_tunnels.sh reported issues; inspect $LOG_DIR/main_setup.log."
         fi
-        log_warn "Remote access now flips to the new tunnel. Confirm the Pangolin org defines resources:"
-        log_warn "  ${_dom} (root) -> manager:80 · nc.${_dom} -> 8080 · ha.${_dom} -> 8123 · vault.${_dom} -> 8082"
+        # Confirm the new tunnel actually came up, then remind the operator of the
+        # Pangolin org-side resources only they can configure (with correct targets).
+        log_warn "Remote access now flips to the new tunnel."
+        verify_newt_connected || true
+        print_pangolin_resource_guide "${_dom}"
     else
         log_info "--no-apply: .env updated but tunnel not redeployed. Run scripts/redeploy_tunnels.sh to apply."
     fi

--- a/src/app.py
+++ b/src/app.py
@@ -1579,8 +1579,17 @@ def revert_tunnel_provider():
     update_env_var("PANGOLIN_ENDPOINT", factory.get("PANGOLIN_ENDPOINT", ""))
     update_env_var("NEWT_ID", factory.get("NEWT_ID", ""))
     update_env_var("NEWT_SECRET", factory.get("NEWT_SECRET", ""))
-    update_env_var("NEXTCLOUD_TRUSTED_DOMAINS", factory.get("NC_DOMAIN", ""))
-    update_env_var("HA_TRUSTED_DOMAINS", factory.get("HA_DOMAIN", ""))
+    # Derive trusted domains from the factory PANGOLIN_DOMAIN rather than the
+    # legacy NC_DOMAIN/HA_DOMAIN keys: provision.sh (remote mode) rewrites
+    # factory_config without those keys, so reading them here would blank the
+    # trusted domains on revert. Mirrors the /api/tunnel revert + start_setup map.
+    main_dom = factory.get("PANGOLIN_DOMAIN", "")
+    update_env_var("PANGOLIN_DOMAIN", main_dom)
+    update_env_var("MANAGER_DOMAIN", main_dom)
+    update_env_var("NEXTCLOUD_TRUSTED_DOMAINS", f"nc.{main_dom}" if main_dom else "")
+    update_env_var("HA_TRUSTED_DOMAINS", f"ha.{main_dom}" if main_dom else "")
+    update_env_var("VAULT_TRUSTED_DOMAINS", f"vault.{main_dom}" if main_dom else "")
+    update_env_var("VAULT_DOMAIN", f"https://vault.{main_dom}" if main_dom else "")
 
     subprocess.run(["chmod", "+x", SCRIPT_REDEPLOY])
     cmd = f"bash {SCRIPT_REDEPLOY} >> {LOG_FILES['setup']} 2>&1"


### PR DESCRIPTION
Upstream follow-ups to the idempotent tunnel-repoint work (PR #100), found while taking the prod RPi5 from `berlin` → `miami`.

## Fixes
- **G5 (bug):** `/api/tunnel/revert` read the factory `NC_DOMAIN`/`HA_DOMAIN` keys, but `provision.sh` (remote mode) rewrites `factory_config` **without** them — so a revert after a re-provision blanked the trusted domains. Now derives from factory `PANGOLIN_DOMAIN` (+ manager/vault domains). `revert_tunnel_provider` was the only consumer of the legacy keys.
- **G6:** `verify_newt_connected` — after the repoint redeploy, confirm newt actually established the tunnel; warn loudly if not (wrong creds otherwise fail silently — LAN fine, remote dead).
- **G8:** `print_pangolin_resource_guide` — prints the Pangolin resource→target map with **correct** targets (container internal ports / bridge gateway). Replaces a wrong hint in the PR #100 reminder (`nc -> 8080`) that caused a real misconfiguration (`nextcloud:8080` → 404; should be `nextcloud:80`).

## Deferred (rationale in docs/plans)
- **G7** OpenClaw public-URL rewrite — GPU/x86 only; can't E2E-verify without a GPU target.
- **G9** registrar re-activation — only when `REGISTRAR_URL` is set; not configured here.
- **G10** already satisfied (uses `redeploy_tunnels.sh`; wipe gated on `.setup_complete`).

## Verification
`bash -n` + shellcheck clean, `py_compile` clean, and both new shell helpers E2E-tested against the live target (resource guide prints correct targets w/ detected gateway; newt grep matches real logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)