### PR TITLE
feat(health): proactive health checks + owner notifications via messenger

### DIFF
--- a/config/.env.template
+++ b/config/.env.template
@@ -85,3 +85,8 @@ RECOVERY_CREATED_AT=
 # Recovery is LAN-origin-only by default. Set to true ONLY if you accept that a
 # full master-password reset becomes reachable over the remote tunnel.
 RECOVERY_ALLOW_REMOTE=false
+# --- Health notifications ---
+# Push health alerts (backup failures, full disks, failing drives, downed
+# services, available updates) to the owner via the linked messenger channel.
+# The dashboard banner always shows them regardless of this setting.
+NOTIFY_PUSH=true

--- a/config/homebrain-health.service
+++ b/config/homebrain-health.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=HomeBrain health check + owner notifications
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/python3 /opt/homebrain/scripts/healthcheck.py
+TimeoutStartSec=300
+StandardOutput=journal
+StandardError=journal

--- a/config/homebrain-health.timer
+++ b/config/homebrain-health.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run HomeBrain health check every 30 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=30min
+RandomizedDelaySec=2min
+
+[Install]
+WantedBy=timers.target

--- a/config/platform_models.json
+++ b/config/platform_models.json
@@ -119,6 +119,23 @@
         "notes": "Hybrid DeltaNet SSM+attn (16/64 standard attn layers, 48 DeltaNet). RS must stay GPU-local — nkvo breaks DeltaNet fused kernel (garbage output). ngl<99 drops to ~2 t/s; partial offload defeats DeltaNet GPU fusion. ctv/ctk with fa is mandatory on AMD Vulkan. MTP CLIFF: the draft-mtp speculative path accelerates ONLY at ctx <= ~34816 (cliff between 34816 and 36864); above it TG snaps back to the ~17.5 baseline. ctx was 49152 (over the cliff, MTP gave ~+2%); lowered to 32768 to capture the full MTP gain: ~17.1 -> ~30 t/s (+75%) with n_max=2, q4_0 KV. Crossing any of {ctx>~35K, n_max>=3, q8 KV} silently disables speculation. NOT fixed by b9381 (DeltaNet-specific; the MoE 35B cliff WAS fixed by b9381). See docs/BENCHMARKS.md '27B cliff localization'."
       },
       "default": false
