### PR TITLE
feat(ftp): robust camera uploads — fix login, self-test, stable IP

### DIFF
--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -266,6 +266,75 @@ EOF
     fi
 
     mkdir -p "$USER_CONFIG_DIR"
+
+    # During login vsftpd chdir()s into the guest user's home dir (www-data → /var/www)
+    # BEFORE applying local_root, and a failed chdir there is fatal. On a Docker-only
+    # host there is no host Apache, so /var/www never gets created and every login dies
+    # with "500 OOPS: cannot change directory:/var/www" — which cameras (e.g. Reolink)
+    # surface as a generic "FTP error 19". Ensure the guest home exists so login can
+    # proceed far enough to honour the per-user local_root.
+    mkdir -p /var/www
+}
+
+# --- Helper: Open/close firewall for FTP (only when ufw is active) ---
+# vsftpd needs the control port (21) plus the passive data range advertised in
+# the config (pasv_min_port..pasv_max_port). provision.sh opens the web ports but
+# not these, so on any box with ufw active the camera's data channel silently
+# fails. Open them lazily when FTP is actually configured.
+_ftp_firewall() {
+    local action="$1" # allow | delete
+    command -v ufw >/dev/null 2>&1 || return 0
+    ufw status 2>/dev/null | grep -q "Status: active" || return 0
+    if [ "$action" = "allow" ]; then
+        ufw allow 21/tcp comment 'HomeBrain FTP control' >/dev/null 2>&1 || true
+        ufw allow 40000:50000/tcp comment 'HomeBrain FTP passive' >/dev/null 2>&1 || true
+        log_info "Opened firewall for FTP (21/tcp + 40000-50000/tcp)."
+    else
+        ufw delete allow 21/tcp >/dev/null 2>&1 || true
+        ufw delete allow 40000:50000/tcp >/dev/null 2>&1 || true
+        log_info "Closed FTP firewall ports (no FTP users remain)."
+    fi
+}
+
+# --- Helper: Write an FTP user into the password file ---
+# pam_pwdfile authenticates against crypt(3) hashes. Prefer bcrypt ($2y$) — it is
+# crypt-compatible on modern glibc/libxcrypt and far stronger than the legacy DES
+# crypt (-d) this previously used (DES silently truncates passwords to 8 chars).
+# Fall back to DES only if this htpasswd build lacks bcrypt support.
+_ftp_write_user() {
+    local user="$1" pass="$2"
+    local algo="-B"
+    if ! htpasswd -nbB _probe _probe >/dev/null 2>&1; then
+        algo="-d"
+        log_warn "htpasswd lacks bcrypt support; falling back to DES crypt."
+    fi
+    if [ ! -f "$FTP_PASSWD_FILE" ]; then
+        htpasswd -b "$algo" -c "$FTP_PASSWD_FILE" "$user" "$pass"
+    else
+        htpasswd -b "$algo" "$FTP_PASSWD_FILE" "$user" "$pass"
+    fi
+    chmod 600 "$FTP_PASSWD_FILE"
+}
+
+# --- Helper: Self-test a freshly configured FTP user ---
+# Performs a real loopback login + passive STOR with the user's own credentials,
+# exactly as a camera would. This catches misconfigurations (missing guest home,
+# bad chroot, incompatible password hash, wrong perms) that leave vsftpd "active"
+# but unusable — the failure mode that surfaced on cameras as "FTP error 19".
+_ftp_selftest() {
+    local user="$1" pass="$2" upload_dir="$3"
+    command -v curl >/dev/null 2>&1 || { log_warn "curl missing; skipping FTP self-test."; return 0; }
+    local tmp marker="/.homebrain_selftest"
+    tmp=$(mktemp)
+    echo "homebrain-ftp-selftest" > "$tmp"
+    local rc=0
+    # -f makes curl return non-zero on any FTP error (login/chroot/STOR failure).
+    if ! curl -fsS --connect-timeout 10 --ftp-pasv -T "$tmp" \
+            "ftp://${user}:${pass}@127.0.0.1${marker}" >/dev/null 2>&1; then
+        rc=1
+    fi
+    rm -f "$tmp" "${upload_dir}${marker}"
+    return $rc
 }
 
 # --- Action: Setup FTP User ---
