### PR TITLE
feat(backup): receive backups from another HomeBrain (replica target)

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -253,9 +253,11 @@ if [[ "$STRATEGY" != "data_only" && -n "$NC_CID" ]]; then
 fi
 
 # 7. Nextcloud Data (Rsync host path — skipped for system snapshots)
+# The "replica" account holds another HomeBrain's off-site archives — backing
+# those up again would double every backup with data the other box already owns.
 if [[ "$STRATEGY" != "system" ]]; then
     log_info "Syncing Nextcloud Data..."
-    rsync -a --delete "$NEXTCLOUD_DATA_DIR"/ "$STAGING_DIR/nc_data/" || die "NC Data Sync failed."
+    rsync -a --delete --exclude=/replica/ "$NEXTCLOUD_DATA_DIR"/ "$STAGING_DIR/nc_data/" || die "NC Data Sync failed."
 else
     rmdir "$STAGING_DIR/nc_data" 2>/dev/null || true
 fi

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -165,7 +165,10 @@ if [ "$HAS_NC_DATA" = true ]; then
     log_info "Restoring Nextcloud Data..."
     SRC="$TMP_DIR/nc_data"; [[ ! -d "$SRC" ]] && SRC="$TMP_DIR/data"
 
-    rsync -a --delete "$SRC/" "$NEXTCLOUD_DATA_DIR/" || die "NC Data RSync failed."
+    # Archives never contain the "replica" landing area (see backup.sh) — the
+    # exclude keeps --delete from destroying another HomeBrain's received
+    # archives when this box is restored.
+    rsync -a --delete --exclude=/replica/ "$SRC/" "$NEXTCLOUD_DATA_DIR/" || die "NC Data RSync failed."
     chown -R 33:33 "$NEXTCLOUD_DATA_DIR"
 fi
 

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -2197,6 +2197,54 @@ offsite_test() {
     log_info "Off-site remote OK (${OFFSITE_TYPE} → ${OFFSITE_PATH:-homebrain-backups})"
 }
 
+# --- Action: Receive backups from another HomeBrain -------------------------
+# A dedicated Nextcloud account "replica" is the landing area for another
+# box's off-site archives: single-purpose, revocable, and excluded from this
+# box's own backups (backup.sh/restore.sh skip its data dir). The password is
+# printed once for the sending box's Off-site form and never stored here;
+# enabling again simply rotates it.
+replica_target_enable() {
+    load_env
+    local nc_cid=$(get_nc_cid)
+    [[ -n "$nc_cid" ]] || die "Nextcloud container is not running."
+    local pass
+    pass=$(pwgen -s 24 1) || die "pwgen is not installed."
+    if docker exec -u www-data "$nc_cid" php occ user:info replica >/dev/null 2>&1; then
+        docker exec -u www-data -e OC_PASS="$pass" "$nc_cid" \
+            php occ user:resetpassword --password-from-env replica >/dev/null \
+            || die "Could not reset the replica password."
+    else
+        docker exec -u www-data -e OC_PASS="$pass" "$nc_cid" \
+            php occ user:add --password-from-env --display-name "HomeBrain Replica" replica >/dev/null \
+            || die "Could not create the replica account."
+    fi
+    echo "REPLICA_PASS=$pass"
+}
+
+replica_target_status() {
+    load_env
+    local nc_cid=$(get_nc_cid)
+    [[ -n "$nc_cid" ]] || die "Nextcloud container is not running."
+    if docker exec -u www-data "$nc_cid" php occ user:info replica >/dev/null 2>&1; then
+        local used
+        used=$(du -sh "${NEXTCLOUD_DATA_DIR}/replica" 2>/dev/null | awk '{print $1}')
+        echo "enabled used=${used:-0}"
+    else
+        echo "disabled"
+    fi
+}
+
+# Deletes the replica account AND every archive it received. The sending box
+# keeps its local copies — this only removes the off-site set.
+replica_target_disable() {
+    load_env
+    local nc_cid=$(get_nc_cid)
+    [[ -n "$nc_cid" ]] || die "Nextcloud container is not running."
+    docker exec -u www-data "$nc_cid" php occ user:delete replica >/dev/null \
+        || die "Could not remove the replica account."
+    rm -rf "${NEXTCLOUD_DATA_DIR:?}/replica"
+}
+
 # --- Main Dispatch (only when executed directly, not sourced) ---
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
 case "${1:-}" in
