### PR TITLE
fix(update): pre-update snapshots skip the off-site mirror

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -9,6 +9,7 @@ source "$SCRIPT_DIR/common.sh"
 LOCK_FILE="/var/run/homebrain-backup.lock"
 BACKUP_LOG_FILE="$LOG_DIR/backup.log"
 STRATEGY="full"
+SKIP_OFFSITE="false"
 
 # Parse Args
 while [[ $# -gt 0 ]]; do
@@ -16,6 +17,10 @@ while [[ $# -gt 0 ]]; do
     --strategy)
       STRATEGY="$2"
       shift 2
+      ;;
+    --skip-offsite)
+      SKIP_OFFSITE="true"
+      shift
       ;;
     *)
       shift
@@ -466,7 +471,10 @@ log_info "=== Backup Complete: $ARCHIVE_PATH ==="
 # local backup is done, and a slow WAN upload must not make this run look
 # failed or stuck to the health check. Failure is non-fatal — it is recorded
 # in a state file the health check reads, and warned about here.
-if [[ "${OFFSITE_ENABLED:-false}" == "true" ]]; then
+# --skip-offsite exists for callers that hold the box hostage while this
+# script runs — update.sh's pre-update snapshot would otherwise block the
+# whole update behind a multi-hour WAN mirror. The scheduled backup mirrors.
+if [[ "${OFFSITE_ENABLED:-false}" == "true" && "$SKIP_OFFSITE" != "true" ]]; then
     OFFSITE_STATE="/var/lib/homebrain/offsite.json"
     mkdir -p /var/lib/homebrain
     log_info "Mirroring backups off-site (${OFFSITE_TYPE:-unset})..."

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -185,7 +185,11 @@ if [[ -f "$INSTALL_DIR/.setup_complete" && "${SKIP_PREUPDATE_BACKUP:-0}" != "1" 
     if [[ "${BACKUP_INTERNAL:-false}" == "true" ]] \
         || mountpoint -q "${BACKUP_MOUNTDIR:-/mnt/backup}" 2>/dev/null; then
         log_info "Taking pre-update system snapshot..."
-        if bash "$INSTALL_DIR/scripts/backup.sh" --strategy system; then
+        # --skip-offsite: this snapshot is a LOCAL rollback point and the
+        # update blocks until backup.sh exits — without the flag a configured
+        # off-site mirror turns every update into a multi-hour WAN upload.
+        # The scheduled backup mirrors on its own cadence.
+        if bash "$INSTALL_DIR/scripts/backup.sh" --strategy system --skip-offsite; then
             log_info "Pre-update snapshot complete."
         else
             log_warn "PRE-UPDATE SNAPSHOT FAILED — continuing, but there is no fresh restore point for this update."


### PR DESCRIPTION
Found live during the v2026.07.20 release train — the first update ever run on a box with off-site enabled.

`backup.sh` runs the off-site mirror inline (after the Complete marker), and `update.sh` blocks on `backup.sh` — so the pre-update snapshot stalled the whole update behind a ~178G WAN upload. The snapshot is a **local rollback point**; mirroring is the scheduled backup's job.

New `--skip-offsite` flag on backup.sh; the pre-update snapshot call passes it. Scheduled/manual backups are unaffected.

**E2E on .58:** `backup.sh --strategy system --skip-offsite` → real 71M encrypted snapshot, no `Mirroring` log line, no rclone process. Berlin's actual update was unblocked by killing the inline mirror once; this removes the need permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)