### PR TITLE
fix(openclaw): 2026.6 stock compat — drop mcp.approvals, fix WhatsApp creds path

### DIFF
--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -82,11 +82,6 @@
       }
     }
   },
-  "mcp": {
-    "approvals": {
-      "enabled": false
-    }
-  },
   "approvals": {
     "exec": {
       "enabled": true,

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1452,12 +1452,11 @@ patch_openclaw_config() {
         # behind the session, so dropping device-identity here does
         # not weaken our auth posture — it just unblocks the LAN flow.
         .gateway.controlUi.allowInsecureAuth = true |
-        # MCP consent gate: disabled by default so the HomeBrain MCP servers
-        # work on stock OpenClaw without our upstream PR. The top-level
-        # approvals config is pre-wired for when the PR lands — flip
-        # mcp.approvals.enabled to true and channel users get /approve
-        # prompts routed back to their DM session.
-        .mcp.approvals.enabled = false |
+        # MCP consent gate is disabled pending our upstream OpenClaw approvals
+        # PR. It must NOT be persisted under .mcp: stock OpenClaw (>=2026.6)
+        # strictly validates the mcp section and rejects unknown keys
+        # (`mcp: Invalid input`), which blocks the gateway from loading. The
+        # top-level .approvals.* below is the native, schema-valid config.
         .approvals.exec.enabled = true |
         .approvals.exec.mode = "session" |
         .approvals.plugin.enabled = true |

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -310,10 +310,14 @@ def _openclaw_daemon_restart() -> None:
 # ---------------------------------------------------------------------------
 
 def _mcp_consent_env() -> dict:
-    """Return env vars that control MCP consent behavior."""
-    data = _read_openclaw_config()
-    enabled = data.get("mcp", {}).get("approvals", {}).get("enabled", False)
-    return {"HOMEBRAIN_MCP_CONSENT": "true" if enabled else "false"}
+    """Return env vars that control MCP consent behavior.
+
+    The HomeBrain MCP consent gate is disabled pending our upstream OpenClaw
+    approvals PR. The flag used to live at mcp.approvals.enabled, but stock
+    OpenClaw (>=2026.6) strictly validates the mcp section and rejects that
+    key, so it is no longer persisted there. Until the upstream feature lands,
+    consent is off (its long-standing default)."""
+    return {"HOMEBRAIN_MCP_CONSENT": "false"}
 
 
 def _spec_self() -> dict:
@@ -1035,10 +1039,19 @@ def _approve_pairing(channel: str, code: str) -> tuple[dict, int]:
 
 
 def _whatsapp_auth_status() -> dict:
-    """Check WhatsApp auth state by looking for session files."""
-    auth_dir = os.path.join(OPENCLAW_DIR, "whatsapp-auth", "default")
-    creds = os.path.join(auth_dir, "creds.json")
-    if os.path.exists(creds):
+    """Check WhatsApp auth state by looking for session files.
+
+    @openclaw/whatsapp persists Baileys creds under
+    ~/.openclaw/credentials/whatsapp/default/creds.json; older builds used
+    ~/.openclaw/whatsapp-auth/default/. Check the current path first, then the
+    legacy one, so the dashboard reports the real link state on both."""
+    candidates = [
+        os.path.join(OPENCLAW_DIR, "credentials", "whatsapp", "default", "creds.json"),
+        os.path.join(OPENCLAW_DIR, "whatsapp-auth", "default", "creds.json"),
+    ]
+    for creds in candidates:
+        if not os.path.exists(creds):
+            continue
         try:
             with open(creds) as f:
                 data = json.load(f)


### PR DESCRIPTION
Found while switching `.58` to **stock openclaw 2026.6.8** for the #98 WhatsApp E2E.

## 1) `mcp.approvals` breaks stock config validation (deploy blocker)

HomeBrain parked its MCP-consent flag at `.mcp.approvals.enabled` (always
`false` — pre-wired for a future upstream approvals PR). Stock OpenClaw `>=2026.6`
strictly validates the `mcp` section and rejects the unknown key:

```
openclaw config validate  ->  × mcp: Invalid input
```

An invalid config blocks the gateway from loading on restart. Both the template
(`config/openclaw.json`) **and** `patch_openclaw_config` emitted it, so the config
re-broke on every deploy. Removed both; the native top-level `.approvals.*` is
untouched. `_mcp_consent_env()` now returns consent `false` directly (its
long-standing default) instead of reading the removed key.

## 2) WhatsApp linked-status checked the wrong path

`@openclaw/whatsapp` persists Baileys creds at
`~/.openclaw/credentials/whatsapp/default/creds.json`, but
`_whatsapp_auth_status()` looked at `~/.openclaw/whatsapp-auth/default/` — so the
dashboard reported `linked:false` even when WhatsApp was linked (verified live:
linked `+4915203460687` but UI said false). Now checks the current path first,
then the legacy one.

## Test

- JSON/py/bash all validate; jq filter chain intact.
- Verified live on `.58` (stock 2026.6.8): removing `mcp.approvals` → `Config valid`;
  creds present at `credentials/whatsapp/default/` with `me.id` set.
- Post-merge redeploy confirms `patch_openclaw_config` no longer re-breaks the config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)