@@ -2214,6 +2262,15 @@ case "${1:-}" in
         ;;
     offsite_test)
         offsite_test
+        ;;
+    replica_enable)
+        replica_target_enable
+        ;;
+    replica_status)
+        replica_target_status
+        ;;
+    replica_disable)
+        replica_target_disable
         ;;
     pci)
         configure_pci_speed "${2}"

--- a/src/app.py
+++ b/src/app.py
@@ -1475,6 +1475,49 @@ def backup_offsite_test():
     return jsonify({"status": "success"})
 
 
+@app.route("/api/backup/replica", methods=["GET", "POST"])
+@limiter.limit("10 per minute")
+def backup_replica():
+    nc_domain = get_env_config().get("NEXTCLOUD_TRUSTED_DOMAINS", "")
+    url = f"https://{nc_domain}/remote.php/dav/files/replica" if nc_domain else ""
+
+    if request.method == "GET":
+        result = subprocess.run(
+            ["bash", SCRIPT_UTILITIES, "replica_status"],
+            capture_output=True, text=True, timeout=30,
+        )
+        out = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else ""
+        if result.returncode != 0:
+            return jsonify({"error": "Could not read replica status"}), 500
+        if out.startswith("enabled"):
+            used = out.split("used=", 1)[1] if "used=" in out else "?"
+            return jsonify({"enabled": True, "url": url, "user": "replica", "used": used})
+        return jsonify({"enabled": False})
+
+    action = request.json.get("action", "")
+    if action == "enable":
+        result = subprocess.run(
+            ["bash", SCRIPT_UTILITIES, "replica_enable"],
+            capture_output=True, text=True, timeout=60,
+        )
+        # The password is shown once to be copied into the sending box's
+        # Off-site form — it is never stored on this box.
+        for line in result.stdout.splitlines():
+            if line.startswith("REPLICA_PASS="):
+                return jsonify({"status": "success", "url": url, "user": "replica",
+                                "pass": line.split("=", 1)[1]})
+        return jsonify({"error": "Could not enable the replica account"}), 500
+    if action == "disable":
+        result = subprocess.run(
+            ["bash", SCRIPT_UTILITIES, "replica_disable"],
+            capture_output=True, text=True, timeout=60,
+        )
+        if result.returncode != 0:
+            return jsonify({"error": "Could not remove the replica account"}), 500
+        return jsonify({"status": "success"})
+    return jsonify({"error": "Invalid action"}), 400
+
+
 # --- Routes: Backup & Restore Execution ---
 @app.route("/api/backup/now", methods=["POST"])
 @limiter.limit("3 per minute")

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -705,6 +705,26 @@
                 <button type="submit" class="btn-primary" style="width:100%; margin-top:10px;">Save &amp; Test Connection</button>
                 <p id="os-status" style="margin-top:10px; font-size:0.9em;"></p>
             </form>
+            <p style="margin-top:10px; font-size:0.85em; color:var(--text-dim);">
+                Tip: another HomeBrain can be the target — enable "Receive Backups" on that box and enter the WebDAV details it shows here.
+            </p>
+        </div>
+
+        <div class="card" style="margin-top:22px;">
+            <h3>Receive Backups from Another HomeBrain</h3>
+            <p>Creates a dedicated <code>replica</code> account another HomeBrain can use as its off-site target. Received archives don't appear in your files and are excluded from this box's own backups.</p>
+            <div id="replica-status" style="margin-bottom:10px;">Loading...</div>
+            <div id="replica-creds" style="display:none; margin-bottom:10px; padding:12px; border:1px solid var(--border); border-radius:8px;">
+                <strong>Copy these into the other HomeBrain's Off-site Copy form now — the password is shown only once.</strong>
+                <div style="margin-top:8px; font-family:monospace; font-size:0.9em; word-break:break-all;">
+                    <div>WebDAV URL: <span id="replica-url"></span></div>
+                    <div>Username: replica</div>
+                    <div>Password: <span id="replica-pass"></span></div>
+                </div>
+            </div>
+            <div style="display:flex; gap:10px;">
+                <button id="replica-btn" onclick="toggleReplica()" disabled>...</button>
+            </div>
         </div>
 
         {% if has_gpu %}
@@ -1439,6 +1459,7 @@
                 loadBackups();
                 loadBackupConfig();
                 loadOffsiteConfig();