+    },
+    {
+      "id": "Qwen3.5-9B-MTP-Q8_0",
+      "filename": "Qwen3.5-9B-MTP-Q8_0.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF/resolve/main/Qwen3.5-9B-Q8_0.gguf",
+      "min_size_bytes": 9500000000,
+      "context_window": 81920,
+      "min_healthy_vram_mb": 14000,
+      "extra_flags": "--parallel 1 --jinja -ngl 99 -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --presence-penalty 1.5 --reasoning-budget 8192 -b 4096 -ub 2048 --threads 6 --spec-type draft-mtp --spec-draft-n-max 2 --chat-template-kwargs '{\"preserve_thinking\": true}'",
+      "benchmark": {
+        "tg_ts": 58.8,
+        "tg_ts_real": 47.1,
+        "pp_ts": 1199,
+        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan + RADV_PERFTEST=rm_kq=1, llama.cpp b9381, MTP n_max=2, q8_0 KV, -ub 2048, ctx 81920, whisper on CPU",
+        "notes": "Small/fast option: Qwen3.5-9B (NOT Qwen3.6 — no 9B exists in that generation). Hybrid arch like the 27B: 24 linear-attention + 8 full-attention layers, so the KV cache is tiny and -ngl 99 is MANDATORY (partial offload breaks the fused linear-attention kernel). No MTP context cliff on this model (unlike the 27B): speculation works at 80K+ with q8 KV, greedy acceptance ~86%. Sustained 58.8 t/s greedy / ~47-51 t/s production samplers (2x the 35B default, ~1.55x the 35B MTP), PP ~1200. Eviction-proof: 61K-token deep-prompt stress with VRAM flat at 14551/16304 MiB (headroom ~1750). ub4096 and UD-Q8_K_XL both rejected (VRAM cost / -20% TG). Meets the >=80K OpenClaw harness requirement. See docs/BENCHMARKS.md (2026-07-15)."
+      },
+      "default": false
     }
   ],
   "llama_server": {

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -501,3 +501,80 @@ The server A/B above made b9672 *look* like a regression, but that conflated com
 - MoE coopmat tile-geometry tweak (#22598): experimental/unmerged, Strix-Halo-gated, not applicable.
 
 **Bottom line: no regression, no free lunch on either build for the offloaded regime.** The real throughput levers remain MTP (characterised above) and headroom discipline (whisper→CPU, ctx ≤ 80K).
+
+## 2026-07-15 — Qwen3.5-9B Q8 sweep (small/fast model) + b9990 evaluation
+
+Goal: a small, fast Q8-quantized model as an alternative to the 35B default, at the **≥80K context the OpenClaw harness requires**, with generous headroom (production KV growth has repeatedly caused headroom pressure). Also: re-probe upstream llama.cpp (**b9990**, latest release) against pinned b9381.
+
+**There is no Qwen3.6-9B** — the Qwen3.6 generation is 27B + 35B-A3B only. The 9B lives in the previous generation: **Qwen3.5-9B** (unsloth GGUFs, base + MTP repos; the MTP repo reuses the base filenames, staged locally with a `-MTP-` infix). Architecture is a **hybrid like the 27B**: 32 layers = 24 linear-attention (DeltaNet-style, fixed-size recurrent state) + 8 full-attention (GQA-4, head_dim 256) → KV cache is tiny (~17 KB/token at q8_0, ~4× smaller per token than the 35B), native 256K positions. Same operating constraint as the 27B: `-ngl 99` mandatory (partial offload breaks the fused linear-attention kernel). Q8 candidates: `Q8_0` (9.53 GB) and `UD-Q8_K_XL` (12.97 GB).
+
+Method as in prior sweeps: server cells with greedy 256-tok TG probe (×2), a "real-sampler" probe (temp 1.0, top-p 0.95, top-k 20, presence 1.5, code prompt) exposing MTP acceptance via `timings.draft_n`, ~6.8K-tok PP probe, idle/post VRAM from sysfs (total 16,304 MiB); whisper on CPU; RADV `rm_kq=1`, `-t 6`, `-b 4096`.
+
+### Phase A — b9381, quant × KV × ub × ctx (ctx 81920 unless noted)
+
+| quant | ctx | KV | ub | TG greedy | TG real | PP | idle VRAM | headroom |
+|---|---:|---|---:|---:|---:|---:|---:|---:|
+| Q8_0 | 80K | q8_0 | 2048 | 32.41 | 31.70 | 1281 | 12836 | 3468 |
+| Q8_0 | 80K | q8_0 | 4096 | 32.39 | 31.66 | 1168 | 15688 | 616 |
+| Q8_0 | 80K | q4_0 | 2048 | 32.41 | 31.70 | 1284 | 12196 | 4108 |
+| Q8_0 | 80K | f16 | 2048 | 32.75 | 31.99 | 1329 | 14036 | 2268 |
+| Q8_0 | 131K | q8_0 | 2048 | 32.40 | 31.68 | 1285 | 13996 | 2308 |
+| UD-Q8_K_XL | 80K | q8_0 | 2048 | 25.87 | 25.39 | 1232 | 15218 | 1086 |
+| UD-Q8_K_XL | 80K | q8_0 | 4096 | 25.80 | 25.34 | 1141 | 14192 | 2112 |
+
+- TG is weight-bandwidth-bound: KV type and ctx are ~free. **UD-Q8_K_XL is 20% slower** (36% more weight bytes) — eliminated.
+- `-ub 4096` costs up to ~2.8 GB VRAM for zero/negative PP gain (dense model; unlike the offloaded MoE) — **`-ub 2048` strictly better**.
+- f16 KV works on this hybrid (no 27B-style mandatory-quantized-KV issue on these builds) and is marginally fastest, but q8_0 buys 1–1.8 GB headroom for <1% TG.
+
+### Phase A, MTP cells (draft-mtp, Q8_0 weights)
+
+| ctx | KV | n_max | TG greedy (acc) | TG real (acc) | PP | idle VRAM | headroom |
+|---:|---|---:|---:|---:|---:|---:|---:|
+| 80K | q8_0 | 2 | **60.03 (86.6%)** | **47.09 (59.9%)** | 1199 | 14555 | 1749 |
+| 80K | q4_0 | 2 | 57.29 (80.1%) | 51.34 (70.3%) | 1112 | 15849¹ | 455¹ |
+| 80K | q8_0 | 3 | 60.23 (70.3%) | 49.05 (54.1%) | 1199 | 14600 | 1704 |
+| 80K | q8_0 | 2 +ub4096 | 59.61 (86.6%) | 46.95 (60.4%) | 995 | 16033 | 271 |
+| 131K | q8_0 | 2 | 59.99 (86.6%) | 50.02 (67.3%) | 1211 | 15493 | 811 |
+| 80K (UD-Q8_K_XL) | q8_0 | 2 | 46.13 (88.0%) | 34.12 (54.1%) | 1075 | 16153 | 151 |
+
+¹ anomalous first reading; settled to 15060 after probes.
+
+**Headline: no MTP context cliff on the 9B.** Unlike the 27B (speculation silently disables above ~35K ctx / with q8 KV, still true on b9381), the 9B accelerates at 80K *and* 131K with q8 KV: **+85% greedy (60 vs 32.4), +48–58% real-sampler (47–51 t/s; the spread is acceptance noise at temp 1.0)**. n=2 ≥ n=3 on real workloads (acceptance drops faster than payoff — same as the 35B). Real-sampler TG tracks acceptance (~60–75% → 47–55 t/s), consistent with the acceptance-not-VRAM mechanism established in May.
+
+### b9990 vs b9381 — compute flat, footprint dramatically lighter
+
+`llama-bench` gold standard (Q8_0, `-fa 1`, r=3): b9381 pp2048 **1703.6 ± 2.5** / tg128 **26.31 ± 0.01**; b9990 **1684.0 ± 1.3** / **26.54 ± 0.01** → compute is a wash (−1% PP, +1% TG), same conclusion as the b9672 probe.
+
+But the **server VRAM footprint at identical configs is 2.6–3.2 GB lighter on b9990** — and it is real allocation reduction, not deferred/lazy KV growth (VRAM stays byte-flat through a 107K-token prompt, see stress below):
+
+| config | b9381 idle / hr | b9990 idle / hr | Δ |
+|---|---:|---:|---:|
+| 9B base Q8_0 @80K q8 KV | 12836 / 3468 | **10224 / 6080** | −2612 |
+| 9B MTP @80K q8 KV n2 | 14555 / 1749 | **11369 / 4935** | −3186 |
+| 9B MTP @131K q8 KV n2 | 15493 / 811 | **12761 / 3543** | −2732 |
+
+b9990 TG/PP on the 9B matches or slightly beats b9381 (MTP greedy 61.4–61.5 vs 60.0–60.2).
+
+### Deep-prompt eviction stress (protocol: fresh shallow TG → deep prompt fills KV → re-measure ×2)
+
+| config | deep fill | fresh → sustained TG | VRAM through stress | verdict |
+|---|---|---:|---:|---|
+| b9990 MTP @131K q8 n2 | **107,301 tok** @ 579 t/s | 61.32 → **60.97** (−0.6%) | **12763 flat** (hr 3541) | ✅ PASS |
+| b9990 MTP @80K q8 n2 | 60,901 tok @ 771 t/s | 61.42 → **60.92** (−0.8%) | 11371 flat (hr 4933) | ✅ PASS |
+| b9381 MTP @80K q8 n2 | 60,901 tok @ 763 t/s | 60.08 → **58.75** (−2.2%) | 14551 flat (hr 1752) | ✅ PASS |
+
+### Phase D — the b9990 upgrade question, answered by the production 35B configs
+
+| config on b9990 | fresh TG | deep 61K-tok PP | sustained TG | VRAM | verdict |
+|---|---:|---:|---:|---|---|
+| 35B **base** Q5_K_XL @80K q8 ot20 **ub4096** (the shipped default) | 29.94 | **367** (vs ~700 on b9381) | **22.65 (−24%)** | 15957 → **14948 during fill** | ❌ **EVICTS** |
+| 35B **MTP** Q5_K_XL @80K q4 ot18 ub2048 n2 | 40.71 | 488 | **42.11 (+3.4%)** | 14760–14768 flat (hr 1536) | ✅ PASS (+10% vs 38.3 on b9381) |
+
+The base-default config shows the textbook eviction signature on b9990 (VRAM *drops* ~1 GB during the deep fill as the compute buffer moves to GTT). b9990's allocation rewrite is a big win for the dense-hybrid 9B (−3 GB) and even for 35B-MTP/ub2048 (+10%, stable), but it **regresses the shipped 35B base default** — so **the pin stays at b9381**. (Future lever: a b9990 bump paired with re-tuning the 35B default away from ub4096 — e.g. MTP-as-default at 42 t/s — but that is a separate, deliberate migration, not a free bump.)
+
+### Conclusion & shipped config
+
+- **Shipped (PR): `Qwen3.5-9B-MTP-Q8_0` added to `platform_models.json`** (non-default; switch via `/api/ai/model/switch`): Q8_0 weights, **ctx 81920**, q8_0 KV, `-ub 2048`, draft-mtp n=2, `-ngl 99` — on the pinned b9381: **~59–60 t/s sustained greedy / 47–51 t/s real-sampler / PP ~1200 (deep-fill 763)**, idle 14555 MiB (headroom ~1750), deep-prompt stress PASS. That is **2× the 35B default's 29.1 t/s** and ~1.55× the 35B-MTP option's 38.3, at Q8 numerics with best-precision (q8) KV.
+- **UD-Q8_K_XL rejected** (−20% TG, headroom as low as 151 MiB); **ub4096 rejected** (VRAM cost, no dense-model PP gain); **n=3 rejected** (acceptance).
+- 131072 ctx is stress-clean on b9990 (hr 3541) but only headroom-marginal on b9381 (hr 811, unstressed) — revisit if/when the build moves.
+- **Upstream (b9990) verdict: compute flat, allocator very different** — lighter for dense/ub2048 regimes, evicting for the offloaded ub4096 default. No blind bumps; any move must re-stress every shipped config.

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -429,7 +429,7 @@ install_deps_enable_docker() {
     # --- 0. Install Dependencies ---
     log_info "Installing dependencies"
     wait_for_apt_lock
-    local common_pkgs="ca-certificates gnupg lsb-release cron gpg rsync python3-flask python3-dotenv python3-requests python3-pip python3-venv jq moreutils pwgen git parted argon2"
+    local common_pkgs="ca-certificates gnupg lsb-release cron gpg rsync python3-flask python3-dotenv python3-requests python3-pip python3-venv jq moreutils pwgen git parted argon2 smartmontools"
     apt-get install -y -qq $common_pkgs
 
     # Install Google Chrome for OpenClaw browser tool (x86 only, non-fatal)

--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""HomeBrain health checker + notifier.
+
+Runs as root from homebrain-health.timer (every 30 min). Evaluates a small,
+fixed set of trust-critical checks — backups, disks, SMART, services,
+containers, updates — writes a machine-readable summary for the dashboard
+banner, and pushes plain-language alerts to the owner through the OpenClaw
+messenger channel (WhatsApp/Telegram) when something *changes*.
+
+Design constraints:
+  - stdlib only; no venv, no pip deps (runs via /usr/bin/python3).
+  - Deterministic delivery: `openclaw message send` goes straight through the
+    gateway to the channel — no LLM in the loop, so alerts still arrive when
+    llama-server is down.
+  - Notify on level transitions, not on every run. Steady-state reminders:
+    critical every 24 h, warnings every 7 days. State in
+    /var/lib/homebrain/health_state.json.
+  - Every check degrades gracefully: a missing tool (smartctl, docker,
+    openclaw) skips its check instead of erroring the whole run. The
+    dashboard banner (/api/health reading health.json) is the universal
+    fallback when no messenger channel is linked.
+"""
+
+import glob
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+
+INSTALL_DIR = "/opt/homebrain"
+ENV_FILE = f"{INSTALL_DIR}/.env"
+VERSION_FILE = f"{INSTALL_DIR}/version.json"
+STATE_DIR = "/var/lib/homebrain"
+HEALTH_FILE = f"{STATE_DIR}/health.json"
+STATE_FILE = f"{STATE_DIR}/health_state.json"
+BACKUP_DIR = "/mnt/backup"
+BACKUP_LOG = "/var/log/homebrain/backup.log"
+BACKUP_CRON_FILE = "/etc/cron.d/homebrain-backup"
+HOMEBRAIN_HOME = "/home/homebrain"
+OPENCLAW_DIR = f"{HOMEBRAIN_HOME}/.openclaw"
+OPENCLAW_PORT = 18789
+REPO_API_URL = "https://api.github.com/repos/oalterg/HomeBrain"
+
+DAY = 86400
+REMIND_SECS = {"crit": 1 * DAY, "warn": 7 * DAY, "info": 7 * DAY}
+UPDATE_CHECK_SECS = 1 * DAY
+
+LEVEL_RANK = {"ok": 0, "info": 1, "warn": 2, "crit": 3}
+
+
+def log(msg):
+    print(msg, flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested in scripts/tests/test_healthcheck.py)
+# ---------------------------------------------------------------------------
+
+def parse_env(text):
+    """Parse .env KEY=VALUE lines, stripping single/double quotes."""
+    env = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        value = value.split(" #")[0].strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
+            value = value[1:-1]
+        env[key.strip()] = value
+    return env
+
+
+def expected_backup_interval(env):
+    """Seconds between scheduled backups, derived from the cron fields the
+    dashboard writes to .env. Daily unless a day-of-week or day-of-month
+    restriction makes it weekly/monthly."""
+    if env.get("BACKUP_DAY_MONTH", "*") != "*":
+        return 31 * DAY
+    if env.get("BACKUP_DAY_WEEK", "*") != "*":
+        return 7 * DAY
+    return 1 * DAY
+
+
+def backup_log_outcome(tail):
+    """Classify the last backup run from the log tail: 'complete' if the
+    newest run finished, 'started' if a run began without finishing (failed
+    or still running — caller disambiguates via log mtime), 'none' if no
+    run markers found."""
+    last_start = tail.rfind("=== Starting Backup")
+    last_done = tail.rfind("=== Backup Complete")
+    if last_start == -1 and last_done == -1:
+        return "none"
+    if last_done > last_start:
+        return "complete"
+    return "started"
+
+
+def disk_level(percent):
+    if percent >= 95:
+        return "crit"
+    if percent >= 85:
+        return "warn"
+    return "ok"
+
+
+def decide_notification(prev, level, now):
+    """Decide whether a check's current level warrants a push.
+
+    prev: {'level': str, 'last_notified': epoch} or None (first sighting).
+    Returns 'alert' (escalation, or steady-state reminder past its window),
+    'recovery' (crit went back to ok), or None.
+    """
+    prev_level = prev.get("level", "ok") if prev else "ok"
+    prev_rank, rank = LEVEL_RANK.get(prev_level, 0), LEVEL_RANK.get(level, 0)
+    if rank > prev_rank:
+        return "alert"
+    if rank == 0:
+        return "recovery" if prev_level == "crit" else None
+    last = prev.get("last_notified", 0) if prev else 0
+    if now - last >= REMIND_SECS[level]:
+        return "alert"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Checks — each returns {"id", "level", "summary"} (or None to skip)
+# ---------------------------------------------------------------------------
+
+def check_disk(path, label, check_id):
+    try:
+        total, used, _ = shutil.disk_usage(path)
+    except OSError:
+        return None
+    percent = round(used / total * 100)
+    return {"id": check_id, "level": disk_level(percent),
+            "summary": f"{label} is {percent}% full"}
+
+
+def check_backup(env, now):
+    scheduled = os.path.exists(BACKUP_CRON_FILE)
+    if not scheduled:
+        return {"id": "backup", "level": "warn",
+                "summary": "Automatic backups are not set up"}
+    if not os.path.ismount(BACKUP_DIR):
+        return {"id": "backup", "level": "crit",
+                "summary": "Backup drive is not connected"}
+
+    archives = glob.glob(f"{BACKUP_DIR}/homebrain_backup*.tar.gz*") + \
+        glob.glob(f"{BACKUP_DIR}/nextcloud_backup*.tar.gz*")
+    newest = max((os.path.getmtime(a) for a in archives), default=0)
+
+    # A run that started after the last success and isn't recent is a failure.
+    try:
+        with open(BACKUP_LOG, "rb") as f:
+            f.seek(max(0, os.path.getsize(BACKUP_LOG) - 65536))
+            tail = f.read().decode(errors="replace")
+        outcome = backup_log_outcome(tail)
+        log_age = now - os.path.getmtime(BACKUP_LOG)
+        if outcome == "started" and log_age > 6 * 3600:
+            return {"id": "backup", "level": "crit",
+                    "summary": "The last backup failed — check the backup log"}
+    except OSError:
+        pass
+
+    if not newest:
+        return {"id": "backup", "level": "warn",
+                "summary": "No backup has been made yet"}
+    age = now - newest
+    interval = expected_backup_interval(env)
+    days = int(age // DAY)
+    if age > 3 * interval:
+        return {"id": "backup", "level": "crit",
+                "summary": f"No backup for {days} days — backups appear to have stopped"}
+    if age > interval + 12 * 3600:
+        return {"id": "backup", "level": "warn",
+                "summary": f"Last backup is {days} days old (schedule looks overdue)"}
+    return {"id": "backup", "level": "ok", "summary": "Backups are up to date"}
+
+
+def check_smart():
+    """SMART health of physical disks. Skips silently when smartmontools is
+    missing or a device doesn't speak SMART (USB bridges commonly don't)."""
+    if not shutil.which("smartctl"):
+        return None
+    failed = []
+    for dev in sorted(glob.glob("/sys/block/sd*") + glob.glob("/sys/block/nvme*n*")):
+        name = os.path.basename(dev)
+        if re.match(r"nvme\d+n\d+p", name):
+            continue
+        try:
+            out = subprocess.run(
+                ["smartctl", "-H", "-j", f"/dev/{name}"],
+                capture_output=True, text=True, timeout=30)
+            data = json.loads(out.stdout or "{}")
+            status = data.get("smart_status")
+            if status is not None and status.get("passed") is False:
+                failed.append(name)
+        except Exception:
+            continue
+    if failed:
+        return {"id": "smart", "level": "crit",
+                "summary": f"Drive {', '.join(failed)} is reporting SMART failure — replace it and check your backups"}
+    return {"id": "smart", "level": "ok", "summary": "Drives report healthy"}
+
+
+def _unit_exists_and_enabled(unit):
+    try:
+        out = subprocess.run(["systemctl", "is-enabled", unit],
+                             capture_output=True, text=True, timeout=10)
+    except Exception:
+        return False
+    return out.returncode == 0 and out.stdout.strip() not in ("masked", "disabled")
+
+
+def check_services(has_gpu):
+    units = ["docker", "homebrain-manager"]
+    if has_gpu:
+        units += ["llama-server", "whisper-server"]
+    down = []
+    for unit in units:
+        if not _unit_exists_and_enabled(unit):
+            continue
+        try:
+            active = subprocess.run(["systemctl", "is-active", "--quiet", unit],
+                                    timeout=10).returncode == 0
+        except Exception:
+            continue
+        if not active:
+            down.append(unit)
+    if down:
+        return {"id": "services", "level": "crit",
+                "summary": f"Service not running: {', '.join(down)}"}
+    return {"id": "services", "level": "ok", "summary": "System services running"}
+
+
+def check_openclaw_gateway(has_gpu):
+    if not (has_gpu and shutil.which("openclaw")):
+        return None
+    try:
+        with socket.create_connection(("127.0.0.1", OPENCLAW_PORT), timeout=3):
+            pass
+        return {"id": "openclaw", "level": "ok", "summary": "AI assistant reachable"}
+    except OSError:
+        return {"id": "openclaw", "level": "warn",
+                "summary": "AI assistant gateway is not responding"}
+
+
+def check_containers():
+    if not shutil.which("docker"):
+        return None
+    try:
+        out = subprocess.run(
+            ["docker", "ps", "-a", "--format", "{{.Names}}|{{.State}}|{{.Status}}"],
+            capture_output=True, text=True, timeout=20)
+        if out.returncode != 0:
+            return None
+    except Exception:
+        return None
+    restarting, unhealthy = [], []
+    for line in out.stdout.splitlines():
+        parts = line.split("|")
+        if len(parts) != 3 or not parts[0].startswith("homebrain"):
+            continue
+        name = parts[0].split("-")[1] if "-" in parts[0] else parts[0]
+        if parts[1] == "restarting":
+            restarting.append(name)
+        elif "(unhealthy)" in parts[2]:
+            unhealthy.append(name)
+    if restarting:
+        return {"id": "containers", "level": "crit",
+                "summary": f"Service crash-looping: {', '.join(restarting)}"}
+    if unhealthy:
+        return {"id": "containers", "level": "warn",
+                "summary": f"Service unhealthy: {', '.join(unhealthy)}"}
+    return {"id": "containers", "level": "ok", "summary": "Containers healthy"}
+
+
+def check_update(state, now):
+    """Once a day, on the stable channel only: is a newer release out?
+    info-level — surfaces in the banner and one push per new version."""
+    try:
+        with open(VERSION_FILE) as f:
+            version = json.load(f)
+    except Exception:
+        return None
+    if version.get("channel") != "stable":
+        return None
+    upd = state.setdefault("update", {})
+    if now - upd.get("ts", 0) < UPDATE_CHECK_SECS and upd.get("latest"):
+        latest = upd["latest"]
+    else:
+        try:
+            req = urllib.request.Request(f"{REPO_API_URL}/releases/latest",
+                                         headers={"User-Agent": "homebrain-health"})
+            with urllib.request.urlopen(req, timeout=6) as resp:
+                latest = json.load(resp).get("tag_name", "")
+            upd["ts"], upd["latest"] = now, latest
+        except Exception:
+            return None
+    if latest and latest != version.get("ref"):
+        return {"id": "update", "level": "info",
+                "summary": f"Update {latest} is available — install it from the dashboard"}
+    return {"id": "update", "level": "ok", "summary": "HomeBrain is up to date"}
+
+
+# ---------------------------------------------------------------------------
+# Push delivery via OpenClaw
+# ---------------------------------------------------------------------------
+
+def resolve_push_target():
+    """(channel, target) for the owner, from the channel allowlists OpenClaw
+    already maintains: whatsapp owners live in openclaw.json allowFrom,
+    telegram pairing lands in credentials/telegram-default-allowFrom.json."""
+    try:
+        with open(f"{OPENCLAW_DIR}/openclaw.json") as f:
+            channels = json.load(f).get("channels", {})
+    except Exception:
+        return None
+    wa = channels.get("whatsapp", {})
+    if wa.get("enabled") and wa.get("allowFrom"):
+        return ("whatsapp", str(wa["allowFrom"][0]))
+    tg = channels.get("telegram", {})
+    if tg.get("enabled"):
+        for source in (f"{OPENCLAW_DIR}/credentials/telegram-default-allowFrom.json",):
+            try:
+                with open(source) as f:
+                    allow = json.load(f).get("allowFrom", [])
+                if allow:
+                    return ("telegram", str(allow[0]))
+            except Exception:
+                pass
+        if tg.get("allowFrom"):
+            return ("telegram", str(tg["allowFrom"][0]))
+    return None
+
+
+def send_push(channel, target, text):
+    """Deterministic send through the gateway (no agent turn involved)."""
+    cmd = ["sudo", "-H", "-u", "homebrain", "timeout", "45",
+           "openclaw", "message", "send", "--channel", channel,
+           "--target", target, "-m", text, "--json"]
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+    except Exception as e:
+        log(f"[WARN] push failed to spawn: {e}")
+        return False
+    if out.returncode == 0 and '"messageId"' in out.stdout:
+        return True
+    log(f"[WARN] push failed (rc={out.returncode}): {out.stdout[-300:]} {out.stderr[-300:]}")
+    return False
+
+
+def compose_message(alerts, recoveries):
+    lines = []
+    if alerts:
+        levels = {a["level"] for a in alerts}
+        serious = levels & {"warn", "crit"}
+        icon = "🚨" if "crit" in levels else ("⚠️" if "warn" in levels else "ℹ️")
+        lines.append(f"{icon} HomeBrain needs attention:" if serious
+                     else f"{icon} HomeBrain:")
+        lines += [f"• {a['summary']}" for a in alerts]
+        if serious:
+            lines.append("Open your dashboard for details.")
+    if recoveries:
+        if lines:
+            lines.append("")
+        lines.append("✅ Resolved: " + "; ".join(r["summary"] for r in recoveries))
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def atomic_write_json(path, data, mode=0o644):
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path))
+    with os.fdopen(fd, "w") as f:
+        json.dump(data, f, indent=1)
+    os.chmod(tmp, mode)
+    os.replace(tmp, path)
+
+
+def has_gpu(env):
+    if env.get("HAS_GPU", "").lower() == "true":
+        return True
+    return bool(glob.glob("/dev/dri/renderD*"))
+
+
+def main():
+    now = time.time()
+    os.makedirs(STATE_DIR, exist_ok=True)
+    try:
+        with open(ENV_FILE) as f:
+            env = parse_env(f.read())
+    except OSError:
+        env = {}
+    try:
+        with open(STATE_FILE) as f:
+            state = json.load(f)
+    except Exception:
+        state = {}
+    state.setdefault("checks", {})
+
+    gpu = has_gpu(env)
+    checks = [c for c in [
+        check_backup(env, now),
+        check_disk("/", "System disk", "disk_root"),
+        check_disk(BACKUP_DIR, "Backup drive", "disk_backup") if os.path.ismount(BACKUP_DIR) else None,
+        check_smart(),
+        check_services(gpu),
+        check_containers(),
+        check_openclaw_gateway(gpu),
+        check_update(state, now),
+    ] if c]
+
+    overall = "ok"
+    for c in checks:
+        if LEVEL_RANK.get(c["level"], 0) > LEVEL_RANK.get(overall, 0):
+            overall = c["level"]
+
+    # Decide pushes per check, then batch into one message.
+    alerts, recoveries = [], []
+    for c in checks:
+        prev = state["checks"].get(c["id"])
+        action = decide_notification(prev, c["level"], now)
+        entry = {"level": c["level"],
+                 "last_notified": prev.get("last_notified", 0) if prev else 0}
+        if action == "alert":
+            alerts.append(c)
+            entry["last_notified"] = now
+        elif action == "recovery":
+            recoveries.append(c)
+        state["checks"][c["id"]] = entry
+
+    push = resolve_push_target()
+    pushed = False
+    push_enabled = env.get("NOTIFY_PUSH", "true").lower() != "false"
+    if (alerts or recoveries) and push and push_enabled:
+        text = compose_message(alerts, recoveries)
+        pushed = send_push(push[0], push[1], text)
+        log(f"[INFO] push via {push[0]}: {'sent' if pushed else 'FAILED'} — {len(alerts)} alert(s), {len(recoveries)} recovery(ies)")
+    elif alerts or recoveries:
+        log(f"[INFO] {len(alerts)} alert(s) — no push channel linked or push disabled; dashboard banner only")
+
+    atomic_write_json(HEALTH_FILE, {
+        "ts": int(now),
+        "overall": overall,
+        "checks": [{"id": c["id"], "level": c["level"], "summary": c["summary"]}
+                   for c in checks],
+        "push_channel": push[0] if push and push_enabled else None,
+    })
+    atomic_write_json(STATE_FILE, state, mode=0o600)
+    log(f"[INFO] health: {overall} — " +
+        "; ".join(f"{c['id']}={c['level']}" for c in checks))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -280,6 +280,14 @@ systemctl enable --now inhibit-sleep.service 2>/dev/null \
     && log_info "Sleep inhibitor service enabled." \
     || log_warn "Failed to enable sleep inhibitor service."
 
+# Deploy and enable the health check timer (proactive owner notifications)
+cp "${SCRIPT_DIR}/../config/homebrain-health.service" /etc/systemd/system/
+cp "${SCRIPT_DIR}/../config/homebrain-health.timer" /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable --now homebrain-health.timer 2>/dev/null \
+    && log_info "Health check timer enabled." \
+    || log_warn "Failed to enable health check timer."
+
 # --- 6. OpenClaw integration scaffold ---
 # Make sure /home/homebrain/.openclaw/ exists with the right ownership before
 # the dashboard starts wiring MCP servers into it. Idempotent.

--- a/scripts/tests/test_healthcheck.py
+++ b/scripts/tests/test_healthcheck.py
@@ -1,0 +1,118 @@
+"""Unit tests for the pure logic in scripts/healthcheck.py.
+
+Run:  python3 -m pytest scripts/tests/test_healthcheck.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from healthcheck import (  # noqa: E402
+    DAY,
+    backup_log_outcome,
+    compose_message,
+    decide_notification,
+    disk_level,
+    expected_backup_interval,
+    parse_env,
+)
+
+NOW = 1_800_000_000
+
+
+def test_parse_env_strips_quotes_and_comments():
+    env = parse_env(
+        "# comment\n"
+        "MASTER_PASSWORD='p4ss'\n"
+        'BACKUP_HOUR="3"\n'
+        "BACKUP_RETENTION=8\n"
+        "EMPTY=\n"
+    )
+    assert env["MASTER_PASSWORD"] == "p4ss"
+    assert env["BACKUP_HOUR"] == "3"
+    assert env["BACKUP_RETENTION"] == "8"
+    assert env["EMPTY"] == ""
+
+
+def test_expected_backup_interval():
+    assert expected_backup_interval({}) == DAY
+    assert expected_backup_interval({"BACKUP_DAY_WEEK": "*"}) == DAY
+    assert expected_backup_interval({"BACKUP_DAY_WEEK": "0"}) == 7 * DAY
+    assert expected_backup_interval({"BACKUP_DAY_MONTH": "1"}) == 31 * DAY
+    # day-of-month wins over day-of-week (matches cron semantics closely enough)
+    assert expected_backup_interval(
+        {"BACKUP_DAY_MONTH": "1", "BACKUP_DAY_WEEK": "0"}) == 31 * DAY
+
+
+def test_backup_log_outcome():
+    assert backup_log_outcome("") == "none"
+    assert backup_log_outcome("junk\n") == "none"
+    ok = "=== Starting Backup [x]: date ===\nstuff\n=== Backup Complete: /mnt/backup/a.tar.gz ===\n"
+    assert backup_log_outcome(ok) == "complete"
+    failed = ok + "=== Starting Backup [x]: date ===\n[ERROR] died\n"
+    assert backup_log_outcome(failed) == "started"
+
+
+def test_disk_level_thresholds():
+    assert disk_level(0) == "ok"
+    assert disk_level(84) == "ok"
+    assert disk_level(85) == "warn"
+    assert disk_level(94) == "warn"
+    assert disk_level(95) == "crit"
+    assert disk_level(100) == "crit"
+
+
+def test_notify_on_escalation_only():
+    # First sighting of ok: silence.
+    assert decide_notification(None, "ok", NOW) is None
+    # First sighting of a problem: alert.
+    assert decide_notification(None, "warn", NOW) == "alert"
+    assert decide_notification(None, "crit", NOW) == "alert"
+    # Same level again, recently notified: silence.
+    prev = {"level": "warn", "last_notified": NOW - 3600}
+    assert decide_notification(prev, "warn", NOW) is None
+    # Escalation warn -> crit: alert even if recently notified.
+    assert decide_notification(prev, "crit", NOW) == "alert"
+    # De-escalation crit -> warn: no new alert.
+    prev = {"level": "crit", "last_notified": NOW - 3600}
+    assert decide_notification(prev, "warn", NOW) is None
+
+
+def test_notify_recovery_only_from_crit():
+    assert decide_notification({"level": "crit", "last_notified": NOW}, "ok", NOW) == "recovery"
+    assert decide_notification({"level": "warn", "last_notified": NOW}, "ok", NOW) is None
+
+
+def test_steady_state_reminders():
+    # crit re-notifies after 24h
+    prev = {"level": "crit", "last_notified": NOW - DAY - 1}
+    assert decide_notification(prev, "crit", NOW) == "alert"
+    prev = {"level": "crit", "last_notified": NOW - DAY + 3600}
+    assert decide_notification(prev, "crit", NOW) is None
+    # warn re-notifies after 7d
+    prev = {"level": "warn", "last_notified": NOW - 7 * DAY - 1}
+    assert decide_notification(prev, "warn", NOW) == "alert"
+    prev = {"level": "warn", "last_notified": NOW - 6 * DAY}
+    assert decide_notification(prev, "warn", NOW) is None
+
+
+def test_info_level_alerts_once_then_weekly():
+    # ok -> info (e.g. "update available") pushes once...
+    prev = {"level": "ok", "last_notified": 0}
+    assert decide_notification(prev, "info", NOW) == "alert"
+    # ...then stays quiet inside the 7-day reminder window...
+    prev = {"level": "info", "last_notified": NOW - DAY}
+    assert decide_notification(prev, "info", NOW) is None
+    # ...and info -> ok produces no recovery noise.
+    assert decide_notification({"level": "info", "last_notified": NOW}, "ok", NOW) is None
+
+
+def test_compose_message():
+    alerts = [{"level": "crit", "summary": "Backup drive is not connected"},
+              {"level": "warn", "summary": "System disk is 91% full"}]
+    msg = compose_message(alerts, [])
+    assert msg.startswith("🚨 HomeBrain needs attention:")
+    assert "• Backup drive is not connected" in msg
+    assert "dashboard" in msg
+    rec = compose_message([], [{"level": "ok", "summary": "Backups are up to date"}])
+    assert rec.startswith("✅ Resolved: Backups are up to date")

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -227,26 +227,37 @@ install_python_venv_deps
 
 # 6a. Service Synchronization (Golden Master)
 # This generalized block handles ALL service file updates (Gunicorn, Venv, or future changes).
-# It ensures the active systemd service matches the repository version exactly.
-INSTALLED_SVC="/etc/systemd/system/homebrain-manager.service"
-REPO_SVC="$INSTALL_DIR/config/homebrain-manager.service"
+# It ensures the active systemd units match the repository versions exactly.
+UNITS_CHANGED=false
+for UNIT in homebrain-manager.service homebrain-health.service homebrain-health.timer; do
+    INSTALLED_SVC="/etc/systemd/system/$UNIT"
+    REPO_SVC="$INSTALL_DIR/config/$UNIT"
 
-if [ -f "$REPO_SVC" ]; then
-    # silent compare: returns 1 if different
-    if ! cmp -s "$REPO_SVC" "$INSTALLED_SVC"; then
-        log_info "Service definition drift detected. Synchronizing with repository version..."
-        
-        # Backup and atomic replace
-        [ -f "$INSTALLED_SVC" ] && cp "$INSTALLED_SVC" "${INSTALLED_SVC}.bak_$(date +%s)"
-        cp "$REPO_SVC" "$INSTALLED_SVC"
-        chmod 644 "$INSTALLED_SVC"
-        
-        systemctl daemon-reload
-        log_info "Service file synchronized."
+    if [ -f "$REPO_SVC" ]; then
+        # silent compare: returns 1 if different
+        if ! cmp -s "$REPO_SVC" "$INSTALLED_SVC"; then
+            log_info "$UNIT drift detected. Synchronizing with repository version..."
+
+            # Backup and atomic replace
+            [ -f "$INSTALLED_SVC" ] && cp "$INSTALLED_SVC" "${INSTALLED_SVC}.bak_$(date +%s)"
+            cp "$REPO_SVC" "$INSTALLED_SVC"
+            chmod 644 "$INSTALLED_SVC"
+            UNITS_CHANGED=true
+        fi
+    else
+        log_warn "Repository service file missing ($REPO_SVC). Skipping synchronization."
     fi
-else
-    log_warn "Repository service file missing ($REPO_SVC). Skipping synchronization."
+done
+if [ "$UNITS_CHANGED" = true ]; then
+    systemctl daemon-reload
+    log_info "Service files synchronized."
 fi
+# The health timer ships disabled on boxes provisioned before it existed —
+# enable it (idempotent). smartmontools is a provision-time dep; install it
+# here once so pre-existing boxes get SMART monitoring too (best-effort).
+systemctl enable --now homebrain-health.timer 2>/dev/null || true
+command -v smartctl >/dev/null 2>&1 || apt-get install -y -qq smartmontools 2>/dev/null \
+    || log_warn "smartmontools install failed — SMART monitoring disabled until next update."
 
 
 # 6b. Layout Migration (idempotent — _detect_migration_work probes first;

--- a/src/app.py
+++ b/src/app.py
@@ -1007,6 +1007,24 @@ def deployment_mode_api():
     return jsonify({"mode": "local" if local else "remote", "tunnelDomain": tunnel_domain})
 
 
+HEALTH_FILE = "/var/lib/homebrain/health.json"
+
+@app.route("/api/health")
+def health_status():
+    """Latest health-check report, written by scripts/healthcheck.py from the
+    homebrain-health.timer. Drives the dashboard banner; the push channel
+    (WhatsApp/Telegram) is handled by the checker itself."""
+    try:
+        with open(HEALTH_FILE) as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return jsonify({"overall": "unknown", "checks": []})
+    # A stale report (timer dead > 2h) is itself a signal — surface it.
+    if time.time() - data.get("ts", 0) > 2 * 3600:
+        data["overall"] = "unknown"
+    return jsonify(data)
+
+
 # --- Routes: API Status ---
 @app.route("/api/status")
 def system_status():

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -466,6 +466,10 @@
         <button class="tab-btn" onclick="openTab('logs')">Logs</button>
     </div>
 
+    <!-- Health banner — fed by /api/health (homebrain-health.timer). Visible on
+         every tab so problems surface no matter where the user lands. -->
+    <div id="health-banner" class="notice" style="display:none; margin-bottom:22px;"></div>
+
     <div id="status" class="tab-content active">
         <div id="recovery-prompt" class="notice notice-warning" style="display:none; margin-bottom:22px;">
             <strong>⚠ Set up your recovery phrase</strong>
@@ -1358,6 +1362,8 @@
             }
 
             // Start Intervals
+            fetchHealth();
+            setInterval(fetchHealth, 300000); // health.json refreshes every 30 min
             setInterval(fetchStatus, 5000);
             setInterval(loadSystemConfig, 10000); // AI state doesn't churn — 10s is enough
             setInterval(pollTask, 2000);
@@ -1406,6 +1412,30 @@
                 connRefresh();
                 vaultMcpRefresh();
             }
