### PR TITLE
feat(ai): add Qwen3.5-9B-MTP-Q8_0 — 2x default TG at >=80K ctx, eviction-proof

### DIFF
--- a/config/platform_models.json
+++ b/config/platform_models.json
@@ -119,6 +119,23 @@
         "notes": "Hybrid DeltaNet SSM+attn (16/64 standard attn layers, 48 DeltaNet). RS must stay GPU-local — nkvo breaks DeltaNet fused kernel (garbage output). ngl<99 drops to ~2 t/s; partial offload defeats DeltaNet GPU fusion. ctv/ctk with fa is mandatory on AMD Vulkan. MTP CLIFF: the draft-mtp speculative path accelerates ONLY at ctx <= ~34816 (cliff between 34816 and 36864); above it TG snaps back to the ~17.5 baseline. ctx was 49152 (over the cliff, MTP gave ~+2%); lowered to 32768 to capture the full MTP gain: ~17.1 -> ~30 t/s (+75%) with n_max=2, q4_0 KV. Crossing any of {ctx>~35K, n_max>=3, q8 KV} silently disables speculation. NOT fixed by b9381 (DeltaNet-specific; the MoE 35B cliff WAS fixed by b9381). See docs/BENCHMARKS.md '27B cliff localization'."
       },
       "default": false
