### PR TITLE
ci: Phase 1 safety net

### DIFF
--- a/.github/check_shell_true.py
+++ b/.github/check_shell_true.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""CI gate: exactly one shell=True call site is allowed in the codebase —
+run_background_task in src/app.py, which needs the shell for log redirection
+and documents its contract. Comments don't count. Anything else fails."""
+import pathlib
+import sys
+
+ALLOWED = ("src/app.py", "run_background_task")
+
+violations = []
+allowed_seen = 0
+for path in pathlib.Path(".").glob("**/*.py"):
+    parts = path.parts
+    if parts[0] not in ("src", "scripts") or "tests" in parts:
+        continue
+    lines = path.read_text(errors="replace").splitlines()
+    for i, line in enumerate(lines, 1):
+        if "shell=True" not in line or line.strip().startswith("#"):
+            continue
+        # The allowed site: inside run_background_task in src/app.py. Anchor on
+        # the enclosing def by scanning backwards for the nearest function.
+        context = next((l for l in reversed(lines[:i]) if l.startswith("def ")), "")
+        if str(path) == ALLOWED[0] and ALLOWED[1] in context:
+            allowed_seen += 1
+            continue
+        violations.append(f"{path}:{i}: {line.strip()}")
+
+if violations:
+    print("shell=True is forbidden (list-args subprocess only). Violations:")
+    print("\n".join(violations))
+    sys.exit(1)
+if allowed_seen != 1:
+    print(f"Expected exactly 1 allowed shell=True site, found {allowed_seen} — "
+          "update .github/check_shell_true.py if this moved deliberately.")
+    sys.exit(1)
+print("shell=True gate: OK (1 documented site)")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: shellcheck (error severity)
+        run: |
+          sudo apt-get install -y -qq shellcheck
+          shellcheck -S error scripts/*.sh
+      - name: ruff (syntax errors + real defects)
+        run: |
+          pip install -q ruff
+          # E9 = syntax errors, F = undefined names / unused imports & vars.
+          # Style classes (E7xx) are deliberately not gated.
+          ruff check src/ scripts/ --select E9,F
+      - name: compileall
+        run: python3 -m compileall -q src/ scripts/
+      - name: shell=True gate
+        run: python3 .github/check_shell_true.py
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: pytest
+        run: |
+          pip install -q pytest cryptography
+          python3 -m pytest scripts/tests/test_healthcheck.py scripts/tests/test_recovery.py -q
+      - name: backup encryption round-trip (gpg)
+        run: bash scripts/tests/test_backup_encryption.sh
+      - name: update guard
+        run: bash scripts/tests/test_update_guard.sh
+
+  compose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: docker compose config
+        run: |
+          cp config/.env.template .env
+          docker compose -f docker-compose.yml config > /dev/null

--- a/scripts/mcp-email.py
+++ b/scripts/mcp-email.py
@@ -21,7 +21,6 @@ plaintext (development mode). The dashboard always sets it on the live box.
 """
 from __future__ import annotations
 
-import base64
 import email
 import imaplib
 import json
@@ -30,7 +29,6 @@ import smtplib
 import sys
 from email.message import EmailMessage
 from email.utils import parsedate_to_datetime
-from typing import Any
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from mcp_common import (  # noqa: E402

--- a/scripts/mcp-nextcloud.py
+++ b/scripts/mcp-nextcloud.py
@@ -35,7 +35,6 @@ import sys
 import urllib.error
 import urllib.request
 import xml.etree.ElementTree as ET
-from typing import Any
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from mcp_common import (  # noqa: E402

--- a/scripts/whisper_proxy.py
+++ b/scripts/whisper_proxy.py
@@ -13,7 +13,6 @@ import os
 import json
 import urllib.request
 import re
-import sys
 
 WHISPER_UPSTREAM = os.environ.get("WHISPER_UPSTREAM", "http://127.0.0.1:8003")
 PORT = int(os.environ.get("WHISPER_PROXY_PORT", "8002"))

--- a/src/app.py
+++ b/src/app.py
@@ -1207,7 +1207,7 @@ def get_logs(log_target):
             cmd_list, stderr=subprocess.STDOUT
         ).decode()
         return output
-    except subprocess.CalledProcessError as e:
+    except subprocess.CalledProcessError:
         return "Failed to fetch docker logs. Service might not be running."
     except Exception as e:
         return f"Error: {str(e)}"
@@ -2148,7 +2148,6 @@ def set_ai_model():
         if not model:
             return jsonify({"error": f"Unknown model: {model_id}"}), 400
 
-        server_defaults = all_models.get("llama_server", {})
         update_env_var("AI_MODEL_ID", model["id"])
         update_env_var("AI_MODEL_FILENAME", model["filename"])
         update_env_var("AI_MODEL_URL", model["url"])
@@ -2180,7 +2179,6 @@ def switch_ai_model():
         if not model:
             return jsonify({"error": f"Unknown model: {model_id}"}), 400
 
-        server_defaults = all_models.get("llama_server", {})
         update_env_var("AI_MODEL_ID", model["id"])
         update_env_var("AI_MODEL_FILENAME", model["filename"])
         update_env_var("AI_MODEL_URL", model["url"])
@@ -2485,7 +2483,7 @@ def _openclaw_ws_handle(ws, subpath):
     except Exception as e:
         logging.warning("OpenClaw WS upstream connect failed: %s", e)
         try:
-            ws.close(reason=f"upstream_unreachable")
+            ws.close(reason="upstream_unreachable")
         except Exception:
             pass
         return


### PR DESCRIPTION
Phase 1 of the product review plan — the CI safety net that was deliberately ordered before Phase 2 and got skipped. Every check here is one we've been running by hand on every change: shellcheck (error severity), ruff `--select E9,F` (real defects only, style ungated), compileall, pytest (healthcheck 13 + recovery 9), the gpg backup round-trip suite, the update-guard suite (30 cases), `docker compose config`, and a `shell=True` gate that allows exactly the one documented `run_background_task` site (#120).

Includes clearing the 8 pre-existing F-class findings the new gate catches (unused imports, two dead assignments).

This PR's own checks run is the E2E for the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)