### PR TITLE
fix(update): run openclaw refresh as utilities.sh subprocess, not source

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -199,36 +199,21 @@ if command -v jq >/dev/null 2>&1 && [[ -f "$INSTALL_DIR/config/versions.json" ]]
             #      never register with the gateway.
             #   2. The patch_openclaw_config jq pipeline in utilities.sh (new
             #      schema keys, refreshed allowedOrigins, etc.).
-            # Snapshot openclaw.json first, then (re)install plugins (which mutate
-            # plugins.entries) and re-patch config; restart the daemon only when
-            # the file actually changed so a freshly-registered route/schema is
-            # picked up without a needless bounce.
-            # After self-update re-exec $SCRIPT_DIR points at /tmp/homebrain_self_update
-            # which only has update.sh + common.sh. utilities.sh lives in the rsynced
-            # install dir, so always source from there — and pass the plugins root
-            # explicitly, because sourcing it resets SCRIPT_DIR to this script's $0.
+            # Delegate to utilities.sh's `refresh_openclaw` subcommand, run as a
+            # SUBPROCESS — never `source` it. Sourcing utilities.sh executes
+            # common.sh's top-level side effects under this script's `set -e`, and
+            # resets SCRIPT_DIR to this script's $0 (the /tmp self-update dir after
+            # the re-exec), so load_versions' `die` fires on the wrong path and
+            # exits THIS script straight past any `|| true`. A subprocess keeps
+            # utilities.sh's SCRIPT_DIR / set -e / die fully isolated — we only
+            # read its return code. The subcommand snapshots openclaw.json,
+            # (re)installs the bundled plugins + re-patches config, and restarts
+            # the gateway only when the file actually changed.
             UTILS_FILE="$INSTALL_DIR/scripts/utilities.sh"
             if command -v openclaw >/dev/null 2>&1 && [[ -f "$UTILS_FILE" ]]; then
-                CFG="${HOMEBRAIN_HOME:-/home/homebrain}/.openclaw/openclaw.json"
-                if [[ -f "$CFG" ]]; then
-                    log_info "Refreshing openclaw plugins + config against current install..."
-                    # shellcheck disable=SC1090
-                    source "$UTILS_FILE"
-                    load_env 2>/dev/null || true
-                    load_versions 2>/dev/null || true
-                    cp "$CFG" "${CFG}.preupdate"
-                    install_homebrain_openclaw_plugins "$INSTALL_DIR/config/openclaw-plugins"
-                    if patch_openclaw_config "$CFG" "${AI_MODEL_ID:-}" "${OC_CTX_SIZE:-}"; then
-                        if ! cmp -s "${CFG}.preupdate" "$CFG"; then
-                            log_info "openclaw plugins/config changed — restarting daemon to apply."
-                            run_as_admin systemctl --user restart openclaw-gateway >/dev/null 2>&1 \
-                                || log_warn "openclaw-gateway restart failed — check logs."
-                        else
-                            log_info "openclaw plugins/config already current — no daemon restart."
-                        fi
-                    fi
-                    rm -f "${CFG}.preupdate"
-                fi
+                log_info "Refreshing openclaw plugins + config against current install..."
+                bash "$UTILS_FILE" refresh_openclaw \
+                    || log_warn "openclaw plugin/config refresh failed — check logs."
             else
                 log_warn "openclaw config refresh skipped: openclaw=$(command -v openclaw||echo missing) utils=$UTILS_FILE present=$([[ -f $UTILS_FILE ]]&&echo y||echo n)"
             fi

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -2223,6 +2223,33 @@ case "${1:-}" in
         setup_llama_server || { log_error "Failed to restart after update."; exit 1; }
         log_info "llama-server updated and restarted."
         ;;
+    refresh_openclaw)
+        # Re-register the bundled HomeBrain OpenClaw plugins and re-patch
+        # openclaw.json against the current install, restarting the gateway only
+        # if the file actually changed. Invoked by update.sh's no-version-bump
+        # path. MUST be run as a subprocess (not sourced) — see the note there:
+        # as a subprocess our SCRIPT_DIR resolves correctly (so load_versions and
+        # the plugins root point at the real install dir) and any die() stays
+        # contained to this process.
+        load_env 2>/dev/null || true
+        CFG="${HOMEBRAIN_HOME:-/home/homebrain}/.openclaw/openclaw.json"
+        if [[ ! -f "$CFG" ]]; then
+            log_info "No openclaw.json present — skipping openclaw refresh."
+            exit 0
+        fi
+        cp "$CFG" "${CFG}.preupdate"
+        install_homebrain_openclaw_plugins
+        if patch_openclaw_config "$CFG" "${AI_MODEL_ID:-}" "${OC_CTX_SIZE:-}"; then
+            if ! cmp -s "${CFG}.preupdate" "$CFG"; then
+                log_info "openclaw plugins/config changed — restarting daemon to apply."
+                run_as_admin systemctl --user restart openclaw-gateway >/dev/null 2>&1 \
+                    || log_warn "openclaw-gateway restart failed — check logs."
+            else
+                log_info "openclaw plugins/config already current — no daemon restart."
+            fi
+        fi
+        rm -f "${CFG}.preupdate"
+        ;;
     migrate)
         load_env 2>/dev/null || true   # .env may not exist on first provision
         migrate_to_consolidated_layout


### PR DESCRIPTION
## Problem

#106 made the no-version-bump openclaw refresh block actually run (it had been
dead code, gated behind a `$SCRIPT_DIR`-relative path). On the first live run on
`.58` it then **died** immediately after logging `Refreshing openclaw plugins…`,
before the `cp`/install. Because that block sits *before* the docker / version /
manager-restart steps, the whole update silently aborted: gateway never
refreshed, `homebrain-whatsapp-login` never registered, manager never restarted.

## Root cause

`update.sh` `source`d `utilities.sh` from inside its own `set -e`:

- `utilities.sh:5` sets `SCRIPT_DIR` from `$0` — after the self-update re-exec
  that's `/tmp/homebrain_self_update` — and `utilities.sh:6` `source`s
  `common.sh`, whose top-level side effects run under `update.sh`'s `set -e`.
- `load_env` / `load_versions` then `die` on the wrong (temp-dir-relative) paths.
  `die` calls `exit`, which blows **past the `|| true` guards** and terminates
  `update.sh` itself.

(`set -e` + `|| true` only catches a non-zero *return*; it cannot catch `exit`.)

## Fix

Stop sourcing `utilities.sh` from `update.sh`. Add a self-contained
`refresh_openclaw` subcommand and invoke it as a **subprocess**
(`bash utilities.sh refresh_openclaw`), mirroring how `migrate` is already run.
As a subprocess, `utilities.sh`'s `SCRIPT_DIR` resolves to the real install dir
and any `die()` stays contained — `update.sh` only reads the return code
(`|| log_warn`). The subcommand snapshots `openclaw.json`, (re)installs the
bundled HomeBrain plugins, re-patches config, and restarts the gateway only when
the file actually changed.

## Test

- `bash -n` clean on both files.
- Local subprocess trace: dispatch guard passes (`BASH_SOURCE==$0`),
  `SCRIPT_DIR` correct, `refresh_openclaw)` case entered; `die`s now contained
  to the subprocess.
- Full install/patch/restart path validated by the live `.58` redeploy in the
  same E2E session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)