### PR TITLE
fix(update): resolve update-deps.sh from INSTALL_DIR, not SCRIPT_DIR

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -171,7 +171,14 @@ if command -v jq >/dev/null 2>&1 && [[ -f "$INSTALL_DIR/config/versions.json" ]]
             echo "VAULTWARDEN_TAG='${new_vault_tag}'" >> "$ENV_FILE"
         fi
     fi
-    UPDATE_DEPS_SCRIPT="$SCRIPT_DIR/update-deps.sh"
+    # Resolve from INSTALL_DIR, not SCRIPT_DIR: after the self-reload re-exec'd
+    # the new update.sh from /tmp/homebrain_self_update, $SCRIPT_DIR points there
+    # — and only update.sh + common.sh are downloaded into that dir. A
+    # $SCRIPT_DIR-relative path would miss update-deps.sh entirely, so this whole
+    # block (llama/openclaw version bumps AND the plugin/config drift catch-all)
+    # would silently skip on every update that also changes update.sh. The
+    # rsync above already put the current update-deps.sh in place under INSTALL_DIR.
+    UPDATE_DEPS_SCRIPT="$INSTALL_DIR/scripts/update-deps.sh"
     if [[ -f "$UPDATE_DEPS_SCRIPT" ]] && [[ "${HAS_GPU:-false}" == "true" ]]; then
         if [[ -n "$new_llama_tag" && "$old_llama_tag" != "$new_llama_tag" ]]; then
             log_info "llama.cpp: ${old_llama_tag} → ${new_llama_tag}. Updating binary..."


### PR DESCRIPTION
## Problem

After `update.sh` self-updates, it `exec`s the freshly downloaded copy from
`/tmp/homebrain_self_update` (which contains **only** `update.sh` + `common.sh`).
From that point `$SCRIPT_DIR` points at the temp dir, so:

```sh
UPDATE_DEPS_SCRIPT="$SCRIPT_DIR/update-deps.sh"   # → /tmp/homebrain_self_update/update-deps.sh (missing)
if [[ -f "$UPDATE_DEPS_SCRIPT" ]] && [[ "${HAS_GPU:-false}" == "true" ]]; then
```

`[[ -f ... ]]` is false, so the **entire** llama/openclaw block is skipped on
any update that also changes `update.sh` — which every real release does, because
`update.sh` self-updates first. This silently disabled:

- the version-bump path (`update-deps.sh llama_cpp` / `openclaw`), and
- the plugin/config drift catch-all from #98 — so #98's "Blocker B" fix
  (`install_homebrain_openclaw_plugins` + `patch_openclaw_config`) **never ran**.

## Evidence (live `.58` E2E)

A `dev → main` deploy produced **zero** openclaw-refresh markers in the update
log (neither the "Refreshing openclaw plugins" success line nor the "skipped"
warning — proving the outer `[[ -f ]]` gate failed, not an inner branch).
`homebrain-whatsapp-login` was rsynced to `/opt/homebrain/config/openclaw-plugins/`
but never registered with the gateway.

## Fix

Resolve from `INSTALL_DIR` (where the rsync just placed the current
`update-deps.sh`), matching the existing migration block that already documents
this exact self-reload hazard.

## Test

- `bash -n` clean.
- Re-deploy to `.58` and confirm the openclaw-refresh markers appear and the
  plugin registers (follow-up in the same E2E session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)