@@ -294,13 +363,8 @@ setup_ftp_user() {
         chown -R www-data:www-data "$upload_dir"
     fi
 
-    # 3. Add/Update Virtual FTP User
-    # Use -B to verify bcrypt compatibility if needed, but md5 (-d) is standard for pam_pwdfile
-    if [ ! -f "$FTP_PASSWD_FILE" ]; then
-        htpasswd -b -c -d "$FTP_PASSWD_FILE" "$ftp_user" "$ftp_pass"
-    else
-        htpasswd -b -d "$FTP_PASSWD_FILE" "$ftp_user" "$ftp_pass"
-    fi
+    # 3. Add/Update Virtual FTP User (bcrypt-hashed, see _ftp_write_user)
+    _ftp_write_user "$ftp_user" "$ftp_pass"
 
     # 4. Map FTP User to NC User Directory
     # We store the NC user in a comment for the API to read back later
@@ -354,7 +418,18 @@ EOF
 
     systemctl enable --now "$service_name"
     systemctl restart vsftpd
-    
+
+    # 6. Open firewall (no-op unless ufw is active)
+    _ftp_firewall allow
+
+    # 7. Verify the user can actually log in and upload — fail loudly if not, so
+    # the dashboard reports a real error instead of a misleading "active" state.
+    if _ftp_selftest "$ftp_user" "$ftp_pass" "$upload_dir"; then
+        log_info "FTP self-test passed: login + passive upload OK for '$ftp_user'."
+    else
+        die "FTP self-test FAILED for '$ftp_user': vsftpd is running but rejected a real upload. Check that '$upload_dir' exists and is owned by www-data, and see /var/log/vsftpd.log."
+    fi
+
     log_info "FTP User '$ftp_user' mapped to Nextcloud user '$nc_user' successfully."
 }
 