+                loadReplicaStatus();
                 loadDiskStats();
                 loadOpenClawBackupStatus();
             }
@@ -3149,6 +3170,56 @@
             document.getElementById('os-pass-label').innerText = labels[3];
             document.getElementById('os-path-label').innerText =
                 document.getElementById('os-type').value === 's3' ? 'Bucket / prefix' : 'Remote folder';
+        }
+
+        let replicaEnabled = false;
+
+        async function loadReplicaStatus() {
+            const status = document.getElementById('replica-status');
+            const btn = document.getElementById('replica-btn');
+            try {
+                const res = await fetch('/api/backup/replica', { credentials: 'include' });
+                const d = await res.json();
+                if (!res.ok) throw new Error(d.error);
+                replicaEnabled = !!d.enabled;
+                if (replicaEnabled) {
+                    status.innerHTML = `<span style="color:var(--accent);">● Active</span> — receiving at <code style="word-break:break-all;">${d.url}</code> (${d.used} used)`;
+                    btn.innerText = 'Disable & Delete Received Archives';
+                    btn.className = 'btn-danger';
+                } else {
+                    status.innerText = 'Not enabled.';
+                    btn.innerText = 'Enable';
+                    btn.className = '';
+                }
+                btn.disabled = false;
+            } catch(e) {
+                status.innerText = 'Status unavailable.';
+            }
+        }
+
+        async function toggleReplica() {
+            const btn = document.getElementById('replica-btn');
+            if (replicaEnabled) {
+                const check = prompt("This deletes the replica account AND every archive received from the other HomeBrain (its own local backups are unaffected).\n\nType 'DELETE' to confirm:");
+                if (check !== 'DELETE') return;
+            }
+            btn.disabled = true;
+            const res = await fetch('/api/backup/replica', { method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({ action: replicaEnabled ? 'disable' : 'enable' }) });
+            const d = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                alert(d.error || 'Operation failed.');
+                btn.disabled = false;
+                return;
+            }
+            const creds = document.getElementById('replica-creds');
+            if (d.pass) {
+                document.getElementById('replica-url').innerText = d.url;
+                document.getElementById('replica-pass').innerText = d.pass;
+                creds.style.display = 'block';
+            } else {
+                creds.style.display = 'none';
+            }
+            loadReplicaStatus();
         }
 
         async function saveOffsiteConfig(e) {


### PR DESCRIPTION
Productizes HomeBrain-to-HomeBrain replication on top of #118. A receiving box gets a dedicated single-purpose Nextcloud account `replica`; its credentials are shown once and pasted into the sending box's Off-site Copy form. No new protocols — the existing WebDAV path through the Pangolin tunnel carries everything (proven at 4.3 MB/s berlin→miami in the #118 E2E).

## What's in it
- `utilities.sh` `replica_enable` / `replica_status` / `replica_disable`: occ-managed account, random 24-char password printed once and never stored (re-enable rotates it); status reports disk used; disable deletes the account + received archives (sender keeps its local copies).
- `backup.sh` + `restore.sh`: the replica data dir is excluded from both NC-data rsyncs. Backing received archives up again would double every backup with data the other box already owns — and a restore's `--delete` would otherwise **destroy** another box's off-site copies (caught in code review of the restore path).
- `app.py` GET/POST `/api/backup/replica`; dashboard "Receive Backups from Another HomeBrain" card with one-time credential display + a pointer hint in the Off-site card.

## E2E on production (.58, self-loop through the real Pangolin tunnel)
- Enable via dashboard API → `occ user:info replica` confirms the account; GET status reports usage; password shown once (24 chars), never retrievable.
- Off-site form configured with those credentials against `nc.berlin.homebrain.house` → probe passed; both encrypted system snapshots (136 MB) landed in the replica account's data dir through the tunnel loop (108 s).
- **Exclusion proven on a real 84 GB encrypted full backup**: the decrypted archive listing has **0** `nc_data/replica` entries out of 33,714, while control users (`OliAidana`, `admin`, appdata) are present — and the replica landing dir with its received archives is untouched on disk.
- Backup verified + retention normal (June 7 plaintext pruned; two fulls + two system snapshots remain).
- restore.sh exclusion is the same anchored `--exclude=/replica/` on the same rsync semantics; a destructive full restore was deliberately not run against the live box.
- The replica account on .58 is left enabled by request — it will receive the production (miami) box's backups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)