### PR TITLE
fix(update): pre-update snapshots in internal-storage mode

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -181,7 +181,9 @@ rsync -a --delete \
 # not make updates impossible, but we warn loudly. SKIP_PREUPDATE_BACKUP=1
 # skips it.
 if [[ -f "$INSTALL_DIR/.setup_complete" && "${SKIP_PREUPDATE_BACKUP:-0}" != "1" ]]; then
-    if mountpoint -q /mnt/backup 2>/dev/null; then
+    # Internal-storage mode has no mountpoint — backup.sh mkdirs its own dir.
+    if [[ "${BACKUP_INTERNAL:-false}" == "true" ]] \
+        || mountpoint -q "${BACKUP_MOUNTDIR:-/mnt/backup}" 2>/dev/null; then
         log_info "Taking pre-update system snapshot..."
         if bash "$INSTALL_DIR/scripts/backup.sh" --strategy system; then
             log_info "Pre-update snapshot complete."


### PR DESCRIPTION
Found by the miami rollout E2E: the pre-update snapshot gate hardcodes `mountpoint -q /mnt/backup`, so a box on internal backup storage (#123) silently skips its restore point ("No backup drive mounted — skipping pre-update snapshot"). The gate now honours `BACKUP_INTERNAL` and the configured `BACKUP_MOUNTDIR`, exactly like backup.sh. Delivery to already-updated boxes is free: update.sh self-updates from the target ref **before** the snapshot step, so the next update runs the fixed gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)