@@ -372,9 +447,130 @@ delete_ftp_user() {
     
     # Note: We do NOT stop the sync service because multiple FTP users might map to the same NC user.
     # Service cleanup is left manual or handled by a deeper logic if needed.
-    
+
     systemctl restart vsftpd
+
+    # Close the FTP firewall ports once the last user is gone.
+    if [ ! -d "$USER_CONFIG_DIR" ] || [ -z "$(ls -A "$USER_CONFIG_DIR" 2>/dev/null)" ]; then
+        _ftp_firewall delete
+    fi
+
     log_info "FTP User '$ftp_user' deleted."
+}
+
+# --- Network: static-IP pinning (camera-friendly stable address) -------------
+# Cameras can't resolve mDNS (.local), and consumer routers (e.g. the stock
+# Starlink router) often can't reserve DHCP leases, so the box's address can
+# drift and break a camera that was pointed at the old IP. These actions let the
+# dashboard pin a fixed address with a confirm-or-revert safety guard: the change
+# is applied to the *running device only* (not yet saved), then automatically
+# rolled back unless the dashboard — reachable only at the NEW address — confirms
+# within a time window. This makes a remote/headless reconfigure safe: a wrong
+# address self-heals back to DHCP instead of bricking access to the box.
+NET_PENDING_FILE="/run/homebrain-net-pending"
+NET_CONFIRM_SENTINEL="/run/homebrain-net-confirmed"
+
+_net_primary_iface() {
+    ip route show default 2>/dev/null | awk '/default/ {print $5; exit}' || true
+}
+
+_net_active_con() {
+    local iface="$1"
+    nmcli -t -f NAME,DEVICE connection show --active 2>/dev/null \
+        | awk -F: -v i="$iface" '$2==i{print $1; exit}' || true
+}
+
+_net_suggest_static() {
+    # Suggest a free address low in the subnet — below the range home routers
+    # typically hand out via DHCP, minimising the chance of a future collision.
+    local base="$1" cur="$2" o
+    for o in 10 11 12 15 20 5 8 25 30; do
+        [ "$o" = "$cur" ] && continue
+        if ! ping -c1 -W1 "${base}.${o}" >/dev/null 2>&1; then
+            echo "${base}.${o}"; return 0
+        fi
+    done
+    echo ""
+}
+
+network_info() {
+    local iface addr ip4 prefix gw dns con method base cur suggest
+    iface=$(_net_primary_iface)
+    if [ -z "$iface" ]; then echo '{"error":"no default interface"}'; return 0; fi
+    addr=$(ip -4 -o addr show dev "$iface" scope global 2>/dev/null | awk '{print $4; exit}' || true)
+    ip4=${addr%/*}; prefix=${addr#*/}
+    gw=$(ip route show default 2>/dev/null | awk '/default/ {print $3; exit}' || true)
+    dns=$(nmcli -g IP4.DNS device show "$iface" 2>/dev/null | head -1 || true)
+    [ -z "$dns" ] && dns="$gw"
+    con=$(_net_active_con "$iface")
+    method=$(nmcli -g ipv4.method connection show "$con" 2>/dev/null || true)
+    base=${ip4%.*}; cur=${ip4##*.}
+    suggest=$(_net_suggest_static "$base" "$cur")
+    local pending="false"
+    [ -f "$NET_PENDING_FILE" ] && pending="true"
+    printf '{"iface":"%s","method":"%s","ip":"%s","prefix":"%s","gateway":"%s","dns":"%s","suggested":"%s","hostname":"%s","pending":%s}\n' \
+        "$iface" "${method:-auto}" "$ip4" "${prefix:-24}" "$gw" "$dns" "$suggest" "$(hostname)" "$pending"
+}
+
+network_pin() {
+    local ip="$1" prefix="$2" gw="$3" dns="${4:-}" revert="${5:-180}"
+    [ -n "$ip" ] && [ -n "$prefix" ] && [ -n "$gw" ] || die "network_pin: ip, prefix and gateway are required"
+    local iface con
+    iface=$(_net_primary_iface)
+    [ -z "$iface" ] && die "No primary network interface found"
+    con=$(_net_active_con "$iface")
+    [ -z "$con" ] && die "No active NetworkManager connection on $iface"
+    [ -z "$dns" ] && dns="$gw"
+
+    rm -f "$NET_CONFIRM_SENTINEL"
+    # Stash desired config so 'network_confirm' can persist it without re-passing args.
+    printf '%s\n%s\n%s\n%s\n%s\n' "$con" "$ip" "$prefix" "$gw" "$dns" > "$NET_PENDING_FILE"
+    chmod 600 "$NET_PENDING_FILE"
+
+    # Detached applier (survives the dropped HTTP/SSH connection and a manager
+    # restart): apply to the running device only, then roll back to the saved
+    # DHCP profile via 'device reapply' unless confirmed in time.
+    local applier; applier=$(mktemp /run/homebrain-netapply.XXXXXX)
+    cat > "$applier" <<APPLY
+#!/bin/bash
+sleep 2
+nmcli device modify "$iface" ipv4.method manual ipv4.addresses "$ip/$prefix" ipv4.gateway "$gw" ipv4.dns "$dns" >/dev/null 2>&1
+sleep $revert
+if [ ! -f "$NET_CONFIRM_SENTINEL" ]; then
+    nmcli device reapply "$iface" >/dev/null 2>&1
+fi
+rm -f "$applier"
+APPLY
+    chmod +x "$applier"
+    setsid bash "$applier" </dev/null >/dev/null 2>&1 &
+    log_info "Static IP $ip/$prefix scheduled on $iface (auto-revert in ${revert}s unless confirmed)."
+    echo "applying"
+}
+
+network_confirm() {
+    [ -f "$NET_PENDING_FILE" ] || die "No pending network change to confirm"
+    local con ip prefix gw dns
+    { read -r con; read -r ip; read -r prefix; read -r gw; read -r dns; } < "$NET_PENDING_FILE"
+    touch "$NET_CONFIRM_SENTINEL"
+    nmcli connection modify "$con" ipv4.method manual ipv4.addresses "$ip/$prefix" \
+        ipv4.gateway "$gw" ipv4.dns "$dns" ipv4.may-fail no
+    nmcli connection up "$con" >/dev/null 2>&1 || true
+    rm -f "$NET_PENDING_FILE"
+    log_info "Static IP $ip/$prefix confirmed and persisted on '$con'."
+    echo "confirmed"
+}
+
+network_dhcp() {
+    local iface con
+    iface=$(_net_primary_iface)
+    con=$(_net_active_con "$iface")
+    [ -z "$con" ] && die "No active NetworkManager connection"
+    touch "$NET_CONFIRM_SENTINEL"   # cancel any in-flight revert guard
+    nmcli connection modify "$con" ipv4.method auto ipv4.addresses "" ipv4.gateway "" ipv4.dns ""
+    nmcli connection up "$con" >/dev/null 2>&1 || true
+    rm -f "$NET_PENDING_FILE"
+    log_info "Reverted '$con' to automatic addressing (DHCP)."
+    echo "dhcp"
 }
 
 # --- Action: Activate Tunnels (Post-Setup) ---
@@ -1919,10 +2115,29 @@ case "${1:-}" in
         configure_nextcloud_redis
         ;;
     setup)
