### PR TITLE
feat(backup): internal-disk backup storage for boxes without a drive

### DIFF
--- a/config/.env.template
+++ b/config/.env.template
@@ -38,6 +38,10 @@ BACKUP_VERIFY=true
 BACKUP_OPENCLAW_WORKSPACE=true        # Include OpenClaw agent workspace in backups (opt-out)
 BACKUP_OPENCLAW_EXCLUDE_CACHES=false  # Exclude workspace/cache/ subtree to reduce size
 BACKUP_OPENCLAW_SIZE_WARN_MB=500      # Warn (not fail) if workspace exceeds this size in MB
+# No-drive mode: keep archives on the internal disk (BACKUP_MOUNTDIR points
+# at a root-disk path). Meant to be paired with the off-site copy below —
+# the mirror is the real protection then.
+BACKUP_INTERNAL=false
 # --- Off-site backup copy ---
 # Mirror the (encrypted) backup archives to one remote via rclone.
 # OFFSITE_TYPE: sftp | webdav | s3

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -80,7 +80,14 @@ esac
 log_info "=== Starting Backup [Strategy: $STRATEGY]: $(date) ==="
 
 # 1. Mount Check
-if ! mountpoint -q "$BACKUP_MOUNTDIR"; then
+# BACKUP_INTERNAL=true (with BACKUP_MOUNTDIR pointing at a root-disk path)
+# is the no-drive mode: archives live on the internal disk purely as the
+# staging set for the off-site mirror — the mirror is the actual protection.
+# The mount check stays mandatory otherwise, so a fallen-off USB drive can
+# never silently fill the root disk.
+if [[ "${BACKUP_INTERNAL:-false}" == "true" ]]; then
+    mkdir -p "$BACKUP_MOUNTDIR"
+elif ! mountpoint -q "$BACKUP_MOUNTDIR"; then
     log_info "Attempting to mount $BACKUP_MOUNTDIR..."
     mount "$BACKUP_MOUNTDIR" || die "Failed to mount backup drive."
 fi

--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -150,7 +150,10 @@ def check_backup(env, now):
     if not scheduled:
         return {"id": "backup", "level": "warn",
                 "summary": "Automatic backups are not set up"}
-    if not os.path.ismount(BACKUP_DIR):
+    # Internal-storage mode (no drive): the directory lives on the root disk,
+    # so "not mounted" is normal and disk_root covers the space check.
+    internal = env.get("BACKUP_INTERNAL", "false").lower() == "true"
+    if not internal and not os.path.ismount(BACKUP_DIR):
         return {"id": "backup", "level": "crit",
                 "summary": "Backup drive is not connected"}
 
@@ -421,6 +424,7 @@ def has_gpu(env):
 
 
 def main():
+    global BACKUP_DIR
     now = time.time()
     os.makedirs(STATE_DIR, exist_ok=True)
     try:
@@ -428,6 +432,7 @@ def main():
             env = parse_env(f.read())
     except OSError:
         env = {}
+    BACKUP_DIR = env.get("BACKUP_MOUNTDIR", BACKUP_DIR)
     try:
         with open(STATE_FILE) as f:
             state = json.load(f)

--- a/src/app.py
+++ b/src/app.py
@@ -618,6 +618,17 @@ def get_env_config():
     return config
 
 
+def backup_storage_dir():
+    """Where archives live: the backup drive, or an internal path in the
+    no-drive mode (BACKUP_INTERNAL=true). Drive-management flows keep using
+    the BACKUP_DIR constant — that is where a physical drive mounts."""
+    return get_env_config().get("BACKUP_MOUNTDIR") or BACKUP_DIR
+
+
+def backup_storage_internal():
+    return get_env_config().get("BACKUP_INTERNAL", "false") == "true"
+
+
 def update_env_var(key, value):
     try:
         # If value is None, remove the line
@@ -1346,14 +1357,18 @@ def format_drive():
 # --- Routes: Backup Config & Stats ---
 @app.route("/api/backup/stats")
 def backup_stats():
-    # Check if mounted
-    if not os.path.ismount(BACKUP_DIR):
-        return jsonify({"mounted": False, "free_gb": 0, "total_gb": 0, "percent": 0})
+    target = backup_storage_dir()
+    internal = backup_storage_internal()
+    if not internal and not os.path.ismount(target):
+        return jsonify({"mounted": False, "internal": False,
+                        "free_gb": 0, "total_gb": 0, "percent": 0})
     try:
-        total, used, free = shutil.disk_usage(BACKUP_DIR)
+        os.makedirs(target, exist_ok=True)
+        total, used, free = shutil.disk_usage(target)
         return jsonify(
             {
                 "mounted": True,
+                "internal": internal,
                 "free_gb": round(free / (1024**3), 2),
                 "total_gb": round(total / (1024**3), 2),
                 "used_gb": round(used / (1024**3), 2),
@@ -1361,7 +1376,22 @@ def backup_stats():
             }
         )
     except:
