### PR TITLE
fix(health): stop advertising older releases as available updates

### DIFF
--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -313,6 +313,16 @@ def check_containers():
     return {"id": "containers", "level": "ok", "summary": "Containers healthy"}
 
 
+def release_key(tag):
+    """Sortable key for a release tag (v2026.07.21, v1.1.0, v0.1).
+
+    Returns None for anything that isn't a dotted numeric tag, which the
+    caller treats as "cannot order" rather than "differs".
+    """
+    m = re.fullmatch(r"v?(\d+(?:\.\d+)*)", (tag or "").strip())
+    return tuple(int(p) for p in m.group(1).split(".")) if m else None
+
+
 def check_update(state, now):
     """Once a day, on the stable channel only: is a newer release out?
     info-level — surfaces in the banner and one push per new version."""
@@ -323,8 +333,14 @@ def check_update(state, now):
         return None
     if version.get("channel") != "stable":
         return None
+    installed = version.get("ref", "")
+
+    # The cached tag is only meaningful for the version it was compared
+    # against. Without this an update installed since the last probe leaves a
+    # day-old `latest` in place that can predate what is now on disk.
     upd = state.setdefault("update", {})
-    if now - upd.get("ts", 0) < UPDATE_CHECK_SECS and upd.get("latest"):
+    fresh = now - upd.get("ts", 0) < UPDATE_CHECK_SECS
+    if fresh and upd.get("latest") and upd.get("installed") == installed:
         latest = upd["latest"]
     else:
         try:
@@ -332,10 +348,17 @@ def check_update(state, now):
                                          headers={"User-Agent": "homebrain-health"})
             with urllib.request.urlopen(req, timeout=6) as resp:
                 latest = json.load(resp).get("tag_name", "")
-            upd["ts"], upd["latest"] = now, latest
+            upd["ts"], upd["latest"], upd["installed"] = now, latest, installed
         except Exception:
             return None
-    if latest and latest != version.get("ref"):
+
+    # Order the tags rather than comparing them for inequality: a plain !=
+    # reports *any* difference as an available update, including a release
+    # older than the one installed. Updates are one-way (see the downgrade
+    # guard in common.sh), so nagging the user toward an older tag sends them
+    # at something update.sh will refuse. Unorderable tags stay quiet.
+    cur, new = release_key(installed), release_key(latest)
+    if cur and new and new > cur:
         return {"id": "update", "level": "info",
                 "summary": f"Update {latest} is available — install it from the dashboard"}
     return {"id": "update", "level": "ok", "summary": "HomeBrain is up to date"}

--- a/scripts/tests/test_healthcheck.py
+++ b/scripts/tests/test_healthcheck.py
@@ -15,11 +15,13 @@ from healthcheck import (  # noqa: E402
     backup_log_outcome,
     check_offsite,
     check_reboot,
+    check_update,
     compose_message,
     decide_notification,
     disk_level,
     expected_backup_interval,
     parse_env,
+    release_key,
 )
 
 NOW = 1_800_000_000
@@ -188,3 +190,99 @@ def test_compose_message():
     assert "dashboard" in msg
     rec = compose_message([], [{"level": "ok", "summary": "Backups are up to date"}])
     assert rec.startswith("✅ Resolved: Backups are up to date")