+    },
+    {
+      "id": "Qwen3.5-9B-MTP-Q8_0",
+      "filename": "Qwen3.5-9B-MTP-Q8_0.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-9B-MTP-GGUF/resolve/main/Qwen3.5-9B-Q8_0.gguf",
+      "min_size_bytes": 9500000000,
+      "context_window": 81920,
+      "min_healthy_vram_mb": 14000,
+      "extra_flags": "--parallel 1 --jinja -ngl 99 -fa 1 --cache-type-k q8_0 --cache-type-v q8_0 --temp 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --presence-penalty 1.5 --reasoning-budget 8192 -b 4096 -ub 2048 --threads 6 --spec-type draft-mtp --spec-draft-n-max 2 --chat-template-kwargs '{\"preserve_thinking\": true}'",
+      "benchmark": {
+        "tg_ts": 58.8,
+        "tg_ts_real": 47.1,
+        "pp_ts": 1199,
+        "measured_on": "AMD RX 9060 XT, AMD Ryzen 5 5600 6-core, Vulkan + RADV_PERFTEST=rm_kq=1, llama.cpp b9381, MTP n_max=2, q8_0 KV, -ub 2048, ctx 81920, whisper on CPU",
+        "notes": "Small/fast option: Qwen3.5-9B (NOT Qwen3.6 — no 9B exists in that generation). Hybrid arch like the 27B: 24 linear-attention + 8 full-attention layers, so the KV cache is tiny and -ngl 99 is MANDATORY (partial offload breaks the fused linear-attention kernel). No MTP context cliff on this model (unlike the 27B): speculation works at 80K+ with q8 KV, greedy acceptance ~86%. Sustained 58.8 t/s greedy / ~47-51 t/s production samplers (2x the 35B default, ~1.55x the 35B MTP), PP ~1200. Eviction-proof: 61K-token deep-prompt stress with VRAM flat at 14551/16304 MiB (headroom ~1750). ub4096 and UD-Q8_K_XL both rejected (VRAM cost / -20% TG). Meets the >=80K OpenClaw harness requirement. See docs/BENCHMARKS.md (2026-07-15)."
+      },
+      "default": false
     }
   ],
   "llama_server": {

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -578,3 +578,20 @@ The base-default config shows the textbook eviction signature on b9990 (VRAM *dr
 - **UD-Q8_K_XL rejected** (−20% TG, headroom as low as 151 MiB); **ub4096 rejected** (VRAM cost, no dense-model PP gain); **n=3 rejected** (acceptance).
 - 131072 ctx is stress-clean on b9990 (hr 3541) but only headroom-marginal on b9381 (hr 811, unstressed) — revisit if/when the build moves.
 - **Upstream (b9990) verdict: compute flat, allocator very different** — lighter for dense/ub2048 regimes, evicting for the offloaded ub4096 default. No blind bumps; any move must re-stress every shipped config.
+
+## 2026-07-17 — 35B production configs: b9381 (pinned) vs current upstream b10032 (Phase E)
+
+Same-day A/B of both shipped 35B configs (exact production flags, ctx 81920) on the pinned b9381 and the current upstream release b10032, on .58 with all services held. Protocol as above: fresh shallow TG → 61K-token deep fill → sustained TG; PASS = sustained ≥90% of fresh.
+
+`llama-bench` compute A/B (Q5_K_XL, `-ncmoe 20 -fa 1 -ctk/-ctv q8_0 -b/-ub 4096`, r=3): b9381 pp2048 **661.9 ± 7.3** / tg128 **22.78 ± 0.01**; b10032 **666.1 ± 7.0** / **22.92 ± 0.08** → **compute flat (+0.6%)**, same as the b9672/b9990 probes.
+
+| cell | config | build | fresh TG | deep 61K-tok PP | sustained TG | VRAM through stress | verdict |
+|---|---|---|---:|---:|---:|---|---|
+| e1 | base Q5_K_XL @80K q8 ot20 ub4096 (default) | b9381 | 27.6 | 419.9 | **29.28 (+6.1%)** | 15402 → 16256 (hr 48) | ✅ PASS |
+| e2 | base (same flags) | b10032 | 29.84 | 367.8 | **22.65 (−24.1%)** | 15959 → **14949 during fill** | ❌ **EVICTS** |
+| e3 | MTP Q5_K_XL @80K q4 ot18 ub2048 n2 | b9381 | 36.5 | 473.3 | **36.67 (+0.5%)** | 15030 → 15035 flat (hr 1269) | ✅ PASS |
+| e4 | MTP (same flags) | b10032 | 36.45 | 483.9 | **36.30 (−0.4%)** | 14566 → 14567 flat (hr 1737) | ✅ PASS |
+
+- **b10032 reproduces b9990's regression exactly**: the shipped base default evicts its compute buffer under deep fill (paradoxical ~1 GB VRAM *drop*, sustained 22.65 ≈ b9990's 22.65). The post-b9381 allocator rewrite is confirmed hostile to the offloaded-MoE + ub4096 regime across two upstream releases — not a one-off.
+- **MTP on b10032 is stable but not faster** in the same-day A/B (36.30 vs 36.67; June's 38.3 and b9990's 42.1 for this config bracket the session-to-session variance — same-day pairs are the only fair read). It does idle **~470 MiB lighter** (hr 1737 vs 1269).
+- **Verdict: pin stays b9381.** Upstream compute is flat and the only shipped-config deltas are neutral-to-negative. Unchanged from the b9990 analysis: a future bump must be paired with re-tuning the 35B default away from ub4096 (or MTP-as-default) and a full re-stress.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -501,3 +501,80 @@ The server A/B above made b9672 *look* like a regression, but that conflated com
 - MoE coopmat tile-geometry tweak (#22598): experimental/unmerged, Strix-Halo-gated, not applicable.
 
 **Bottom line: no regression, no free lunch on either build for the offloaded regime.** The real throughput levers remain MTP (characterised above) and headroom discipline (whisper→CPU, ctx ≤ 80K).
+
+## 2026-07-15 — Qwen3.5-9B Q8 sweep (small/fast model) + b9990 evaluation
+
+Goal: a small, fast Q8-quantized model as an alternative to the 35B default, at the **≥80K context the OpenClaw harness requires**, with generous headroom (production KV growth has repeatedly caused headroom pressure). Also: re-probe upstream llama.cpp (**b9990**, latest release) against pinned b9381.
+
+**There is no Qwen3.6-9B** — the Qwen3.6 generation is 27B + 35B-A3B only. The 9B lives in the previous generation: **Qwen3.5-9B** (unsloth GGUFs, base + MTP repos; the MTP repo reuses the base filenames, staged locally with a `-MTP-` infix). Architecture is a **hybrid like the 27B**: 32 layers = 24 linear-attention (DeltaNet-style, fixed-size recurrent state) + 8 full-attention (GQA-4, head_dim 256) → KV cache is tiny (~17 KB/token at q8_0, ~4× smaller per token than the 35B), native 256K positions. Same operating constraint as the 27B: `-ngl 99` mandatory (partial offload breaks the fused linear-attention kernel). Q8 candidates: `Q8_0` (9.53 GB) and `UD-Q8_K_XL` (12.97 GB).
+
+Method as in prior sweeps: server cells with greedy 256-tok TG probe (×2), a "real-sampler" probe (temp 1.0, top-p 0.95, top-k 20, presence 1.5, code prompt) exposing MTP acceptance via `timings.draft_n`, ~6.8K-tok PP probe, idle/post VRAM from sysfs (total 16,304 MiB); whisper on CPU; RADV `rm_kq=1`, `-t 6`, `-b 4096`.
+
+### Phase A — b9381, quant × KV × ub × ctx (ctx 81920 unless noted)
+
+| quant | ctx | KV | ub | TG greedy | TG real | PP | idle VRAM | headroom |
+|---|---:|---|---:|---:|---:|---:|---:|---:|
+| Q8_0 | 80K | q8_0 | 2048 | 32.41 | 31.70 | 1281 | 12836 | 3468 |
+| Q8_0 | 80K | q8_0 | 4096 | 32.39 | 31.66 | 1168 | 15688 | 616 |
+| Q8_0 | 80K | q4_0 | 2048 | 32.41 | 31.70 | 1284 | 12196 | 4108 |
+| Q8_0 | 80K | f16 | 2048 | 32.75 | 31.99 | 1329 | 14036 | 2268 |
+| Q8_0 | 131K | q8_0 | 2048 | 32.40 | 31.68 | 1285 | 13996 | 2308 |
+| UD-Q8_K_XL | 80K | q8_0 | 2048 | 25.87 | 25.39 | 1232 | 15218 | 1086 |
+| UD-Q8_K_XL | 80K | q8_0 | 4096 | 25.80 | 25.34 | 1141 | 14192 | 2112 |
+
+- TG is weight-bandwidth-bound: KV type and ctx are ~free. **UD-Q8_K_XL is 20% slower** (36% more weight bytes) — eliminated.
+- `-ub 4096` costs up to ~2.8 GB VRAM for zero/negative PP gain (dense model; unlike the offloaded MoE) — **`-ub 2048` strictly better**.
+- f16 KV works on this hybrid (no 27B-style mandatory-quantized-KV issue on these builds) and is marginally fastest, but q8_0 buys 1–1.8 GB headroom for <1% TG.
+
+### Phase A, MTP cells (draft-mtp, Q8_0 weights)
+
+| ctx | KV | n_max | TG greedy (acc) | TG real (acc) | PP | idle VRAM | headroom |
+|---:|---|---:|---:|---:|---:|---:|---:|
+| 80K | q8_0 | 2 | **60.03 (86.6%)** | **47.09 (59.9%)** | 1199 | 14555 | 1749 |
+| 80K | q4_0 | 2 | 57.29 (80.1%) | 51.34 (70.3%) | 1112 | 15849¹ | 455¹ |
+| 80K | q8_0 | 3 | 60.23 (70.3%) | 49.05 (54.1%) | 1199 | 14600 | 1704 |
+| 80K | q8_0 | 2 +ub4096 | 59.61 (86.6%) | 46.95 (60.4%) | 995 | 16033 | 271 |
+| 131K | q8_0 | 2 | 59.99 (86.6%) | 50.02 (67.3%) | 1211 | 15493 | 811 |
+| 80K (UD-Q8_K_XL) | q8_0 | 2 | 46.13 (88.0%) | 34.12 (54.1%) | 1075 | 16153 | 151 |
+
+¹ anomalous first reading; settled to 15060 after probes.
+
+**Headline: no MTP context cliff on the 9B.** Unlike the 27B (speculation silently disables above ~35K ctx / with q8 KV, still true on b9381), the 9B accelerates at 80K *and* 131K with q8 KV: **+85% greedy (60 vs 32.4), +48–58% real-sampler (47–51 t/s; the spread is acceptance noise at temp 1.0)**. n=2 ≥ n=3 on real workloads (acceptance drops faster than payoff — same as the 35B). Real-sampler TG tracks acceptance (~60–75% → 47–55 t/s), consistent with the acceptance-not-VRAM mechanism established in May.
+
+### b9990 vs b9381 — compute flat, footprint dramatically lighter
+
+`llama-bench` gold standard (Q8_0, `-fa 1`, r=3): b9381 pp2048 **1703.6 ± 2.5** / tg128 **26.31 ± 0.01**; b9990 **1684.0 ± 1.3** / **26.54 ± 0.01** → compute is a wash (−1% PP, +1% TG), same conclusion as the b9672 probe.
+
+But the **server VRAM footprint at identical configs is 2.6–3.2 GB lighter on b9990** — and it is real allocation reduction, not deferred/lazy KV growth (VRAM stays byte-flat through a 107K-token prompt, see stress below):
+
+| config | b9381 idle / hr | b9990 idle / hr | Δ |
+|---|---:|---:|---:|
+| 9B base Q8_0 @80K q8 KV | 12836 / 3468 | **10224 / 6080** | −2612 |
+| 9B MTP @80K q8 KV n2 | 14555 / 1749 | **11369 / 4935** | −3186 |
+| 9B MTP @131K q8 KV n2 | 15493 / 811 | **12761 / 3543** | −2732 |
+
+b9990 TG/PP on the 9B matches or slightly beats b9381 (MTP greedy 61.4–61.5 vs 60.0–60.2).
+
+### Deep-prompt eviction stress (protocol: fresh shallow TG → deep prompt fills KV → re-measure ×2)
+
+| config | deep fill | fresh → sustained TG | VRAM through stress | verdict |
+|---|---|---:|---:|---|
+| b9990 MTP @131K q8 n2 | **107,301 tok** @ 579 t/s | 61.32 → **60.97** (−0.6%) | **12763 flat** (hr 3541) | ✅ PASS |
+| b9990 MTP @80K q8 n2 | 60,901 tok @ 771 t/s | 61.42 → **60.92** (−0.8%) | 11371 flat (hr 4933) | ✅ PASS |
+| b9381 MTP @80K q8 n2 | 60,901 tok @ 763 t/s | 60.08 → **58.75** (−2.2%) | 14551 flat (hr 1752) | ✅ PASS |
+
+### Phase D — the b9990 upgrade question, answered by the production 35B configs
+
+| config on b9990 | fresh TG | deep 61K-tok PP | sustained TG | VRAM | verdict |
+|---|---:|---:|---:|---|---|
+| 35B **base** Q5_K_XL @80K q8 ot20 **ub4096** (the shipped default) | 29.94 | **367** (vs ~700 on b9381) | **22.65 (−24%)** | 15957 → **14948 during fill** | ❌ **EVICTS** |
+| 35B **MTP** Q5_K_XL @80K q4 ot18 ub2048 n2 | 40.71 | 488 | **42.11 (+3.4%)** | 14760–14768 flat (hr 1536) | ✅ PASS (+10% vs 38.3 on b9381) |
+
+The base-default config shows the textbook eviction signature on b9990 (VRAM *drops* ~1 GB during the deep fill as the compute buffer moves to GTT). b9990's allocation rewrite is a big win for the dense-hybrid 9B (−3 GB) and even for 35B-MTP/ub2048 (+10%, stable), but it **regresses the shipped 35B base default** — so **the pin stays at b9381**. (Future lever: a b9990 bump paired with re-tuning the 35B default away from ub4096 — e.g. MTP-as-default at 42 t/s — but that is a separate, deliberate migration, not a free bump.)
+
+### Conclusion & shipped config
+
+- **Shipped (PR): `Qwen3.5-9B-MTP-Q8_0` added to `platform_models.json`** (non-default; switch via `/api/ai/model/switch`): Q8_0 weights, **ctx 81920**, q8_0 KV, `-ub 2048`, draft-mtp n=2, `-ngl 99` — on the pinned b9381: **~59–60 t/s sustained greedy / 47–51 t/s real-sampler / PP ~1200 (deep-fill 763)**, idle 14555 MiB (headroom ~1750), deep-prompt stress PASS. That is **2× the 35B default's 29.1 t/s** and ~1.55× the 35B-MTP option's 38.3, at Q8 numerics with best-precision (q8) KV.
+- **UD-Q8_K_XL rejected** (−20% TG, headroom as low as 151 MiB); **ub4096 rejected** (VRAM cost, no dense-model PP gain); **n=3 rejected** (acceptance).
+- 131072 ctx is stress-clean on b9990 (hr 3541) but only headroom-marginal on b9381 (hr 811, unstressed) — revisit if/when the build moves.
+- **Upstream (b9990) verdict: compute flat, allocator very different** — lighter for dense/ub2048 regimes, evicting for the offloaded ub4096 default. No blind bumps; any move must re-stress every shipped config.


### PR DESCRIPTION
## Summary
- Adds **`Qwen3.5-9B-MTP-Q8_0`** to `platform_models.json` (non-default; activate via `POST /api/ai/model/switch`): Q8_0 weights + draft-mtp n=2 + q8_0 KV @ ctx 81920, `-ngl 99`, `-ub 2048`.
- Full sweep writeup appended to `docs/BENCHMARKS.md` (2026-07-15 section).

## Why Qwen3.5 (not 3.6)
There is no 9B in the Qwen3.6 generation (27B + 35B-A3B only). Qwen3.5-9B is the current 9B: a hybrid like the 27B (24 linear-attention + 8 full-attention layers → tiny KV, ~17 KB/token at q8_0). `-ngl 99` is mandatory (partial offload breaks the fused linear-attention kernel).

## Measured on .58 (RX 9060 XT 16 GB, pinned b9381, whisper on CPU)
| metric | value |
|---|---|
| TG sustained (greedy, post 61K-token deep fill) | **58.8 t/s** (2× the 35B default's 29.1) |
| TG production samplers | 47–51 t/s (MTP acceptance 60–75%) |
| PP | ~1200 t/s shallow / 763 deep-fill |
| VRAM | 14,551 MiB flat through stress (**headroom ~1750 MiB**) |
| Eviction stress | ✅ PASS (fresh 60.08 → 58.75, −2.2%) |

No MTP context cliff on this model (unlike the 27B): speculation stays active at 80K+ with q8 KV. Rejected: UD-Q8_K_XL (−20% TG, headroom to 151 MiB), `-ub 4096` (~2.8 GB VRAM for no dense-model PP gain), n=3 (acceptance).

## Upstream llama.cpp probe (b9990)
Compute is flat (llama-bench A/B), but the allocator differs sharply: **−3 GB footprint for the dense 9B** (131K ctx becomes comfortable, hr 3541, stress-PASS at 107K-token fill) yet it **evicts the shipped 35B base default** (sustained −24%, paradoxical VRAM drop during deep fill). **Pin stays at b9381.** A future deliberate migration (e.g. 35B-MTP-as-default, which does +10% on b9990) is documented in BENCHMARKS.md.

## Verification
- All sweep/stress cells run live on .58 (services held down during bench, restored after).
- Production restored and verified: 35B default healthy, TG 28.81 t/s (baseline 29.1).
- `platform_models.json` validates as JSON; entry follows the 35B-MTP entry conventions (`min_healthy_vram_mb` guard, benchmark block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)