### PR TITLE
chore(versions): bump openclaw + @openclaw/whatsapp to 2026.6.8

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -7,11 +7,11 @@
     "git_ref": "v1.8.4"
   },
   "openclaw": {
-    "version": "2026.5.12"
+    "version": "2026.6.8"
   },
   "openclaw_whatsapp": {
     "_comment": "WhatsApp is a separate channel plugin (not bundled in openclaw). Pin MUST stay peer-compatible with openclaw.version above: @openclaw/whatsapp declares peerDependencies.openclaw and compat.pluginApi (e.g. 2026.5.28 requires openclaw>=2026.5.28). Bump this in lockstep with openclaw.version. Telegram is bundled in core and needs no pin.",
-    "version": "2026.5.12"
+    "version": "2026.6.8"
   },
   "vaultwarden": {
     "tag": "1.35.8"


### PR DESCRIPTION
Bumps openclaw `2026.5.12 → 2026.6.8` (npm `latest`) and `@openclaw/whatsapp`
to `2026.6.8` in lockstep (its `peerDependencies` require `openclaw >=2026.6.8`).

On a GPU box this hits `update.sh`'s version-change path
(`update-deps.sh openclaw` → `setup_openclaw`), which reinstalls stock openclaw
and rewrites the gateway unit via `openclaw daemon install --force` — also
rolling a fork-swapped box back onto stock upstream.

Validated live on `.58` after merge (stock rollback + WhatsApp-plugin E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)