-        setup_ftp_user "${2}" "${3}" "${4}"
+        # $4 is the path to a 0600 file holding the password — keeps the secret
+        # out of argv (and therefore out of `ps`). Read it, shred it, then setup.
+        _ftp_pass_file="${4}"
+        [ -f "$_ftp_pass_file" ] || die "FTP password file not found: $_ftp_pass_file"
+        _ftp_pass="$(cat "$_ftp_pass_file")"
+        shred -u "$_ftp_pass_file" 2>/dev/null || rm -f "$_ftp_pass_file"
+        setup_ftp_user "${2}" "${3}" "$_ftp_pass"
+        unset _ftp_pass
         ;;
     delete)
         delete_ftp_user "${2}"
+        ;;
+    network_info)
+        network_info
+        ;;
+    network_pin)
+        network_pin "${2}" "${3}" "${4}" "${5:-}" "${6:-180}"
+        ;;
+    network_confirm)
+        network_confirm
+        ;;
+    network_dhcp)
+        network_dhcp
         ;;
     activate_tunnels)
         activate_tunnels
@@ -1973,7 +2188,7 @@ case "${1:-}" in
         migrate_to_consolidated_layout
         ;;
     *)
-        echo "Usage: $0 {setup <nc_user> <ftp_user> <ftp_pass> | delete <ftp_user>}"
+        echo "Usage: $0 {setup <nc_user> <ftp_user> <pass_file> | delete <ftp_user> | network_info | network_pin <ip> <prefix> <gw> [dns] [revert_secs] | network_confirm | network_dhcp}"
         exit 1
         ;;
 esac

--- a/src/app.py
+++ b/src/app.py
@@ -3235,12 +3235,21 @@ def setup_ftp():
     # Ensure utility script is executable
     subprocess.run(["chmod", "+x", SCRIPT_UTILITIES])
 
-    # Pass password securely? 
-    # For simplicity in this context, we pass as arg, but in high security 
-    # we would write to temp file or pipe. Since this is local root, args are acceptable-ish
-    # but strictly speaking visible in ps. 
-    # Use shlex to prevent injection.
-    cmd = f"bash {SCRIPT_UTILITIES} setup {shlex.quote(nc_user)} {shlex.quote(ftp_user)} {shlex.quote(ftp_pass)} >> {LOG_FILES['setup']} 2>&1"
+    # Write the password to a private temp file (0600) and pass only its path —
+    # this keeps the secret out of argv (and therefore out of `ps`). utilities.sh
+    # reads then shreds the file.
+    fd, pass_file = tempfile.mkstemp(prefix="hb_ftp_", suffix=".pw")
+    try:
+        os.write(fd, ftp_pass.encode())
+    finally:
+        os.close(fd)
+    os.chmod(pass_file, 0o600)
+
+    cmd = (
+        f"bash {shlex.quote(SCRIPT_UTILITIES)} setup "
+        f"{shlex.quote(nc_user)} {shlex.quote(ftp_user)} {shlex.quote(pass_file)} "
+        f">> {LOG_FILES['setup']} 2>&1"
+    )
 
     threading.Thread(
         target=run_background_task, args=("Setup FTP Server", cmd, "setup")
@@ -3263,6 +3272,108 @@ def delete_ftp():
         target=run_background_task, args=("Delete FTP User", cmd, "setup")
     ).start()
     return jsonify({"status": "started"})
