### PR TITLE
chore(deps): gunicorn 23→26, gevent 25.5→26.5, redis-py 7→8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,15 +2,15 @@ Flask==3.1.3
 requests==2.34.2
 python-dotenv==1.2.2
 flask-limiter==4.1.1
-redis==7.0.1
-gunicorn==23.0.0
+redis==8.0.1
+gunicorn==26.0.0
 cryptography==49.0.0
 # OpenClaw control UI is proxied through the manager so a single
 # authenticated origin (master-password session) serves both. WS support
 # requires a non-blocking worker; gevent monkey-patches the stdlib at
 # gunicorn startup, simple-websocket is the server-side WS lib used by
 # flask-sock, and websocket-client handles the upstream WS leg.
-gevent==25.5.1
+gevent==26.5.0
 flask-sock==0.7.0
 simple-websocket==1.1.0
 websocket-client==1.9.0


### PR DESCRIPTION
Releases the three holds from #121, with the WS-focused E2E they were held for.

**Changelog gates:** gunicorn 26 removes only the eventlet worker (we're on gevent, which is first-class through 26 — HTTP/2 support, stricter RFC 9110/9112 request parsing); gevent 26.5.0 has no monkey-patching changes and supports our Python; redis-py 8 defaults to RESP3 with legacy-compatible response shapes + 5s socket timeouts — we only touch it through flask-limiter on loopback.

**E2E on .58 (production):**
- manager restarts clean on gunicorn 26.0.0 / gevent 26.5.0 / redis 8.0.1
- login rate limit → 429 at the limit (flask-limiter → limits → redis-py 8, storage `redis://127.0.0.1:6379/1`)
- authenticated WS via `/openclaw` proxy: **101 upgrade + gateway `connect.challenge` frame streamed back** — the full gunicorn → flask-sock → gevent greenlets → websocket-client chain
- unauthenticated WS rejected at handshake; clean close works; task API healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)