### PR TITLE
feat(health): surface pending OS security reboots

### DIFF
--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -43,6 +43,7 @@ BACKUP_DIR = "/mnt/backup"
 BACKUP_LOG = "/var/log/homebrain/backup.log"
 BACKUP_CRON_FILE = "/etc/cron.d/homebrain-backup"
 OFFSITE_STATE = f"{STATE_DIR}/offsite.json"
+REBOOT_REQUIRED_FILE = "/var/run/reboot-required"
 HOMEBRAIN_HOME = "/home/homebrain"
 OPENCLAW_DIR = f"{HOMEBRAIN_HOME}/.openclaw"
 OPENCLAW_PORT = 18789
@@ -340,6 +341,23 @@ def check_update(state, now):
     return {"id": "update", "level": "ok", "summary": "HomeBrain is up to date"}
 
 
+def check_reboot():
+    """unattended-upgrades never reboots on its own (deliberate — this is a
+    NAS), so a kernel/libc patch waits invisibly until the next manual
+    restart. Surface it. warn-only: the box keeps working, just on old code."""
+    if not os.path.exists(REBOOT_REQUIRED_FILE):
+        return {"id": "reboot", "level": "ok", "summary": "No restart pending"}
+    pkgs = []
+    try:
+        with open(REBOOT_REQUIRED_FILE + ".pkgs") as f:
+            pkgs = sorted({line.strip() for line in f if line.strip()})
+    except OSError:
+        pass
+    detail = f" ({', '.join(pkgs[:3])})" if pkgs else ""
+    return {"id": "reboot", "level": "warn",
+            "summary": f"Restart this box to finish OS security updates{detail}"}
+
+
 # ---------------------------------------------------------------------------
 # Push delivery via OpenClaw
 # ---------------------------------------------------------------------------
@@ -451,6 +469,7 @@ def main():
         check_containers(),
         check_openclaw_gateway(gpu),
         check_update(state, now),
+        check_reboot(),
     ] if c]
 
     overall = "ok"

--- a/scripts/tests/test_healthcheck.py
+++ b/scripts/tests/test_healthcheck.py
@@ -14,6 +14,7 @@ from healthcheck import (  # noqa: E402
     DAY,
     backup_log_outcome,
     check_offsite,
+    check_reboot,
     compose_message,
     decide_notification,
     disk_level,
@@ -154,6 +155,28 @@ def test_offsite_stale_and_fresh():
     weekly = _offsite({"OFFSITE_ENABLED": "true", "BACKUP_DAY_WEEK": "0"},
                       {"ts": NOW - 6 * DAY, "ok": True})
     assert weekly["level"] == "ok"
+
+
+def test_reboot_not_pending_is_ok():
+    with tempfile.TemporaryDirectory() as d:
+        healthcheck.REBOOT_REQUIRED_FILE = os.path.join(d, "reboot-required")
+        c = check_reboot()
+        assert c["level"] == "ok"
+
+
+def test_reboot_pending_warns_with_packages():
+    with tempfile.TemporaryDirectory() as d:
+        marker = os.path.join(d, "reboot-required")
+        healthcheck.REBOOT_REQUIRED_FILE = marker
+        open(marker, "w").close()
+        c = check_reboot()
+        assert c["level"] == "warn" and "Restart" in c["summary"]
+        # duplicate package lines collapse; detail lists them
+        with open(marker + ".pkgs", "w") as f:
+            f.write("linux-image-generic\nlibc6\nlinux-image-generic\n")
+        c = check_reboot()
+        assert c["level"] == "warn"
+        assert "libc6" in c["summary"] and c["summary"].count("linux-image") == 1
 
 
 def test_compose_message():


### PR DESCRIPTION
unattended-upgrades never reboots on its own (deliberate — this is a NAS), so kernel/libc patches wait invisibly for the next manual restart. This adds a warn-only health check: warn when `/var/run/reboot-required` exists, with deduped package detail from `.pkgs`; ok otherwise. No UI work — the dashboard banner and Telegram push render checks generically.

**E2E on .58 (production):**
- ok path: `{"id":"reboot","level":"ok","summary":"No restart pending"}` in `/api/health`
- warn path: real marker + pkgs file → `Restart this box to finish OS security updates (linux-image-generic)` and a live Telegram alert delivered
- recovery: marker removed → back to ok

2 new pytest cases (15 total pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)