+
+
+# --- Routes: Network (stable address for cameras) ---
+# Cameras can't resolve mDNS (.local) and consumer routers often can't reserve a
+# DHCP lease, so a fixed IP on the box is the reliable way to keep a camera's FTP
+# target valid. Pinning uses a confirm-or-revert guard (see utilities.sh) so a bad
+# address self-heals back to DHCP rather than locking the box off the network.
+_IPV4_RE = re.compile(r"^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$")
+
+def _valid_ipv4(s):
+    m = _IPV4_RE.match((s or "").strip())
+    return bool(m) and all(0 <= int(g) <= 255 for g in m.groups())
+
+@app.route("/api/network/info", methods=["GET"])
+def api_network_info():
+    """Current addressing (iface, method, ip, gateway, dns) + a suggested free static IP."""
+    try:
+        out = subprocess.check_output(
+            ["bash", SCRIPT_UTILITIES, "network_info"], text=True, timeout=20
+        ).strip()
+        return Response(out, mimetype="application/json")
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+@app.route("/api/network/pin", methods=["POST"])
+@limiter.limit("10 per minute")
+def api_network_pin():
+    """Apply a static IP to the running device with an auto-revert guard.
+
+    The box's IP changes ~2s after this returns, so the client must reconnect at
+    the new address and POST /api/network/confirm before the revert window
+    elapses, or addressing rolls back to DHCP automatically.
+    """
+    data = request.json or {}
+    ip = (data.get("ip") or "").strip()
+    prefix = str(data.get("prefix") or "24").strip()
+    gateway = (data.get("gateway") or "").strip()
+    dns = (data.get("dns") or gateway).strip()
+    try:
+        revert = str(max(30, min(600, int(data.get("revert", 180)))))
+    except (TypeError, ValueError):
+        revert = "180"
+
+    if not _valid_ipv4(ip):
+        return jsonify({"error": "Invalid IP address"}), 400
+    if not _valid_ipv4(gateway):
+        return jsonify({"error": "Invalid gateway"}), 400
+    if not prefix.isdigit() or not (1 <= int(prefix) <= 32):
+        return jsonify({"error": "Invalid prefix length"}), 400
+    if not dns or any(not _valid_ipv4(d) for d in dns.split()):
+        return jsonify({"error": "Invalid DNS server"}), 400
+
+    subprocess.run(["chmod", "+x", SCRIPT_UTILITIES])
+    try:
+        # network_pin schedules a detached applier and returns immediately, so
+        # this call does not block on the IP change itself.
+        subprocess.check_output(
+            ["bash", SCRIPT_UTILITIES, "network_pin", ip, prefix, gateway, dns, revert],
+            text=True, timeout=15, stderr=subprocess.STDOUT,
+        )
+    except subprocess.CalledProcessError as e:
+        return jsonify({"error": (e.output or "").strip() or "Failed to schedule static IP"}), 500
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+    return jsonify({
+        "status": "applying",
+        "new_ip": ip,
+        "new_url": f"http://{ip}/",
+        "revert_seconds": int(revert),
+    })
+
+@app.route("/api/network/confirm", methods=["POST"])
+@limiter.limit("10 per minute")
+def api_network_confirm():
+    """Persist the pending static IP and cancel the auto-revert guard."""
+    try:
+        subprocess.check_output(
+            ["bash", SCRIPT_UTILITIES, "network_confirm"], text=True, timeout=30,
+            stderr=subprocess.STDOUT,
+        )
+        return jsonify({"status": "confirmed"})
+    except subprocess.CalledProcessError as e:
+        return jsonify({"error": (e.output or "").strip() or "Confirm failed"}), 500
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+@app.route("/api/network/dhcp", methods=["POST"])
+@limiter.limit("10 per minute")
+def api_network_dhcp():
+    """Revert addressing to automatic (DHCP)."""
+    subprocess.run(["chmod", "+x", SCRIPT_UTILITIES])
+    try:
+        subprocess.check_output(
+            ["bash", SCRIPT_UTILITIES, "network_dhcp"], text=True, timeout=30,
+            stderr=subprocess.STDOUT,
+        )
+        return jsonify({"status": "reverting"})
+    except subprocess.CalledProcessError as e:
+        return jsonify({"error": (e.output or "").strip() or "Revert failed"}), 500
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
 
 if __name__ == "__main__":
     try:

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -1163,6 +1163,40 @@
                         <div id="ftp-user-list" style="min-height:50px;">Loading...</div>
                     </div>
                 </div>