+        }
+
+        async function fetchHealth() {
+            try {
+                const res = await fetch('/api/health', { credentials: 'include' });
+                if (!res.ok) return;
+                const h = await res.json();
+                const el = document.getElementById('health-banner');
+                if (!el) return;
+                const issues = (h.checks || []).filter(c => c.level !== 'ok');
+                if (!issues.length || h.overall === 'ok' || h.overall === 'unknown') {
+                    el.style.display = 'none';
+                    return;
+                }
+                el.classList.remove('notice-warning', 'notice-danger');
+                if (h.overall === 'crit') el.classList.add('notice-danger');
+                else if (h.overall === 'warn') el.classList.add('notice-warning');
+                const heading = h.overall === 'info' ? 'ℹ️ Good to know' : '⚠ Needs attention';
+                el.innerHTML = `<strong>${heading}</strong>` +
+                    '<ul style="margin:6px 0 0 18px; padding:0;">' +
+                    issues.map(c => `<li>${escapeHtml(c.summary)}</li>`).join('') +
+                    '</ul>';
+                el.style.display = 'block';
+            } catch (e) { /* non-fatal — banner just stays hidden */ }
         }
 
         async function fetchStatus() {


### PR DESCRIPTION
## What

A systemd timer (`homebrain-health.timer`, every 30 min) runs `scripts/healthcheck.py` (stdlib-only):

- **Backup**: age vs. schedule, failed-run detection from the log, drive present
- **Disks**: usage thresholds (85% warn / 95% crit) for root + backup drive
- **SMART**: drive health via smartmontools (graceful skip if absent)
- **Services**: systemd units (docker, manager, llama/whisper on GPU boxes), OpenClaw gateway TCP probe
- **Containers**: crash-looping / unhealthy
- **Updates**: new stable release available (info, checked daily)

Alerts push to the owner via `openclaw message send` on the linked channel — **deterministic, no LLM in the loop**, so alerts arrive even when llama-server is down. The owner target comes from the channel allowlists OpenClaw already maintains (whatsapp `allowFrom`, telegram pairing store). Notify on level transitions; steady-state reminders crit=24h, warn/info=7d; recovery notice when a crit clears. `NOTIFY_PUSH=false` opts out.

Dashboard: `/api/health` + a banner on every tab — the universal fallback when no messenger channel is linked (HomeCloud boxes).

`update.sh`: golden-master unit sync generalized to all three units, enables the timer + installs smartmontools once on existing boxes.

## E2E on .58 (x86/GPU, stock openclaw 2026.6.8)

- First live run **caught a real incident**: no backup for 38 days (box is off at the cron hour — fix lands in the encrypted-backups PR as a persistent systemd timer). 🚨 alert delivered to owner Telegram, `messageId` confirmed.
- Second run: no duplicate push (transition dedupe verified); smartmontools installed → `smart=ok` appeared.
- `/api/health` served after manager restart; banner div present in rendered dashboard.
- `scripts/tests/test_healthcheck.py`: 9 tests pass (pure logic: env parsing, cron→interval, log outcome, thresholds, notification policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)