-        return jsonify({"mounted": False, "error": "Disk check failed"})
+        return jsonify({"mounted": False, "internal": internal, "error": "Disk check failed"})
+
+
+@app.route("/api/backup/internal", methods=["POST"])
+@limiter.limit("5 per minute")
+def backup_internal():
+    enabled = bool(request.json.get("enabled"))
+    if enabled and os.path.ismount(BACKUP_DIR):
+        return jsonify({"error": "A backup drive is connected — use that instead"}), 400
+    if enabled:
+        update_env_var("BACKUP_INTERNAL", "true")
+        update_env_var("BACKUP_MOUNTDIR", "/var/backups/homebrain")
+    else:
+        update_env_var("BACKUP_INTERNAL", "false")
+        update_env_var("BACKUP_MOUNTDIR", "/mnt/backup")
+    return jsonify({"status": "success"})
 
 
 @app.route("/api/backup/config", methods=["GET", "POST"])
@@ -1561,10 +1591,11 @@ def trigger_backup():
 @app.route("/api/backups/list")
 def list_backups():
     backups = []
-    if os.path.exists(BACKUP_DIR):
-        for f in os.listdir(BACKUP_DIR):
+    storage = backup_storage_dir()
+    if os.path.exists(storage):
+        for f in os.listdir(storage):
             if f.endswith(".tar.gz") or f.endswith(".tar.gz.gpg"):
-                path = os.path.join(BACKUP_DIR, f)
+                path = os.path.join(storage, f)
                 try:
                     size = os.path.getsize(path) / (1024 * 1024)
                     # Infer type from filename injected by backup.sh
@@ -1593,7 +1624,7 @@ def trigger_restore():
     if not filename or "/" in filename:
         return jsonify({"error": "Invalid filename"}), 400
 
-    full_path = os.path.join(BACKUP_DIR, filename)
+    full_path = os.path.join(backup_storage_dir(), filename)
 
     # Optional passphrase for encrypted archives made under a DIFFERENT master
     # password (pre-rotation or from another box). Passed via a root-only temp

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -592,6 +592,10 @@
                 <p>Manage external USB storage devices.</p>
                 <div id="drive-list" style="margin-bottom:15px;">Loading drives...</div>
                 <button onclick="loadDrives()">Scan for Drives</button>
+                <label style="display:flex; align-items:center; gap:10px; cursor:pointer; margin-top:12px;">
+                    <input type="checkbox" id="internal-backup" style="width:auto;" onchange="toggleInternalBackup(this.checked)">
+                    <span>No drive — keep backups on the internal disk (pair with Off-site Copy)</span>
+                </label>
 
                 <hr>
                 
@@ -3071,13 +3075,24 @@
 
                 if (d.mounted) {
                     bar.style.width = d.percent + '%';
-                    txt.innerText = `${d.used_gb} GB Used / ${d.total_gb} GB Total`;
+                    txt.innerText = `${d.used_gb} GB Used / ${d.total_gb} GB Total` + (d.internal ? ' (internal disk)' : '');
                     bar.style.backgroundColor = d.percent > 90 ? 'var(--hb-danger)' : 'var(--hb-green)';
                 } else {
                     bar.style.width = '0%';
                     txt.innerText = 'Not Mounted';
                 }
+                const cb = document.getElementById('internal-backup');
+                if (cb) cb.checked = !!d.internal;
             } catch (e) { }
+        }
+
+        async function toggleInternalBackup(enabled) {
+            const res = await fetch('/api/backup/internal', { method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({ enabled: enabled }) });
+            const d = await res.json().catch(() => ({}));
+            if (!res.ok) {
+                alert(d.error || 'Could not change backup storage.');
+            }
+            loadDiskStats();
         }
 
         async function loadBackupConfig() {


### PR DESCRIPTION
Enables data protection for boxes that have no backup drive attached (the miami production box has none): `BACKUP_INTERNAL=true` keeps archives on the root disk (default `/var/backups/homebrain`), intended to pair with the off-site mirror as the real protection. The mount requirement stays mandatory otherwise, so a fallen-off USB drive can never silently fill the root disk; enabling internal mode is refused while a drive is mounted.

Touches: backup.sh (mkdir instead of mount/die in internal mode — space estimation, emergency prune, retention and the off-site step already work on any path), healthcheck.py (no false "drive not connected" crit; honours BACKUP_MOUNTDIR), app.py (stats/list/restore use the configured storage dir; POST /api/backup/internal toggle; drive-management flows keep the /mnt/backup constant), dashboard checkbox, .env.template.

## E2E on production (.58)
- Guard verified: POST enable with a drive mounted → 400 "A backup drive is connected".
- Env-level internal mode: `--strategy system` backup wrote, encrypted, and **verified** an archive to `/var/backups/homebrain` (5.0 GB — .58's agent workspace has grown to 23 GB of real project data, included by design via BACKUP_OPENCLAW_WORKSPACE).
- Healthcheck: no drive-not-connected crit in internal mode; all-ok after restoring drive mode.
- 13/13 healthcheck unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)