+
+                <div id="ftp-recipe" style="margin-top:18px; padding:14px 16px; border:1px solid var(--border); border-radius:8px; background:var(--surface-sunken); font-size:0.9em; display:none;">
+                    <div style="font-weight:600; margin-bottom:8px;">📷 Enter these in your camera's FTP settings</div>
+                    <div style="display:grid; grid-template-columns:max-content 1fr; gap:4px 16px; align-items:baseline;">
+                        <span style="color:var(--text-dim);">Server / Host</span><span><code id="ftp-recipe-host">…</code></span>
+                        <span style="color:var(--text-dim);">Port</span><span><code>21</code></span>
+                        <span style="color:var(--text-dim);">Mode</span><span><code>Passive (PASV)</code> &nbsp;<span style="color:var(--text-faint);">— "Auto" also works</span></span>
+                        <span style="color:var(--text-dim);">Username</span><span><code>your FTP user above</code></span>
+                        <span style="color:var(--text-dim);">Remote folder</span><span><code>/</code> &nbsp;<span style="color:var(--text-faint);">— uploads land in that user's Nextcloud <code>uploads</code> folder</span></span>
+                    </div>
+                    <div id="ftp-recipe-warn" style="margin-top:10px; color:var(--warning); display:none;">
+                        ⚠️ Use the <b>IP address</b> shown above — cameras can't reach <code>homebrain.local</code>.
+                        For a target that never changes, pin a fixed address in <b>Network</b> below.
+                    </div>
+                </div>
+            </div>
+
+            <div class="card" style="grid-column: 1 / -1;">
+                <h3>Network <span style="font-weight:400; color:var(--text-dim); font-size:0.85em;">— stable address for cameras &amp; devices</span></h3>
+                <p style="margin-bottom:14px;">Cameras and many smart devices can't use <code>homebrain.local</code> — they need a numeric IP. Pin a fixed address so the IP your camera points at never changes.</p>
+                <div id="net-status" style="margin-bottom:14px; font-size:0.92em;">Loading network status…</div>
+
+                <div id="net-pin-form" style="display:none; align-items:end; gap:12px; flex-wrap:wrap;">
+                    <div><label style="margin-bottom:4px;">Fixed IP address</label><input type="text" id="net-ip" style="margin-bottom:0; width:160px;"></div>
+                    <button onclick="pinNetwork()" class="btn-primary" style="margin-bottom:0;">Use this fixed address</button>
+                    <button onclick="revertDhcp()" id="net-dhcp-btn" style="margin-bottom:0; display:none;">Back to automatic (DHCP)</button>
+                </div>
+
+                <div id="net-confirm" style="display:none; margin-top:14px; padding:14px 16px; border:1px solid var(--warning); border-radius:8px; background:var(--surface-sunken);">
+                    <div style="font-weight:600;">Confirm the new address</div>
+                    <div id="net-confirm-msg" style="margin:8px 0; font-size:0.92em;"></div>
+                    <button onclick="confirmNetwork()" class="btn-primary" style="margin-bottom:0;">Keep this address</button>
+                    <span id="net-countdown" style="margin-left:12px; color:var(--text-dim);"></span>
+                </div>
             </div>
 
             {% if ha_domain %}
@@ -1341,6 +1375,7 @@
                 loadSerialDevices();
                 loadFtpUsers();
                 populateFtpNcUserSelect();
