### PR TITLE
feat(backup): off-site mirror of encrypted archives via rclone (2c)

### DIFF
--- a/config/.env.template
+++ b/config/.env.template
@@ -38,6 +38,18 @@ BACKUP_VERIFY=true
 BACKUP_OPENCLAW_WORKSPACE=true        # Include OpenClaw agent workspace in backups (opt-out)
 BACKUP_OPENCLAW_EXCLUDE_CACHES=false  # Exclude workspace/cache/ subtree to reduce size
 BACKUP_OPENCLAW_SIZE_WARN_MB=500      # Warn (not fail) if workspace exceeds this size in MB
+# --- Off-site backup copy ---
+# Mirror the (encrypted) backup archives to one remote via rclone.
+# OFFSITE_TYPE: sftp | webdav | s3
+# OFFSITE_HOST: sftp host[:port], WebDAV base URL, or S3 endpoint URL
+# OFFSITE_USER / OFFSITE_PASS: login / app password (S3: access key / secret)
+# OFFSITE_PATH: remote directory (S3: bucket[/prefix])
+OFFSITE_ENABLED=false
+OFFSITE_TYPE=
+OFFSITE_HOST=
+OFFSITE_USER=
+OFFSITE_PASS=
+OFFSITE_PATH=
 # Optional Cloudflare Tokens (alternative to Pangolin)
 CF_TUNNEL_ID=
 TRUSTED_PROXIES_0=172.18.0.1

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -452,4 +452,23 @@ find "$BACKUP_MOUNTDIR" -maxdepth 1 -type f -name "homebrain_backup_system_*.tar
     xargs -r rm --
 
 log_info "=== Backup Complete: $ARCHIVE_PATH ==="
+
+# 14. Off-site mirror (optional). Deliberately AFTER the Complete marker: the
+# local backup is done, and a slow WAN upload must not make this run look
+# failed or stuck to the health check. Failure is non-fatal — it is recorded
+# in a state file the health check reads, and warned about here.
+if [[ "${OFFSITE_ENABLED:-false}" == "true" ]]; then
+    OFFSITE_STATE="/var/lib/homebrain/offsite.json"
+    mkdir -p /var/lib/homebrain
+    log_info "Mirroring backups off-site (${OFFSITE_TYPE:-unset})..."
+    if offsite_sync; then
+        printf '{"ts": %d, "ok": true}\n' "$(date +%s)" > "${OFFSITE_STATE}.tmp" \
+            && mv "${OFFSITE_STATE}.tmp" "$OFFSITE_STATE"
+        log_info "Off-site mirror complete."
+    else
+        printf '{"ts": %d, "ok": false}\n' "$(date +%s)" > "${OFFSITE_STATE}.tmp" \
+            && mv "${OFFSITE_STATE}.tmp" "$OFFSITE_STATE"
+        log_warn "OFF-SITE COPY FAILED — the local backup is fine; check the off-site settings on the Backup page."
+    fi
+fi
 # Lock file removed by trap

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -692,3 +692,57 @@ configure_nextcloud_redis() {
 
     log_info "Redis configuration applied successfully."
 }
