### PR TITLE
chore(ai): OpenClaw 2026.6.8 → 2026.7.1-2 + nodejs engines auto-upgrade

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -7,7 +7,7 @@
     "git_ref": "v1.8.4"
   },
   "openclaw": {
-    "version": "2026.6.8"
+    "version": "2026.7.1-2"
   },
   "vaultwarden": {
     "tag": "1.36.0"

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1594,6 +1594,14 @@ setup_openclaw() {
             apt-get install -y -qq nodejs
         fi
 
+        # OpenClaw's engines range moves at PATCH granularity (2026.7.1
+        # wants >=22.22.3; a box provisioned a month earlier has 22.22.2).
+        # The major-version guard above can't see that, so always pull the
+        # latest 22.x from the NodeSource repo — a no-op when current.
+        wait_for_apt_lock
+        DEBIAN_FRONTEND=noninteractive apt-get install --only-upgrade -y -qq nodejs 2>/dev/null \
+            || log_warn "nodejs upgrade failed — openclaw may refuse to run if its engines range moved."
+
         log_info "Node $(node --version)"
         log_info "Installing openclaw@${OPENCLAW_VERSION}..."
         if npm install -g "openclaw@${OPENCLAW_VERSION}" --no-fund --no-audit; then


### PR DESCRIPTION
First OpenClaw bump since going Telegram-only (#127) — no plugin lockstep, so the bump itself is one line in `versions.json`.

**What the E2E surfaced and fixed:** OpenClaw's `engines` range moves at **patch** granularity (2026.7.1 requires node ≥22.22.3; berlin had 22.22.2 from provision time). `setup_openclaw` only guarded the **major** version, so the new binary refused to run. Fix: idempotent `apt-get install --only-upgrade nodejs` (NodeSource repo) before every OpenClaw install — no-op when current.

**E2E on .58 (production):**
- node 22.22.2 → 22.23.1, clean npm install of 2026.7.1-2
- new-version startup migrations ran (one stale-lock crash-loop rode systemd's rate limit; resolved at lock expiry — no manual intervention needed beyond `reset-failed`)
- gateway healthy on :18789, unit shows v2026.7.1-2
- config sanity: telegram enabled, model primary + 80K ctx preserved, no whatsapp keys
- Telegram round-trip delivered; **live agent turn** → llama-server → "pong"
- 23G workspace intact; health: `openclaw=ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)