+                loadNetworkStatus();
                 connRefresh();
                 vaultMcpRefresh();
             }
@@ -2668,7 +2703,10 @@
             try {
                 const res = await fetch('/api/ftp/users', { credentials: 'include' });
                 const users = await res.json();
-                
+
+                const recipe = document.getElementById('ftp-recipe');
+                if (recipe) recipe.style.display = users.length ? 'block' : 'none';
+
                 if (users.length === 0) {
                     el.innerHTML = '<em style="color:var(--text-faint);">No FTP users configured.</em>';
                     return;
@@ -2704,6 +2742,106 @@
                 triggerAction('/api/ftp/delete', 'Delete FTP User', { ftp_user: user });
                 setTimeout(loadFtpUsers, 3000);
             }
+        }
+
+        // --- Network / FTP-recipe Logic ---
+        let _netInfo = null;
+        let _netCountdownTimer = null;
+
+        async function loadNetworkStatus() {
+            const statusEl = document.getElementById('net-status');
+            try {
+                const res = await fetch('/api/network/info', { credentials: 'include' });
+                const n = await res.json();
+                if (n.error) { statusEl.textContent = 'Network status unavailable: ' + n.error; return; }
+                _netInfo = n;
+
+                const isStatic = (n.method === 'manual');
+                statusEl.innerHTML =
+                    `Current address: <code>${n.ip}</code> ` +
+                    `<span style="color:var(--text-dim);">(${isStatic ? 'fixed / static' : 'automatic / DHCP'})</span>`;
+
+                // Populate the camera recipe (server host = the numeric IP).
+                const host = document.getElementById('ftp-recipe-host');
+                if (host) host.textContent = n.ip;
+                const warn = document.getElementById('ftp-recipe-warn');
+                if (warn) warn.style.display = isStatic ? 'none' : 'block';
+
+                // Pin form
+                document.getElementById('net-pin-form').style.display = 'flex';
+                const ipInput = document.getElementById('net-ip');
+                if (document.activeElement !== ipInput) ipInput.value = n.suggested || n.ip;
+                document.getElementById('net-dhcp-btn').style.display = isStatic ? 'inline-block' : 'none';
+
+                // If a change is awaiting confirmation (e.g. we just reconnected at
+                // the new address), surface the confirm panel automatically.
+                if (n.pending) showConfirmPanel(n.ip, null);
+            } catch (e) {
+                statusEl.textContent = 'Network status unavailable (offline?).';
+            }
+        }
+
+        function showConfirmPanel(newIp, revertSeconds) {
+            document.getElementById('net-confirm').style.display = 'block';
+            document.getElementById('net-confirm-msg').innerHTML =
+                `The box is now reachable at <a href="http://${newIp}/"><code>${newIp}</code></a>. ` +
+                `Click <b>Keep this address</b> to make it permanent. If you don't, it reverts to DHCP automatically.`;
+            if (_netCountdownTimer) clearInterval(_netCountdownTimer);
+            if (revertSeconds) {
+                let left = revertSeconds;
+                const cd = document.getElementById('net-countdown');
+                const tick = () => {
+                    cd.textContent = left > 0 ? `auto-revert in ${left}s` : 'reverting…';
+                    if (left-- <= 0) clearInterval(_netCountdownTimer);
+                };
+                tick();
+                _netCountdownTimer = setInterval(tick, 1000);
+            }
+        }
+
+        async function pinNetwork() {
+            const ip = document.getElementById('net-ip').value.trim();
+            if (!_netInfo) return;
+            if (!confirm(`Pin this box to ${ip}?\n\nThe box's address will change. You'll need to reconnect at http://${ip}/ and click "Keep this address" within ~3 minutes, or it automatically reverts to DHCP.\n\nRemember to update your camera's FTP server to ${ip} afterwards.`)) return;
+            const body = { ip, prefix: _netInfo.prefix || '24', gateway: _netInfo.gateway, dns: _netInfo.dns, revert: 180 };
+            try {
+                const res = await fetch('/api/network/pin', {
+                    method: 'POST', credentials: 'include',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(body)
+                });
+                const data = await res.json();
+                if (!res.ok) { alert('Could not pin address: ' + (data.error || res.status)); return; }
+                showConfirmPanel(data.new_ip, data.revert_seconds);
+                // The current page may lose the box when the IP flips; nudge the user over.
+                setTimeout(() => { window.location.href = data.new_url; }, (data.revert_seconds > 20 ? 6000 : 3000));
+            } catch (e) {
+                // Expected: the connection may drop as the IP changes. Guide the user.
+                showConfirmPanel(ip, body.revert);
+            }
+        }
+
+        async function confirmNetwork() {
+            try {
+                const res = await fetch('/api/network/confirm', { method: 'POST', credentials: 'include' });
+                const data = await res.json();
+                if (!res.ok) { alert('Confirm failed: ' + (data.error || res.status)); return; }
+                if (_netCountdownTimer) clearInterval(_netCountdownTimer);
+                document.getElementById('net-confirm').style.display = 'none';
+                document.getElementById('net-countdown').textContent = '';
+                alert('Fixed address saved. Point your camera at this IP.');
+                loadNetworkStatus();
+            } catch (e) {
+                alert('Confirm failed — are you connected to the box at its new address?');
+            }
+        }
+
+        async function revertDhcp() {
+            if (!confirm('Revert to automatic addressing (DHCP)? The IP may change again.')) return;
+            try {
+                await fetch('/api/network/dhcp', { method: 'POST', credentials: 'include' });
+                alert('Reverting to DHCP. The box address may change.');
+            } catch (e) { /* connection may drop as IP changes */ }
         }
 
         // --- Zigbee Logic ---


