### PR TITLE
chore(nextcloud): 32.0.12 → 33.0.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       retries: 5
 
   nextcloud:
-    image: nextcloud:32.0.12-apache
+    image: nextcloud:33.0.6-apache
     restart: unless-stopped
     ports:
       - "${NEXTCLOUD_PORT:-8080}:80"


### PR DESCRIPTION
Single-major step (32→33) on the supported path — the official image entrypoint performs the code update and `occ upgrade` on first start. MariaDB 11.4 LTS and the in-image PHP 8.4 are both in NC 33's support matrix.

**E2E on .58 (production):**
- Pre-upgrade **system snapshot** taken first (69M encrypted, includes DB dump — the rollback point; NC upgrades are one-way)
- `docker compose pull && up -d nextcloud` → entrypoint upgrade, zero manual steps
- `occ status`: 33.0.6.2, `needsDbUpgrade: false`, maintenance off
- `occ app:update --all`: all current; nothing disabled by the upgrade
- WebDAV PROPFIND as admin: 207 (auth + files subsystem)
- `replica` account (miami's off-site target): enabled, data intact
- Public login page 200 through Pangolin; health: containers=ok

**Miami note:** rides the next stable release; its pre-update snapshot lands on the internal disk (#124), and `occ upgrade` touches DB+code only — never the 426 GB of user files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)