### PR TITLE
fix(dashboard): prompt to set up recovery phrase after update

### DIFF
--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -302,6 +302,13 @@
         .notice-warning { border-left-color: var(--warning); background: var(--warning-soft); }
         .notice-warning strong { color: var(--warning); }
 
+        /* Brief pulse to point the user at a card after a deep-link jump. */
+        .flash-highlight { animation: flashHl 2.2s ease-out; }
+        @keyframes flashHl {
+            0%, 100% { box-shadow: none; }
+            12%      { box-shadow: 0 0 0 3px var(--warning-soft); border-color: var(--warning); }
+        }
+
         /* Tunnel/preview info panel */
         .info-panel {
             background: var(--surface-2);
@@ -460,6 +467,11 @@
     </div>
 
     <div id="status" class="tab-content active">
+        <div id="recovery-prompt" class="notice notice-warning" style="display:none; margin-bottom:22px;">
+            <strong>⚠ Set up your recovery phrase</strong>
+            <p style="margin:6px 0 12px;">This device has no recovery phrase. If you forget your master password there is no way back into the Dashboard, Nextcloud or Home Assistant short of wiping the device. Setting one up takes a few seconds — it is shown only once, so write it down.</p>
+            <button class="btn-warning" onclick="goToRecoverySetup()">Set up recovery phrase →</button>
+        </div>
         <div class="grid">
             <div class="card">
                 <h3>Services</h3>
@@ -3263,7 +3275,12 @@
         async function loadRecoveryStatus() {
             const line = document.getElementById('recovery-status-line');
             const btn = document.getElementById('recovery-gen-btn');
+            const prompt = document.getElementById('recovery-prompt');
             if (!line) return;
+            // The Status-tab prompt only nags when a phrase is genuinely missing
+            // and can be generated; default to hidden so a failed/again status
+            // probe never strands a stale warning on screen.
+            if (prompt) prompt.style.display = 'none';
             try {
                 const r = await fetch('/api/recovery/status', { credentials: 'include' });
                 const d = await r.json();
@@ -3282,14 +3299,31 @@
                 } else {
                     line.innerHTML = 'No recovery phrase is set. Generate one now so you can recover access if you forget your master password.';
                     if (btn) btn.textContent = 'Generate recovery phrase';
+                    if (prompt) prompt.style.display = 'block';
                 }
             } catch (e) { /* leave the placeholder text */ }
+        }
+
+        // Deep-link from the Status-tab prompt to the Recovery card in Settings.
+        function goToRecoverySetup() {
+            openTab('settings');
+            const card = document.getElementById('recovery-card');
+            if (!card) return;
+            card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            card.classList.remove('flash-highlight');
+            void card.offsetWidth;              // restart the animation if re-clicked
+            card.classList.add('flash-highlight');
+            setTimeout(() => card.classList.remove('flash-highlight'), 2200);
         }
 
         async function regenerateRecovery() {
             const btn = document.getElementById('recovery-gen-btn');
             const msg = document.getElementById('recovery-msg');
-            if (!confirm('Generate a new recovery phrase? Any previous phrase will stop working immediately.')) return;
+            // Only confirm the destructive case (replacing a working phrase).
+            // First-time generation is exactly what we're nudging the user to do,
+            // so don't gate it behind a "previous phrase will stop working" prompt.
+            const replacing = btn && /regenerate/i.test(btn.textContent || '');
+            if (replacing && !confirm('Generate a new recovery phrase? Your previous phrase will stop working immediately.')) return;
             btn.disabled = true; msg.textContent = 'Generating…';
             try {
                 const r = await fetch('/api/recovery/regenerate', { method: 'POST', credentials: 'include' });


### PR DESCRIPTION
## Problem

Boxes provisioned **before** the recovery-phrase feature mint no `RECOVERY_*` keys, and `update.sh` never backfills them. After a dashboard update such a box has **no recovery phrase and no visible recovery path** — the login "Forgot your password?" link is gated on `_recovery_configured()`, and the only fix (the Settings → Recovery card) is buried where users never look. Forget the master password and the only exits are SSH into `.env` or a nuclear wipe. This is the unintentional-lockout window the recovery feature was meant to close, left open for already-deployed devices.

## Fix (UI-only, no backend change)

- **Status-tab notice** (the default landing view) shown *only* when `/api/recovery/status` returns `configured:false && wordlist_ok`. Explains the lockout risk in plain language and offers a "Set up recovery phrase →" button.
- `goToRecoverySetup()` deep-links to the Recovery card and pulses it so the user lands on the right control, reusing the existing **reveal-once** generate flow.
- Banner **self-clears**: `regenerateRecovery()` already re-calls `loadRecoveryStatus()`, which now hides it. `get_env_config()` reads `.env` fresh, so the new phrase is live to `/status`, `/verify`, `/reset` immediately — no restart.
- The card's destructive `confirm()` now fires **only when replacing** an existing phrase, so first-time setup isn't fronted by a misleading "your previous phrase will stop working" warning.

## Deliberately unchanged

- Master password is **not** regenerated on update (silently rotating a working credential would desync services and confuse the user). Existing boxes keep theirs.
- Login-gate recovery link stays gated on `configured` — offering recovery to an already-locked-out box with no phrase is a dead end. The nudge happens *before* lockout.

## Testing notes

- The banner only renders on a box **without** a phrase. The `.58` target already minted one in the earlier E2E (`configured:true`), so updating it correctly shows **no** banner. To exercise the prompt, target a pre-feature box or confirm `GET /api/recovery/status` returns `configured:false` first.
- Static checks: JS brace balance verified for the three touched functions; additions contain no Jinja syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)