### PR TITLE
fix(plugin): add required configSchema to homebrain-whatsapp-login manifest

### DIFF
--- a/config/openclaw-plugins/homebrain-whatsapp-login/openclaw.plugin.json
+++ b/config/openclaw-plugins/homebrain-whatsapp-login/openclaw.plugin.json
@@ -4,5 +4,9 @@
   "description": "Gateway HTTP route (POST /api/channels/login/whatsapp/{start,wait}) for WhatsApp QR linking, consumed by the HomeBrain dashboard. Replaces the equivalent core route from the OpenClaw fork so HomeBrain can run stock upstream OpenClaw.",
   "activation": {
     "onStartup": true
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false
   }
 }


### PR DESCRIPTION
## Problem

The OpenClaw plugin API **requires** every plugin manifest to declare a
`configSchema` (every stock plugin — `whatsapp`, `matrix`, … — has one). The
`homebrain-whatsapp-login` manifest from #98 omits it, so `openclaw plugins
install` registers the extension but `openclaw config validate` then fails:

```
plugins: plugin: plugin manifest requires configSchema
```

That leaves `~/.openclaw/openclaw.json` **invalid**, and the gateway refuses to
load an invalid config on its next restart. So deploying #98 as-is **corrupts
the openclaw config on every box** (caught on live `.58` — the plugin partial-
installed into `~/.openclaw/extensions/` and validation broke; had to remove the
extension manually to restore a valid config).

## Fix

This plugin takes no configuration (it only registers an HTTP route), so the
schema is an empty closed object:

```json
"configSchema": { "type": "object", "additionalProperties": false }
```

## Test

Verified live on `.58`: with this added, `openclaw plugins install <dir> --force`
returns `0` and prints "Installed plugin: homebrain-whatsapp-login", and
`openclaw config validate` reports **Config valid** (`openclaw plugins list` then
works again). JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)