+
+
+# --- update check ----------------------------------------------------------
+
+def _stable(tmpdir, ref):
+    """Point healthcheck at a version.json pinned to `ref` on stable."""
+    path = os.path.join(tmpdir, "version.json")
+    with open(path, "w") as f:
+        json.dump({"channel": "stable", "ref": ref}, f)
+    healthcheck.VERSION_FILE = path
+
+
+def test_release_key_orders_date_and_semver_tags():
+    assert release_key("v2026.07.21") == (2026, 7, 21)
+    assert release_key("v1.1.0") == (1, 1, 0)
+    assert release_key("v0.1") == (0, 1)
+    assert release_key("v0.1") < release_key("v1.0.0") < release_key("v2026.06.12")
+    assert release_key("v2026.07.19") < release_key("v2026.07.21")
+    # unorderable input must be reported as such, not guessed at
+    assert release_key("main") is None
+    assert release_key("") is None
+    assert release_key(None) is None
+
+
+def test_update_available_only_when_release_is_newer(tmp_path):
+    _stable(str(tmp_path), "v2026.07.19")
+    state = {"update": {"ts": NOW, "latest": "v2026.07.21",
+                        "installed": "v2026.07.19"}}
+    out = check_update(state, NOW)
+    assert out["level"] == "info"
+    assert "v2026.07.21" in out["summary"]
+
+
+def test_older_release_is_not_an_update(tmp_path):
+    """The bug: a cached tag older than what's installed read as `!=` and so
+    advertised a downgrade the update script would refuse."""
+    _stable(str(tmp_path), "v2026.07.21")
+    state = {"update": {"ts": NOW, "latest": "v2026.07.19",
+                        "installed": "v2026.07.21"}}
+    out = check_update(state, NOW)
+    assert out["level"] == "ok"
+    assert out["summary"] == "HomeBrain is up to date"
+
+
+def test_same_release_is_up_to_date(tmp_path):
+    _stable(str(tmp_path), "v2026.07.21")
+    state = {"update": {"ts": NOW, "latest": "v2026.07.21",
+                        "installed": "v2026.07.21"}}
+    assert check_update(state, NOW)["level"] == "ok"
+
+
+def test_cache_is_invalidated_when_installed_version_changes(tmp_path, monkeypatch):
+    """A cached `latest` is only valid for the ref it was compared against;
+    after an update the probe must run again rather than reuse it."""
+    _stable(str(tmp_path), "v2026.07.21")
+    state = {"update": {"ts": NOW, "latest": "v2026.07.19",
+                        "installed": "v2026.07.19"}}   # cached pre-update
+
+    calls = []
+
+    class _Resp:
+        def read(self):
+            return b'{"tag_name": "v2026.07.21"}'
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(req, timeout=0):
+        calls.append(req.full_url)
+        return _Resp()
+
+    # Patch only the transport — json.load is shared with the version.json
+    # read at the top of check_update, so stubbing it would break that too.
+    monkeypatch.setattr(healthcheck.urllib.request, "urlopen", fake_urlopen)
+
+    out = check_update(state, NOW)
+    assert calls, "stale cache should have forced a fresh probe"
+    assert out["level"] == "ok"
+    assert state["update"]["installed"] == "v2026.07.21"
+
+
+def test_unorderable_tag_stays_quiet(tmp_path):
+    """Never nag toward a tag we cannot order against the installed one."""
+    _stable(str(tmp_path), "v2026.07.21")
+    state = {"update": {"ts": NOW, "latest": "nightly",
+                        "installed": "v2026.07.21"}}
+    assert check_update(state, NOW)["level"] == "ok"
+
+
+def test_beta_channel_is_skipped(tmp_path):
+    path = os.path.join(str(tmp_path), "version.json")
+    with open(path, "w") as f:
+        json.dump({"channel": "beta", "ref": "main"}, f)
+    healthcheck.VERSION_FILE = path
+    assert check_update({}, NOW) is None


### PR DESCRIPTION
The dashboard banner on a box running **v2026.07.21** read *"Update v2026.07.19 is available"* — pointing the owner at a release two versions behind what was installed.

## Two defects, combined

**1. Inequality instead of ordering.** `check_update` compared `latest != version.ref`, so any difference read as "newer" — including a release strictly older than the installed one. Tags are now ordered via `release_key()`, which parses both `vYYYY.MM.DD` and the legacy `vX.Y.Z` tags in this repo (`v0.1`, `v1.0.0`, `v1.1.0`). A tag that cannot be ordered now stays quiet instead of being guessed at.

**2. The daily cache had no version key.** It stored `latest` and a timestamp but not the installed ref it was compared against. An update applied between probes left a day-old tag in place that could predate what was now on disk — which is exactly how the box got into this state:

```
cached:    {"ts": …, "latest": "v2026.07.19"}   # 22.9h old
installed: v2026.07.21
```

## Why it matters

Updates are one-way — see `detect_downgrade` in `common.sh` — so `update.sh` would have refused the release this banner was recommending. The check also pushes to Telegram once per "new version", so the bad recommendation left the dashboard.

## Verification

On the reference box the stale entry missed on the new cache key, re-probed, and the check flipped `info` → `ok`. The banner now shows only the genuine off-site-copy warning.

Seven tests added. Both fixes are mutation-tested — reverting the ordering fix fails `test_older_release_is_not_an_update` and `test_unorderable_tag_stays_quiet`; reverting the cache key fails `test_cache_is_invalidated_when_installed_version_changes`. 22 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)