### PR DESCRIPTION
## Why
A camera (Reolink) configured to upload over FTP failed with **"FTP error 19"** even though the dashboard showed the FTP server *active*. Root-cause tracing on real hardware surfaced three classes of problem in the camera-FTP feature: it could be silently broken, gave the user no connection details, and depended on an address (`homebrain.local` / a DHCP IP) that cameras can't use or that drifts.

## What

**FTP correctness**
- **Fix the actual failure:** `500 OOPS: cannot change directory:/var/www`. vsftpd's guest user `www-data` has home `/var/www`, and vsftpd `chdir()`s there during login *before* applying `local_root`. On a Docker-only host there's no host Apache, so `/var/www` never exists and every login dies — which cameras report as the generic "error 19". `configure_vsftpd` now creates it.
- **Self-test after setup:** a real loopback login + passive `STOR` with the new credentials. If it fails the task fails *loudly* with the real reason, instead of a misleading "active". This would have caught the bug instantly.
- **Lazy firewall:** open `21/tcp` + passive `40000-50000` only when FTP is configured (ufw-gated), and close them when the last user is deleted. (`provision.sh` only opened the web ports.)

**Security hardening**
- Passwords hashed with **bcrypt** (`htpasswd -B`) instead of legacy DES crypt (DES silently truncates to 8 chars), with a DES fallback.
- Password passed to `utilities.sh` via a `0600` temp file (shredded after read), not argv — keeps it out of `ps`.

**Stable addressing (cameras can't resolve mDNS; routers like Starlink can't reserve leases)**
- New **Network** card + `/api/network/{info,pin,confirm,dhcp}` to pin a static IP.
- **Confirm-or-revert guard:** the address is applied to the *running device only* and auto-reverts to DHCP unless confirmed at the new address — a wrong/remote change self-heals instead of bricking access.

**UX**
- FTP card now shows the exact camera recipe (IP / port 21 / passive) with an explicit *"use the IP, not `homebrain.local`"* warning.

## Testing (on real hardware)
- bcrypt self-test passes; password file ends up `$2y$…`; passfile is shredded.
- Mixed DES/bcrypt password file still authenticates existing users.
- `network_info` returns correct JSON + a suggested free low IP.
- Live **pin → reconnect at new IP → confirm** cycle: box moved to a static IP, guard armed (`pending:true`), confirm persisted it (`nmcli ipv4.method=manual`, survives reboot).
- Authenticated dashboard renders the new Network card + FTP recipe; unauth requests still 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)