+
+# --- Off-site backup copy ---------------------------------------------------
+# One rclone remote named "offsite", defined entirely by the OFFSITE_* vars
+# from .env — no rclone.conf to manage. Credentials travel via rclone's
+# RCLONE_CONFIG_* environment variables (and stdin for `obscure`), never argv.
+
+offsite_env() {
+    case "${OFFSITE_TYPE:-}" in
+        sftp)
+            local host="${OFFSITE_HOST}" port=""
+            if [[ "$host" == *:* ]]; then port="${host##*:}"; host="${host%%:*}"; fi
+            export RCLONE_CONFIG_OFFSITE_TYPE=sftp
+            export RCLONE_CONFIG_OFFSITE_HOST="$host"
+            [[ -n "$port" ]] && export RCLONE_CONFIG_OFFSITE_PORT="$port"
+            export RCLONE_CONFIG_OFFSITE_USER="${OFFSITE_USER}"
+            RCLONE_CONFIG_OFFSITE_PASS=$(printf '%s' "${OFFSITE_PASS}" | rclone obscure -) || return 1
+            export RCLONE_CONFIG_OFFSITE_PASS
+            ;;
+        webdav)
+            export RCLONE_CONFIG_OFFSITE_TYPE=webdav
+            export RCLONE_CONFIG_OFFSITE_URL="${OFFSITE_HOST}"
+            # Nextcloud speaks chunked upload — required for multi-GB archives.
+            if [[ "${OFFSITE_HOST}" == *remote.php* ]]; then
+                export RCLONE_CONFIG_OFFSITE_VENDOR=nextcloud
+            else
+                export RCLONE_CONFIG_OFFSITE_VENDOR=other
+            fi
+            export RCLONE_CONFIG_OFFSITE_USER="${OFFSITE_USER}"
+            RCLONE_CONFIG_OFFSITE_PASS=$(printf '%s' "${OFFSITE_PASS}" | rclone obscure -) || return 1
+            export RCLONE_CONFIG_OFFSITE_PASS
+            ;;
+        s3)
+            export RCLONE_CONFIG_OFFSITE_TYPE=s3
+            export RCLONE_CONFIG_OFFSITE_PROVIDER=Other
+            export RCLONE_CONFIG_OFFSITE_ENDPOINT="${OFFSITE_HOST}"
+            export RCLONE_CONFIG_OFFSITE_ACCESS_KEY_ID="${OFFSITE_USER}"
+            export RCLONE_CONFIG_OFFSITE_SECRET_ACCESS_KEY="${OFFSITE_PASS}"
+            ;;
+        *)
+            log_warn "Unknown off-site type: '${OFFSITE_TYPE:-}'"
+            return 1
+            ;;
+    esac
+}
+
+# Mirror the local archive set to the remote. Local retention already decides
+# what to keep, so a plain filtered sync gives remote retention for free.
+offsite_sync() {
+    command -v rclone >/dev/null || { log_warn "rclone is not installed."; return 1; }
+    offsite_env || return 1
+    rclone sync "$BACKUP_MOUNTDIR" "offsite:${OFFSITE_PATH:-homebrain-backups}" \
+        --include 'homebrain_backup*.tar.gz*' \
+        --include 'nextcloud_backup*.tar.gz*'
+}

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -742,7 +742,11 @@ offsite_env() {
 offsite_sync() {
     command -v rclone >/dev/null || { log_warn "rclone is not installed."; return 1; }
     offsite_env || return 1
+    # Leading / anchors the patterns to the drive's top level and --max-depth
+    # stops recursion — same scope as local retention's `find -maxdepth 1`.
+    # Without both, archives inside subdirectories would get mirrored too.
     rclone sync "$BACKUP_MOUNTDIR" "offsite:${OFFSITE_PATH:-homebrain-backups}" \
-        --include 'homebrain_backup*.tar.gz*' \
-        --include 'nextcloud_backup*.tar.gz*'
+        --max-depth 1 \
+        --include '/homebrain_backup*.tar.gz*' \
+        --include '/nextcloud_backup*.tar.gz*'
 }

--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -42,6 +42,7 @@ STATE_FILE = f"{STATE_DIR}/health_state.json"
 BACKUP_DIR = "/mnt/backup"
 BACKUP_LOG = "/var/log/homebrain/backup.log"
 BACKUP_CRON_FILE = "/etc/cron.d/homebrain-backup"
+OFFSITE_STATE = f"{STATE_DIR}/offsite.json"
 HOMEBRAIN_HOME = "/home/homebrain"
 OPENCLAW_DIR = f"{HOMEBRAIN_HOME}/.openclaw"
 OPENCLAW_PORT = 18789
@@ -187,6 +188,27 @@ def check_backup(env, now):
         return {"id": "backup", "level": "warn",
                 "summary": f"Last backup is {days} days old (schedule looks overdue)"}
     return {"id": "backup", "level": "ok", "summary": "Backups are up to date"}
+
+
+def check_offsite(env, now):
+    """Warn-only: the local backup is the data protection; off-site is a copy."""
+    if env.get("OFFSITE_ENABLED", "false").lower() != "true":
+        return None
+    try:
+        with open(OFFSITE_STATE) as f:
+            st = json.load(f)
+    except Exception:
+        return {"id": "offsite", "level": "warn",
+                "summary": "Off-site copy is enabled but has not run yet"}
+    if not st.get("ok"):
+        return {"id": "offsite", "level": "warn",
+                "summary": "The last off-site copy failed — local backups are unaffected"}
+    age = now - st.get("ts", 0)
+    if age > expected_backup_interval(env) + DAY:
+        days = int(age // DAY)
+        return {"id": "offsite", "level": "warn",
+                "summary": f"No off-site copy for {days} days"}
+    return {"id": "offsite", "level": "ok", "summary": "Off-site copy is up to date"}
 
 
 def check_smart():
@@ -416,6 +438,7 @@ def main():
     gpu = has_gpu(env)
     checks = [c for c in [
         check_backup(env, now),
+        check_offsite(env, now),
         check_disk("/", "System disk", "disk_root"),
         check_disk(BACKUP_DIR, "Backup drive", "disk_backup") if os.path.ismount(BACKUP_DIR) else None,
         check_smart(),

--- a/scripts/tests/test_healthcheck.py
+++ b/scripts/tests/test_healthcheck.py
@@ -2,14 +2,18 @@
 
 Run:  python3 -m pytest scripts/tests/test_healthcheck.py
 """
+import json
 import os
 import sys
+import tempfile
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+import healthcheck  # noqa: E402
 from healthcheck import (  # noqa: E402
     DAY,
     backup_log_outcome,
+    check_offsite,
     compose_message,
     decide_notification,
     disk_level,
@@ -105,6 +109,51 @@ def test_info_level_alerts_once_then_weekly():
     assert decide_notification(prev, "info", NOW) is None
     # ...and info -> ok produces no recovery noise.
     assert decide_notification({"level": "info", "last_notified": NOW}, "ok", NOW) is None
+
+
+def _offsite(env, state=None, now=NOW):
+    """Run check_offsite against a temp state file (or a missing one)."""
+    orig = healthcheck.OFFSITE_STATE
+    try:
+        if state is None:
+            healthcheck.OFFSITE_STATE = "/nonexistent/offsite.json"
+            return check_offsite(env, now)
+        with tempfile.NamedTemporaryFile("w", suffix=".json") as f:
+            json.dump(state, f)
+            f.flush()
+            healthcheck.OFFSITE_STATE = f.name
+            return check_offsite(env, now)
+    finally:
+        healthcheck.OFFSITE_STATE = orig
+
+
+def test_offsite_disabled_is_silent():
+    assert _offsite({}) is None
+    assert _offsite({"OFFSITE_ENABLED": "false"}) is None
+
+
+def test_offsite_enabled_but_never_ran():
+    c = _offsite({"OFFSITE_ENABLED": "true"})
+    assert c["level"] == "warn" and "has not run" in c["summary"]
+
+
+def test_offsite_last_run_failed():
+    c = _offsite({"OFFSITE_ENABLED": "true"}, {"ts": NOW, "ok": False})
+    assert c["level"] == "warn" and "failed" in c["summary"]
+    # warn-only by design: local backups are the data protection
+    assert "local backups are unaffected" in c["summary"]
+
+
+def test_offsite_stale_and_fresh():
+    env = {"OFFSITE_ENABLED": "true"}  # daily schedule -> stale after 2 days
+    ok = _offsite(env, {"ts": NOW - DAY, "ok": True})
+    assert ok["level"] == "ok"
+    stale = _offsite(env, {"ts": NOW - 3 * DAY, "ok": True})
+    assert stale["level"] == "warn" and "3 days" in stale["summary"]
+    # a weekly schedule tolerates a week-old copy
+    weekly = _offsite({"OFFSITE_ENABLED": "true", "BACKUP_DAY_WEEK": "0"},
+                      {"ts": NOW - 6 * DAY, "ok": True})
+    assert weekly["level"] == "ok"
 
 
 def test_compose_message():

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -2179,6 +2179,24 @@ EOF
     log_info "Backup timer configured: OnCalendar=$oncal (Persistent=true)"
 }
 
+# Probe the configured off-site remote with a real write + delete — the only
+# test that proves backups will actually land there. Called by the dashboard's
+# "Save & test" button after the OFFSITE_* vars are saved to .env.
+offsite_test() {
+    load_env
+    command -v rclone >/dev/null || die "rclone is not installed."
+    [[ "${OFFSITE_TYPE:-}" =~ ^(sftp|webdav|s3)$ ]] || die "Off-site remote is not configured."
+    [[ -n "${OFFSITE_HOST:-}" ]] || die "Off-site host is not set."
+    offsite_env || die "Invalid off-site configuration."
+    local dest="offsite:${OFFSITE_PATH:-homebrain-backups}"
+    local probe=".homebrain-write-test-$$"
+    rclone mkdir "$dest" 2>/dev/null || true
+    printf 'homebrain off-site probe\n' | rclone rcat "$dest/$probe" \
+        || die "Cannot write to the off-site remote — check host, credentials and path."
+    rclone deletefile "$dest/$probe" 2>/dev/null || true
+    log_info "Off-site remote OK (${OFFSITE_TYPE} → ${OFFSITE_PATH:-homebrain-backups})"
+}
+
 # --- Main Dispatch (only when executed directly, not sourced) ---
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
 case "${1:-}" in
@@ -2193,6 +2211,9 @@ case "${1:-}" in
         ;;
     backup_timer)
         configure_backup_timer
+        ;;
+    offsite_test)
+        offsite_test
         ;;
     pci)
         configure_pci_speed "${2}"

--- a/src/app.py
+++ b/src/app.py
@@ -1409,6 +1409,72 @@ def backup_config():
         return jsonify({"error": str(e)}), 500
 
 
+@app.route("/api/backup/offsite", methods=["GET", "POST"])
+@limiter.limit("10 per minute")
+def backup_offsite():
+    if request.method == "GET":
+        env = get_env_config()
+        return jsonify(
+            {
+                "enabled": env.get("OFFSITE_ENABLED", "false") == "true",
+                "type": env.get("OFFSITE_TYPE", ""),
+                "host": env.get("OFFSITE_HOST", ""),
+                "user": env.get("OFFSITE_USER", ""),
+                "has_pass": bool(env.get("OFFSITE_PASS", "")),
+                "path": env.get("OFFSITE_PATH", ""),
+            }
+        )
+
+    data = request.json
+    enabled = bool(data.get("enabled"))
+    remote_type = data.get("type", "")
+    host = data.get("host", "").strip()
+    user = data.get("user", "").strip()
+    password = data.get("pass", "")
+    path = data.get("path", "").strip()
+
+    if enabled:
+        if remote_type not in ["sftp", "webdav", "s3"]:
+            return jsonify({"error": "Invalid remote type"}), 400
+        if not host:
+            return jsonify({"error": "Host is required"}), 400
+
+    update_env_var("OFFSITE_ENABLED", "true" if enabled else "false")
+    update_env_var("OFFSITE_TYPE", remote_type)
+    update_env_var("OFFSITE_HOST", host)
+    update_env_var("OFFSITE_USER", user)
+    if password:  # an empty field means "keep the saved password"
+        update_env_var("OFFSITE_PASS", password)
+    update_env_var("OFFSITE_PATH", path)
+
+    if enabled and not shutil.which("rclone"):
+        try:
+            subprocess.run(
+                ["apt-get", "install", "-y", "rclone"],
+                check=True, capture_output=True, text=True, timeout=300,
+            )
+        except Exception:
+            return jsonify({"error": "Could not install rclone"}), 500
+    return jsonify({"status": "success"})
+
+
+@app.route("/api/backup/offsite/test", methods=["POST"])
+@limiter.limit("5 per minute")
+def backup_offsite_test():
+    try:
+        result = subprocess.run(
+            ["bash", SCRIPT_UTILITIES, "offsite_test"],
+            capture_output=True, text=True, timeout=60,
+        )
+    except subprocess.TimeoutExpired:
+        return jsonify({"error": "Connection test timed out"}), 500
+    if result.returncode != 0:
+        lines = (result.stderr or result.stdout or "").strip().splitlines()
+        msg = lines[-1].removeprefix("[ERROR] ") if lines else "Connection test failed"
+        return jsonify({"error": msg}), 400
+    return jsonify({"status": "success"})
+
+
 # --- Routes: Backup & Restore Execution ---
 @app.route("/api/backup/now", methods=["POST"])
 @limiter.limit("3 per minute")

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -666,6 +666,47 @@
             </div>
         </div>
 
+        <div class="card" style="margin-top:22px;">
+            <h3>Off-site Copy</h3>
+            <p>Mirror the encrypted backup archives to another machine or cloud storage after each backup.</p>
+            <form onsubmit="saveOffsiteConfig(event)">
+                <label style="display:flex; align-items:center; gap:10px; cursor:pointer; margin-bottom:12px;">
+                    <input type="checkbox" id="os-enabled" style="width:auto;">
+                    <span>Enable off-site copy</span>
+                </label>
+                <div class="grid" style="grid-template-columns: 1fr 2fr; gap:15px;">
+                    <div>
+                        <label>Type</label>
+                        <select id="os-type" onchange="updateOffsiteUI()">
+                            <option value="sftp">SFTP / SSH</option>
+                            <option value="webdav">WebDAV / Nextcloud</option>
+                            <option value="s3">S3-compatible</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label id="os-host-label">Host</label>
+                        <input type="text" id="os-host" autocomplete="off">
+                    </div>
+                </div>
+                <div class="grid" style="grid-template-columns: 1fr 1fr 1fr; gap:15px;">
+                    <div>
+                        <label id="os-user-label">Username</label>
+                        <input type="text" id="os-user" autocomplete="off">
+                    </div>
+                    <div>
+                        <label id="os-pass-label">Password</label>
+                        <input type="password" id="os-pass" autocomplete="new-password">
+                    </div>
+                    <div>
+                        <label id="os-path-label">Remote folder</label>
+                        <input type="text" id="os-path" placeholder="homebrain-backups">
+                    </div>
+                </div>
+                <button type="submit" class="btn-primary" style="width:100%; margin-top:10px;">Save &amp; Test Connection</button>
+                <p id="os-status" style="margin-top:10px; font-size:0.9em;"></p>
+            </form>
+        </div>
+
         {% if has_gpu %}
         <div class="card" style="margin-top: 16px;">
           <div class="card-header">
@@ -694,7 +735,7 @@
               </label>
             </div>
             <p style="margin-top: 12px; font-size: 0.85em; color: var(--text-dim);">
-              Workspace contains conversation history and agent memory. Backups are stored unencrypted.
+              Workspace contains conversation history and agent memory. Backups are encrypted with your master password.
             </p>
           </div>
         </div>
@@ -1397,6 +1438,7 @@
                 loadDrives();
                 loadBackups();
                 loadBackupConfig();
+                loadOffsiteConfig();
                 loadDiskStats();
                 loadOpenClawBackupStatus();
             }
@@ -3078,6 +3120,74 @@
         async function runBackup() {
             const s = document.getElementById('backup-strategy').value;
             triggerAction('/api/backup/now', 'Manual Backup', { strategy: s });
+        }
+
+        async function loadOffsiteConfig() {
+            try {
+                const res = await fetch('/api/backup/offsite', { credentials: 'include' });
+                const d = await res.json();
+                document.getElementById('os-enabled').checked = !!d.enabled;
+                if (d.type) document.getElementById('os-type').value = d.type;
+                document.getElementById('os-host').value = d.host || '';
+                document.getElementById('os-user').value = d.user || '';
+                document.getElementById('os-pass').value = '';
+                document.getElementById('os-pass').placeholder = d.has_pass ? '(unchanged)' : '';
+                document.getElementById('os-path').value = d.path || '';
+                updateOffsiteUI();
+            } catch(e) {}
+        }
+
+        function updateOffsiteUI() {
+            const labels = {
+                sftp:   ['Host (host or host:port)', 'backup.example.com', 'Username', 'Password'],
+                webdav: ['WebDAV URL', 'https://cloud.example.com/remote.php/dav/files/USER', 'Username', 'App password'],
+                s3:     ['Endpoint URL', 'https://s3.example.com', 'Access key ID', 'Secret key'],
+            }[document.getElementById('os-type').value];
+            document.getElementById('os-host-label').innerText = labels[0];
+            document.getElementById('os-host').placeholder = labels[1];
+            document.getElementById('os-user-label').innerText = labels[2];
+            document.getElementById('os-pass-label').innerText = labels[3];
+            document.getElementById('os-path-label').innerText =
+                document.getElementById('os-type').value === 's3' ? 'Bucket / prefix' : 'Remote folder';
+        }
+
+        async function saveOffsiteConfig(e) {
+            e.preventDefault();
+            const status = document.getElementById('os-status');
+            const enabled = document.getElementById('os-enabled').checked;
+            const body = {
+                enabled: enabled,
+                type: document.getElementById('os-type').value,
+                host: document.getElementById('os-host').value,
+                user: document.getElementById('os-user').value,
+                pass: document.getElementById('os-pass').value,
+                path: document.getElementById('os-path').value,
+            };
+            status.style.color = '';
+            status.innerText = 'Saving...';
+            const res = await fetch('/api/backup/offsite', { method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify(body) });
+            const d = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                status.style.color = 'var(--danger)';
+                status.innerText = d.error || 'Error saving settings.';
+                return;
+            }
+            if (!enabled) {
+                status.innerText = 'Off-site copy disabled.';
+                return;
+            }
+            status.innerText = 'Testing connection...';
+            const t = await fetch('/api/backup/offsite/test', { method: 'POST' });
+            const td = await t.json().catch(() => ({}));
+            if (t.ok) {
+                status.style.color = 'var(--accent)';
+                status.innerText = '✓ Connected — backups will be copied off-site after each run.';
+                document.getElementById('os-pass').value = '';
+                document.getElementById('os-pass').placeholder = '(unchanged)';
+            } else {
+                status.style.color = 'var(--danger)';
+                status.innerText = td.error || 'Connection test failed.';
+            }
         }
 
         let backupIndex = {};  // name -> {encrypted, ...} from /api/backups/list


### PR DESCRIPTION
Phase 2c of the product review plan (docs/plans/PRODUCT_REVIEW_2026-07.md): the last leg of the trust story. Local backups are now encrypted + verified (#117); this mirrors them to one off-site remote so a stolen/dead box no longer means lost data.

## Design (minimalism first)
- **One rclone remote, zero config files.** The remote named `offsite` is defined entirely by six `OFFSITE_*` vars in `.env`, passed to rclone via `RCLONE_CONFIG_*` environment variables. No `rclone.conf` to create, migrate, or leak. Credentials never touch argv (`rclone obscure` reads stdin).
- **Three remote types**: `sftp` (host[:port]), `webdav` (Nextcloud chunked upload auto-detected via `remote.php` in the URL — required for multi-GB archives), `s3` (any S3-compatible endpoint).
- **`rclone sync` mirror = remote retention for free.** Local retention already decides what to keep; the filtered sync mirrors exactly that set, deletions included. No bespoke remote-retention code.
- **Sync runs AFTER the `=== Backup Complete ===` marker** and is non-fatal: a slow WAN upload or a dead remote can never make a finished local backup look failed to the health check. Outcome lands in `/var/lib/homebrain/offsite.json`.
- **Warn-only health signal.** `check_offsite` (never-ran / failed / stale vs the backup schedule) never exceeds `warn` — local backups remain the data protection.
- **Dashboard**: Off-site Copy card with per-type field labels, write-only password (empty field keeps the saved one; GET returns only `has_pass`), and a Save & Test button backed by a real write+delete probe (`utilities.sh offsite_test`).

## E2E on production (192.168.178.58, sftp remote)
- Save & Test through the full chain (dashboard API → `.env` → `offsite_test` → rclone): probe file written + deleted on the remote. GET never returns the password; `.env` values single-quoted.
- Real path: `backup.sh --strategy system` → encrypted snapshot created, verified, then mirrored — `Off-site mirror complete.`, `offsite.json {"ok": true}`, health check `offsite=ok`.
- **Retention mirroring proven live**: a second run pruned the oldest snapshot locally (keep-2) and the sync deleted it remotely; remote listing == local listing.
- **Failure path proven live**: killed rclone mid-sync → `[WARN] OFF-SITE COPY FAILED` + `{"ok": false}`, local backup untouched, backup still reported Complete.
- **E2E caught a real bug** (second commit): rclone's unanchored `--include` matched archives inside *subdirectories* of the backup drive and started mirroring them. Fixed by anchoring the patterns (`/homebrain_backup*`) + `--max-depth 1`, scoping the sync to exactly what local retention manages (`find -maxdepth 1`).
- Health check disabled-state verified: the `offsite` check vanishes from the health summary when `OFFSITE_ENABLED=false`.
- Unit tests: 13/13 (9 existing + 4 new `check_offsite` cases) pass on Mac and on the box.
- Also fixes the stale dashboard note claiming backups are stored unencrypted (untrue since #117).

All E2E artifacts cleaned up: config disabled, password cleared, remote scratch dir and state file removed, archives restored, health all-ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)