### PR TITLE
chore(security): Phase 3 hardening sweep

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,8 +177,10 @@ services:
       - pangolin
     image: fosrl/newt:1.8.1
     restart: unless-stopped
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+    # No docker.sock mount: newt only used it for optional container
+    # discovery in the Pangolin UI, and socket API access is root-equivalent
+    # on the host ("ro" only protects the socket file, not the API). Tunnel
+    # targets resolve via the compose network DNS.
     environment:
       - PANGOLIN_ENDPOINT=${PANGOLIN_ENDPOINT}
       - NEWT_ID=${NEWT_ID}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,11 @@ services:
   redis:
     image: redis:8.4.3-alpine
     restart: unless-stopped
+    # Loopback-only publish: the manager (gunicorn on the host) uses Redis as
+    # shared rate-limit storage — its 3 workers otherwise each count limits
+    # separately in memory.
+    ports:
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis_data:/data
     healthcheck:

--- a/docs/plans/PRODUCT_REVIEW_2026-07.md
+++ b/docs/plans/PRODUCT_REVIEW_2026-07.md
@@ -1,6 +1,10 @@
 # Product review & improvement plan — July 2026
 
-**Status:** Phase 2 (Trust features) in progress.
+**Status:** Phase 2 complete (#115 #117 #118 + replica target). Phase 3 largely complete;
+Caddy LAN-HTTPS edge deferred — both production boxes are remote-mode (Pangolin
+provides end-to-end TLS) and the edge would entangle the pre-stack bootstrap flow
+where the dashboard must run without containers. Revisit if LAN-only deployments
+become a real user base. Phase 1 (CI) is the known open debt.
 **Date:** 2026-07-15
 **Scope:** Holistic review of the product — reliability, security, engineering foundation,
 missing features — with a phased, minimalist plan. Findings verified against the working

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Flask==3.1.2
 requests==2.32.5
 python-dotenv==1.2.1
 flask-limiter==4.1.1
+redis==7.0.1
 gunicorn==23.0.0
 cryptography==46.0.4
 # OpenClaw control UI is proxied through the manager so a single

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -429,7 +429,7 @@ install_deps_enable_docker() {
     # --- 0. Install Dependencies ---
     log_info "Installing dependencies"
     wait_for_apt_lock
-    local common_pkgs="ca-certificates gnupg lsb-release cron gpg rsync python3-flask python3-dotenv python3-requests python3-pip python3-venv jq moreutils pwgen git parted argon2 smartmontools"
+    local common_pkgs="ca-certificates gnupg lsb-release cron gpg rsync python3-flask python3-dotenv python3-requests python3-pip python3-venv jq moreutils pwgen git parted argon2 smartmontools unattended-upgrades"
     apt-get install -y -qq $common_pkgs
 
     # Install Google Chrome for OpenClaw browser tool (x86 only, non-fatal)

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -100,7 +100,8 @@ if [[ "$HAS_GPU" == "true" ]]; then
         ufw allow 80/tcp    # Dashboard
         ufw allow 8080/tcp  # Nextcloud
         ufw allow 8123/tcp  # Home Assistant
-        ufw allow 18789/tcp # OpenClaw
+        # No 18789 rule: the OpenClaw gateway binds loopback only and is
+        # reached through the manager's authenticated proxy.
     fi
 
     # Vulkan drivers for AMD GPU (RADV via Mesa, ships in Ubuntu archive)

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -280,6 +280,16 @@ systemctl enable --now homebrain-health.timer 2>/dev/null || true
 command -v smartctl >/dev/null 2>&1 || apt-get install -y -qq smartmontools 2>/dev/null \
     || log_warn "smartmontools install failed — SMART monitoring disabled until next update."
 
+# OS security patches apply themselves nightly (Debian defaults: security
+# origin only, no automatic reboots — kernel updates wait for the next manual
+# reboot). Idempotent, best-effort.
+command -v unattended-upgrade >/dev/null 2>&1 || apt-get install -y -qq unattended-upgrades 2>/dev/null \
+    || log_warn "unattended-upgrades install failed — OS security patches stay manual."
+if command -v unattended-upgrade >/dev/null 2>&1; then
+    printf 'APT::Periodic::Update-Package-Lists "1";\nAPT::Periodic::Unattended-Upgrade "1";\n' \
+        > /etc/apt/apt.conf.d/20auto-upgrades
+fi
+
 # Migrate backup scheduling cron -> persistent systemd timer. Cron silently
 # skips runs the box sleeps through; the timer catches up on next boot. Only
 # when a cron entry exists (i.e. the user actually configured backups) —

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -290,6 +290,11 @@ if command -v unattended-upgrade >/dev/null 2>&1; then
         > /etc/apt/apt.conf.d/20auto-upgrades
 fi
 
+# Remove the stale OpenClaw firewall allow older provisions added — the
+# gateway binds loopback only and is reached via the manager's proxy, so the
+# rule just advertised a closed port. Idempotent, no-op without ufw.
+command -v ufw >/dev/null 2>&1 && ufw delete allow 18789/tcp >/dev/null 2>&1 || true
+
 # Migrate backup scheduling cron -> persistent systemd timer. Cron silently
 # skips runs the box sleeps through; the timer catches up on next boot. Only
 # when a cron entry exists (i.e. the user actually configured backups) —

--- a/src/app.py
+++ b/src/app.py
@@ -199,6 +199,17 @@ LOG_FILES = {
     "nuclear": f"{LOG_DIR}/nuclear_reset.log",
 }
 
+
+def compose_ps_q(service):
+    """Container ID of a compose service, or "" if not created/running."""
+    try:
+        return subprocess.check_output(
+            ["docker", "compose", "-f", COMPOSE_FILE, "ps", "-q", service],
+            stderr=subprocess.DEVNULL,
+        ).decode().strip()
+    except Exception:
+        return ""
+
 JOURNAL_SERVICES = {"openclaw", "llama-server"}
 
 # --- Logging Configuration (Global & Robust) ---
@@ -265,10 +276,7 @@ def _enforce_vault_signups_lockdown():
         return
 
     try:
-        db_cid = subprocess.check_output(
-            f"docker compose -f {COMPOSE_FILE} ps -q db",
-            shell=True, stderr=subprocess.DEVNULL,
-        ).decode().strip()
+        db_cid = compose_ps_q("db")
         if not db_cid:
             return
         out = subprocess.check_output(
@@ -470,7 +478,7 @@ def login():
         # Pre-Setup: Factory Sticker Password
         target_pass = get_factory_password()
 
-    if target_pass and password == target_pass:
+    if target_pass and hmac.compare_digest((password or "").encode(), target_pass.encode()):
         session['authenticated'] = True
         session.permanent = True  # Keep session active across browser restarts
         return jsonify({"status": "success", "redirect": "/"})
@@ -531,6 +539,10 @@ def get_local_version():
     return {"channel": "unknown", "ref": "unknown", "updated_at": "unknown"}
 
 def run_background_task(task_name, command, log_type):
+    # The one deliberate shell=True in this codebase: callers hand over
+    # internally-built command strings with log redirection (>> file 2>&1) and
+    # shlex.quote() at every interpolation. Never pass request data here
+    # unquoted.
     status = {
              "status": "running",
              "message": f"{task_name} in progress...",
@@ -883,17 +895,18 @@ def mount_drive():
     # 2. Get UUID and FSType from the target path
     try:
         # Check UUID/FSType of the identified partition/device
-        uuid_cmd = f"blkid -o value -s UUID {shlex.quote(target_path)}"
-        fstype_cmd = f"blkid -o value -s TYPE {shlex.quote(target_path)}"
-
-        uuid = subprocess.check_output(uuid_cmd, shell=True).decode().strip()
-        fstype = subprocess.check_output(fstype_cmd, shell=True).decode().strip()
+        uuid = subprocess.check_output(
+            ["blkid", "-o", "value", "-s", "UUID", target_path]).decode().strip()
+        fstype = subprocess.check_output(
+            ["blkid", "-o", "value", "-s", "TYPE", target_path]).decode().strip()
 
         if not uuid:
             # Fallback to the original whole-disk path if the partition check failed
             if target_path != drive_path:
-                uuid = subprocess.check_output(f"blkid -o value -s UUID {shlex.quote(drive_path)}", shell=True).decode().strip()
-                fstype = subprocess.check_output(f"blkid -o value -s TYPE {shlex.quote(drive_path)}", shell=True).decode().strip()
+                uuid = subprocess.check_output(
+                    ["blkid", "-o", "value", "-s", "UUID", drive_path]).decode().strip()
+                fstype = subprocess.check_output(
+                    ["blkid", "-o", "value", "-s", "TYPE", drive_path]).decode().strip()
                 if uuid:
                      target_path = drive_path # Use the whole disk path if it has a UUID
             
@@ -1040,17 +1053,17 @@ def system_status():
         # Docker Services Check
         # Get profiles dynamically from common.sh for consistency
         profiles = subprocess.check_output(
-            f"bash -c 'source {INSTALL_DIR}/scripts/common.sh; load_env; "
-            f"echo $(get_tunnel_profiles) $(get_vault_profiles)'",
-            shell=True,
+            ["bash", "-c",
+             f"source {INSTALL_DIR}/scripts/common.sh; load_env; "
+             "echo $(get_tunnel_profiles) $(get_vault_profiles)"],
         ).decode().strip()
 
-        compose_cmd = f"docker compose -f {COMPOSE_FILE} --env-file {ENV_FILE}"
+        compose_cmd = ["docker", "compose", "-f", COMPOSE_FILE, "--env-file", ENV_FILE]
         if os.path.exists(OVERRIDE_FILE):
-            compose_cmd += f" -f {OVERRIDE_FILE}"
-        compose_cmd += f" {profiles} ps --format '{{{{.Service}}}}:{{{{.State}}}}:{{{{.Health}}}}'"
+            compose_cmd += ["-f", OVERRIDE_FILE]
+        compose_cmd += profiles.split() + ["ps", "--format", "{{.Service}}:{{.State}}:{{.Health}}"]
 
-        out = subprocess.check_output(compose_cmd, shell=True).decode()
+        out = subprocess.check_output(compose_cmd).decode()
         tunnel_status = "stopped"
 
         for line in out.splitlines():
@@ -1079,8 +1092,8 @@ def system_status():
         # Maintenance Mode Check
         try:
             m_check = subprocess.check_output(
-                f"docker compose -f {COMPOSE_FILE} exec -u www-data nextcloud php occ maintenance:mode",
-                shell=True,
+                ["docker", "compose", "-f", COMPOSE_FILE, "exec", "-u", "www-data",
+                 "nextcloud", "php", "occ", "maintenance:mode"],
             ).decode()
             services["maintenance_mode"] = (
                 "enabled" if "enabled" in m_check else "disabled"
@@ -1116,13 +1129,11 @@ def system_status():
 
             # RAM
             # Because we used quoted EOF, $2 and $3 are preserved literally for awk here:
-            mem_info = (
-                subprocess.check_output(
-                    "free -m | awk '/Mem:/ {print $2 \" \" $3}'", shell=True
-                )
-                .decode()
-                .split()
-            )
+            mem_line = next(
+                line for line in subprocess.check_output(["free", "-m"]).decode().splitlines()
+                if line.startswith("Mem:")
+            ).split()
+            mem_info = mem_line[1:3]  # total, used
             if len(mem_info) == 2:
                 total_mem = int(mem_info[0])
                 used_mem = int(mem_info[1])
@@ -1207,7 +1218,7 @@ def client_log():
 def list_drives():
     try:
         root_dev = (
-            subprocess.check_output("findmnt -n -o SOURCE /", shell=True)
+            subprocess.check_output(["findmnt", "-n", "-o", "SOURCE", "/"])
             .decode()
             .strip()
         )
@@ -1222,7 +1233,7 @@ def list_drives():
         # SATA controller doesn't advertise removable media. TRAN=usb is
         # the truthful signal for an externally-attached drive.
         output = subprocess.check_output(
-            "lsblk -J -o NAME,SIZE,TYPE,MODEL,RM,MOUNTPOINT,TRAN", shell=True
+            ["lsblk", "-J", "-o", "NAME,SIZE,TYPE,MODEL,RM,MOUNTPOINT,TRAN"]
         ).decode()
         data = json.loads(output)
 
@@ -1231,14 +1242,12 @@ def list_drives():
         try:
             # Returns e.g. /dev/sda1
             backup_mount_source = (
-                subprocess.check_output(
-                    f"findmnt -n -o SOURCE {BACKUP_DIR} || true", shell=True
-                )
+                subprocess.check_output(["findmnt", "-n", "-o", "SOURCE", BACKUP_DIR])
                 .decode()
                 .strip()
             )
-        except:
-            pass
+        except Exception:
+            pass  # not mounted
 
         system_mounts = {'/', '/boot', '/boot/efi', '/opt/homebrain'}
 
@@ -1781,8 +1790,8 @@ def set_maintenance():
     flag = "--on" if mode == "on" else "--off"
     try:
         subprocess.check_call(
-            f"docker compose -f {COMPOSE_FILE} exec -u www-data nextcloud php occ maintenance:mode {flag}",
-            shell=True,
+            ["docker", "compose", "-f", COMPOSE_FILE, "exec", "-u", "www-data",
+             "nextcloud", "php", "occ", "maintenance:mode", flag],
         )
         return jsonify({"status": "success"})
     except Exception as e:
@@ -1888,8 +1897,8 @@ def trigger_upgrade():
     # We reuse the bash logic to ensure consistency with deploy.sh
     try:
         profiles = subprocess.check_output(
-            f"bash -c 'source {shlex.quote(INSTALL_DIR)}/scripts/common.sh; load_env; get_tunnel_profiles'", 
-            shell=True
+            ["bash", "-c",
+             f"source {INSTALL_DIR}/scripts/common.sh; load_env; get_tunnel_profiles"],
         ).decode().strip()
     except Exception as e:
         logging.error(f"Failed to fetch profiles: {e}")
@@ -2019,13 +2028,14 @@ def do_manager_update():
     except Exception:
         pass
 
-    cmd = (
-        f"echo 'Starting Manager Update ({shlex.quote(channel)})...' > {LOG_FILES['update']}; "
-        f"{SCRIPT_UPDATE} {shlex.quote(channel)} {shlex.quote(target_ref)} >> {LOG_FILES['update']} 2>&1"
-    )
-
     # Fire and forget thread, as the service will restart
-    threading.Thread(target=lambda: subprocess.run(cmd, shell=True)).start()
+    def _run_update():
+        with open(LOG_FILES["update"], "w") as log:
+            log.write(f"Starting Manager Update ({channel})...\n")
+            log.flush()
+            subprocess.run(["bash", SCRIPT_UPDATE, channel, target_ref],
+                           stdout=log, stderr=subprocess.STDOUT)
+    threading.Thread(target=_run_update).start()
 
     return jsonify({
         "status": "started",
@@ -2598,10 +2608,7 @@ def vault_status():
     }
     # Container running?
     try:
-        cid = subprocess.check_output(
-            f"docker compose -f {COMPOSE_FILE} ps -q vaultwarden",
-            shell=True, stderr=subprocess.DEVNULL,
-        ).decode().strip()
+        cid = compose_ps_q("vaultwarden")
         if cid:
             state = subprocess.check_output(
                 ["docker", "inspect", "-f", "{{.State.Health.Status}}", cid],
@@ -2614,10 +2621,7 @@ def vault_status():
     # User count: query the DB directly (avoids the admin-cookie JWT dance).
     if info["container"] in ("running", "healthy"):
         try:
-            db_cid = subprocess.check_output(
-                f"docker compose -f {COMPOSE_FILE} ps -q db",
-                shell=True, stderr=subprocess.DEVNULL,
-            ).decode().strip()
+            db_cid = compose_ps_q("db")
             db_name = env.get("VAULT_DB_NAME", "vaultwarden")
             db_user = env.get("VAULT_DB_USER", "vaultwarden_user")
             db_pass = env.get("VAULT_DB_PASSWORD", "")
@@ -2798,10 +2802,7 @@ def _vault_first_user_email():
     if not db_pass:
         return ""
     try:
-        db_cid = subprocess.check_output(
-            f"docker compose -f {COMPOSE_FILE} ps -q db",
-            shell=True, stderr=subprocess.DEVNULL,
-        ).decode().strip()
+        db_cid = compose_ps_q("db")
         if not db_cid:
             return ""
         out = subprocess.check_output(
@@ -3073,10 +3074,7 @@ def vault_docs_status():
         return jsonify({"error": "unauthenticated"}), 401
     info = {"e2ee_enabled": False, "folder_exists": False, "folder_url": ""}
     try:
-        nc_cid = subprocess.check_output(
-            f"docker compose -f {COMPOSE_FILE} ps -q nextcloud",
-            shell=True, stderr=subprocess.DEVNULL,
-        ).decode().strip()
+        nc_cid = compose_ps_q("nextcloud")
         if not nc_cid:
             return jsonify(info)
         out = subprocess.check_output(
@@ -3122,10 +3120,7 @@ def vault_docs_setup():
     if not session.get("authenticated"):
         return jsonify({"error": "unauthenticated"}), 401
     try:
-        nc_cid = subprocess.check_output(
-            f"docker compose -f {COMPOSE_FILE} ps -q nextcloud",
-            shell=True, stderr=subprocess.DEVNULL,
-        ).decode().strip()
+        nc_cid = compose_ps_q("nextcloud")
         if not nc_cid:
             return jsonify({"error": "Nextcloud container not running"}), 503
 
@@ -3200,10 +3195,7 @@ def vault_local_ca():
         return ("Local CA is only used in LAN-only deployments. "
                 "Remote-mode installs use Pangolin's public TLS chain."), 404
     try:
-        cid = subprocess.check_output(
-            f"docker compose -f {COMPOSE_FILE} ps -q caddy",
-            shell=True, stderr=subprocess.DEVNULL,
-        ).decode().strip()
+        cid = compose_ps_q("caddy")
         if not cid:
             return "Caddy container not running.", 503
         # Caddy stores its internal CA root at a known path inside the

--- a/src/app.py
+++ b/src/app.py
@@ -413,13 +413,17 @@ except Exception as e:
 def get_task_status():
     return jsonify(read_status())
 
-# Initialize Limiter with memory storage
-# Uses remote IP for identification.
+# Rate limits live in the stack's Redis (loopback-published) so all gunicorn
+# workers share one counter — in-memory storage counted per worker, turning
+# "5 per minute" into 15. Uses remote IP for identification. If Redis is down
+# (e.g. during boot) the limiter falls back to per-worker memory rather than
+# failing requests.
 limiter = Limiter(
     get_remote_address,
     app=app,
     default_limits=["2000 per minute"], # High limit to prevent dashboard polling blocks
-    storage_uri="memory://"
+    storage_uri="redis://127.0.0.1:6379/1",
+    in_memory_fallback_enabled=True,
 )
 
 # Mount the OpenClaw integrations module — adds /api/integrations/* routes


### PR DESCRIPTION
Phase 3 of the product review plan (docs/plans/PRODUCT_REVIEW_2026-07.md), all items except the Caddy LAN-HTTPS edge — deferred with rationale recorded in the plan doc: both production boxes are remote-mode (Pangolin already provides end-to-end TLS) and the edge would entangle the pre-stack bootstrap flow where the dashboard must run without containers.

## Changes
- **`shell=True` sweep**: 22 of 23 sites in app.py become list-args subprocess calls or plain Python; 7 duplicated `docker compose ps -q` strings collapse into one `compose_ps_q()` helper. The single survivor (`run_background_task`, needs the shell for log redirection) carries an allowlist comment for the future CI grep gate.
- **`hmac.compare_digest`** for the dashboard login comparison.
- **Shared rate-limit storage in Redis** (loopback-only port publish): 3 gunicorn workers previously counted limits per worker in memory, so "5/min" on /login was really up to 15, resetting on restart. In-memory fallback keeps the dashboard working when Redis is down (boot, restarts).
- **unattended-upgrades**: nightly OS security patches (Debian defaults — security origin only, no auto-reboots). Fresh provisions via common_pkgs; existing boxes via update.sh's idempotent ensure block.
- **Dead 18789 ufw rule dropped** (provision) + deleted on update: the OpenClaw gateway binds loopback only (verified live with `ss`) and is reached through the manager's authenticated proxy. Default on-box ufw stance stays opt-in: Docker bypasses ufw INPUT for published ports anyway, and enabling a firewall over a remote update risks SSH lockout for no gain.
- **newt loses docker.sock**: audit conclusion — newt used it only for optional container discovery in the Pangolin UI; tunnel targets resolve via compose-network DNS. Socket API access is root-equivalent (":ro" only protects the file), and newt is the one third-party binary talking to the internet edge.

## E2E on production (.58)
- Deploy mirrored update.sh's order (venv dep → compose → code → restart); manager healthy.
- Login OK (compare_digest path); `/api/drives` exercises the lsblk/findmnt conversions.
- **Rate limit now exact**: 1 valid + 4 wrong logins → 429 on the 6th request; `LIMITS:*` keys live in Redis db 1.
- **Tunnel verified without docker.sock**: newt recreated with zero mounts; `https://nc.berlin.homebrain.house/status.php` → HTTP 200 through Pangolin.
- unattended-upgrades installed, 20auto-upgrades written, `apt-daily-upgrade.timer` enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)