### PR TITLE
docs(readme): correct the install flow — the wizard is not optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,20 +83,24 @@ sudo /opt/homebrain/scripts/provision.sh
 sudo reboot
 ```
 
-After the reboot, open `http://<server-ip>` and the wizard walks you through deployment mode, passwords, and model selection.
+`provision.sh` prints a **factory password** at the end of its run. Record it — it is not recoverable, and it is what gets you into the setup wizard.
 
-To skip the wizard, pass everything to `provision.sh`:
+After the reboot, open `http://<server-ip>`, log in with that password, and choose local network or a Pangolin tunnel. The box deploys itself and hands you a generated master password and recovery phrase, shown once.
+
+Provisioning always finishes in the browser. Passing tunnel credentials up front doesn't skip the wizard — it arrives pre-filled and pre-set to remote access:
 
 ```bash
-# Remote access via a Pangolin tunnel
 sudo /opt/homebrain/scripts/provision.sh \
-  "<NEWT_ID>" "<NEWT_SECRET>" "<TUNNEL_DOMAIN>" "<PANGOLIN_ENDPOINT>" "<PASSWORD>"
+  --newt-id "<ID>" --newt-secret "<SECRET>" --domain "<TUNNEL_DOMAIN>" \
+  --endpoint "<PANGOLIN_ENDPOINT>" --factory-pass "<PASSWORD>"
 
-# Local network only
-sudo /opt/homebrain/scripts/provision.sh "<PASSWORD>"
+# force local-network mode
+sudo /opt/homebrain/scripts/provision.sh --local --factory-pass "<PASSWORD>"
 ```
 
-Omit the password and one is generated for you.
+`--factory-pass` sets the wizard's login password instead of generating one. The master password — for the dashboard, Nextcloud and Home Assistant — is always generated during deployment and never passed in.
+
+AI model selection lives in the dashboard under **Settings → Personal AI Assistant**, once the box is up.
 
 ---
 


### PR DESCRIPTION
Raised by @oalterg: *"the README mentions a dual way installation … the second one I wasn't aware — is this really implemented?"*

**The wizard is real and fully implemented.** `welcome.html` → `POST /start_setup` → `installing.html` streams the setup log and hands over credentials; it was driven end-to-end in a browser during the v2026.07.21 verification, including the cloud-registration gate.

What was wrong is the README's description of it.

## Corrections

| README said | Code does |
|---|---|
| Two install paths; args "skip the wizard" | `provision.sh` never writes `.setup_complete` — only `factory_config.txt`. Deployment always finishes in the browser. Args pre-fill the wizard and pre-select remote (`welcome.html` shows a "Factory provisioned device" panel). |
| Wizard covers "deployment mode, passwords, and model selection" | Deployment mode only. |
| — | Master password is generated in `/start_setup` and shown once at handover; no password field exists in the wizard. |
| — | Model selection is in the dashboard, **Settings → Personal AI Assistant**, after setup. |
| `"<PASSWORD>"` positional | That's the **factory** password — the wizard's login gate — not the master password the surrounding text implied. |
| "Omit the password and one is generated for you" | True, but `provision.sh` prints it once with *"Record this on the device label — it cannot be recovered."* A reader following the old text could reboot into a login prompt for a password they never saw. |

## Also

Examples now use the flag interface (`--newt-id`, `--domain`, `--local`, …). That's the branch `provision.sh` checks first, and the only form that can express `--local`. The positional form still works as legacy compat; it just isn't what the docs should teach.

Verified: every flag used in the README is accepted by `provision.sh`'s parser, and the Settings section named actually exists in `dashboard.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)