### PR TITLE
fix(agent): keep the self-MCP bearer token in step with the master password

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         run: bash scripts/tests/test_backup_encryption.sh
       - name: update guard
         run: bash scripts/tests/test_update_guard.sh
+      - name: self-MCP token derivation
+        run: bash scripts/tests/test_self_token.sh
 
   compose:
     runs-on: ubuntu-latest

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -242,6 +242,75 @@ update_env_var() {
     fi
 }
 
+# Read a single value out of .env. Deliberately takes the LAST match: the
+# .env.template ships empty placeholders (HOMEBRAIN_SELF_NONCE=, etc.) that the
+# dashboard later appends real values for, so a naive first-match grep returns
+# the empty one. Surrounding quotes (update_env_var writes them) are stripped.
+env_value() {
+    local key="$1" v
+    [[ -f "$ENV_FILE" ]] || return 0
+    v="$(grep -E "^${key}=" "$ENV_FILE" 2>/dev/null | tail -n1)"
+    v="${v#*=}"
+    v="${v%\"}"; v="${v#\"}"
+    v="${v%\'}"; v="${v#\'}"
+    printf '%s' "$v"
+}
+
+# --- Self-MCP bearer token -------------------------------------------------
+# The homebrain-self MCP server authenticates to the dashboard with a bearer
+# token derived from the master password:
+#
+#     token = HMAC-SHA256(key=HOMEBRAIN_SELF_NONCE, msg=MASTER_PASSWORD)
+#
+# The dashboard recomputes it from .env on every request (src/integrations.py:
+# _self_token) while the MCP server reads a cached copy from
+# ~/.openclaw/homebrain.token. Any path that changes MASTER_PASSWORD or
+# HOMEBRAIN_SELF_NONCE must refresh that file or every homebrain-self__* tool
+# call starts 401ing — silently, because nothing else reads it.
+
+# Pure derivation, kept separate so the unit test can pin it against the
+# Python implementation without touching the filesystem.
+derive_self_token() {
+    local nonce="$1" password="$2"
+    [[ -n "$nonce" && -n "$password" ]] || return 1
+    printf '%s' "$password" \
+        | openssl dgst -sha256 -hmac "$nonce" -r 2>/dev/null \
+        | cut -d' ' -f1
+}
+
+# Re-derive ~/.openclaw/homebrain.token in place. Optional $1 overrides the
+# password to derive from — the rotation script needs this because it calls us
+# with the NEW password, which .env may not carry yet. Best-effort by design:
+# a box with no OpenClaw has no self-MCP, and a failure here must never strand
+# a rotation or a restore.
+refresh_self_token() {
+    local new_pass="${1:-}"
+    local tok_dir="${HOMEBRAIN_HOME}/.openclaw"
+    local tok_file="${SELF_TOKEN_FILE:-${tok_dir}/homebrain.token}"
+    [[ -d "$tok_dir" ]] || return 0   # no OpenClaw on this box — nothing to do
+
+    local mp nonce tok
+    mp="${new_pass:-$(env_value MASTER_PASSWORD)}"
+    nonce="$(env_value HOMEBRAIN_SELF_NONCE)"
+    if [[ -z "$mp" || -z "$nonce" ]]; then
+        log_warn "Self-MCP token not re-derived: MASTER_PASSWORD or HOMEBRAIN_SELF_NONCE missing."
+        return 1
+    fi
+    if ! tok="$(derive_self_token "$nonce" "$mp")" || [[ -z "$tok" ]]; then
+        log_warn "Self-MCP token derivation failed (openssl missing?) — agent self-tools may 401."
+        return 1
+    fi
+
+    # Subshell so the restrictive umask cannot leak into the caller's shell.
+    if ! ( umask 077; printf '%s\n' "$tok" > "$tok_file" ); then
+        log_warn "Could not write ${tok_file} — agent self-tools may 401."
+        return 1
+    fi
+    chmod 600 "$tok_file" 2>/dev/null || true
+    chown "${HOMEBRAIN_USER}:${HOMEBRAIN_USER}" "$tok_file" 2>/dev/null || true
+    log_info "Self-MCP bearer token re-derived."
+}
+
 # --- Docker Helpers ---
 # Helper to get all active compose files
 get_compose_args() {

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -220,6 +220,11 @@ if [[ -d "${TMP_DIR}/openclaw_integrations" ]]; then
         chown "${HOMEBRAIN_USER}:${HOMEBRAIN_USER}" "${HOMEBRAIN_HOME}/.openclaw/${f}"
     done
     log_info "Integration credentials restored."
+    # homebrain.token above came from the SOURCE box, where it was derived from
+    # that box's MASTER_PASSWORD. This box keeps its own master password (only
+    # the nonce is portable, see the instance-secret merge earlier), so the
+    # restored copy is wrong on any cross-box restore. Re-derive it locally.
+    refresh_self_token
 fi
 
 # Per-integration audit logs (best-effort; the live log path is owned by

--- a/scripts/rotate_master_password.sh
+++ b/scripts/rotate_master_password.sh
@@ -158,4 +158,10 @@ if [[ "${HAS_GPU:-false}" == "true" ]] && [[ -f "$CFG" ]] && command -v jq >/dev
     fi
 fi
 
+# --- 7. Re-derive the self-MCP bearer token (BEST-EFFORT) ------------------
+# Derived from MASTER_PASSWORD, so it goes stale the moment step 4 lands. The
+# dashboard only rewrites it on a Connections "Apply", so without this the
+# agent's homebrain-self__* tools 401 until someone happens to click that.
+refresh_self_token "$NEW_PASS"
+
 log_info "=== Master password rotation complete ==="

--- a/scripts/tests/test_self_token.sh
+++ b/scripts/tests/test_self_token.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# Unit tests for the self-MCP bearer token helpers in common.sh.
+#
+# The token is a contract between two implementations that must never drift:
+# src/integrations.py:_self_token() derives it in Python on every dashboard
+# request, and common.sh:derive_self_token() rewrites the cached copy from
+# bash during a password rotation or a restore. If they disagree, every
+# homebrain-self__* agent tool 401s. So the first test pins one against the
+# other rather than against a hardcoded digest.
+#
+#   bash scripts/tests/test_self_token.sh
+#
+# Exit status: 0 if every case passes, 1 otherwise.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# common.sh reads ENV_FILE/HOMEBRAIN_HOME at call time, so point them at the
+# sandbox before sourcing. It also mkdir's /var/log/homebrain and probes the
+# GPU at source time; on a dev box that is harmless noise, so silence it.
+export ENV_FILE="$TMP_ROOT/.env"
+export HOMEBRAIN_HOME="$TMP_ROOT/home"
+export SELF_TOKEN_FILE="$TMP_ROOT/home/.openclaw/homebrain.token"
+mkdir -p "$TMP_ROOT/home/.openclaw"
+# shellcheck source=../common.sh disable=SC1091
+source "$SCRIPT_DIR/../common.sh" 2>/dev/null
+# common.sh exports its own ENV_FILE/HOMEBRAIN_HOME at source time; re-assert.
+ENV_FILE="$TMP_ROOT/.env"
+HOMEBRAIN_HOME="$TMP_ROOT/home"
+
+pass=0
+fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf '  FAIL  %s\n        %s\n' "$1" "$2"; fail=$((fail + 1)); }
+
+NONCE="4172e9b7e4be108aba7618d038a59d45"
+PASS="napped-plausible-sizzling-breeching-onyx"
+
+echo "== derive_self_token matches the Python derivation =="
+py_tok="$(python3 -c '
+import hashlib, hmac, sys
+print(hmac.new(sys.argv[1].encode(), sys.argv[2].encode(), hashlib.sha256).hexdigest())
+' "$NONCE" "$PASS")"
+sh_tok="$(derive_self_token "$NONCE" "$PASS")"
+if [[ -n "$py_tok" && "$sh_tok" == "$py_tok" ]]; then
+    ok "bash HMAC == python HMAC"
+else
+    bad "bash HMAC == python HMAC" "bash=$sh_tok python=$py_tok"
+fi
+
+# A password containing shell/regex metacharacters must survive both paths —
+# generated recovery passwords are hyphenated and the policy allows @!#%+=:?.
+py_tok2="$(python3 -c '
+import hashlib, hmac, sys
+print(hmac.new(sys.argv[1].encode(), sys.argv[2].encode(), hashlib.sha256).hexdigest())
+' "$NONCE" 'a@b!c#d%e+f=g:h?i-j.k')"
+sh_tok2="$(derive_self_token "$NONCE" 'a@b!c#d%e+f=g:h?i-j.k')"
+if [[ "$sh_tok2" == "$py_tok2" ]]; then
+    ok "metacharacter-heavy password derives identically"
+else
+    bad "metacharacter-heavy password derives identically" "bash=$sh_tok2 python=$py_tok2"
+fi
+
+if derive_self_token "" "$PASS" >/dev/null 2>&1; then
+    bad "empty nonce is rejected" "returned success"
+else
+    ok "empty nonce is rejected"
+fi
+
+echo "== env_value takes the LAST match =="
+# This is the shape a real box has: .env.template ships an empty placeholder
+# and the dashboard appends the real value later. A first-match read yields
+# the empty string and would silently derive a garbage token.
+cat > "$ENV_FILE" <<EOF
+# --- OpenClaw integrations ---
+HOMEBRAIN_SELF_NONCE=
+MASTER_PASSWORD='${PASS}'
+HOMEBRAIN_SELF_NONCE=${NONCE}
+EOF
+got="$(env_value HOMEBRAIN_SELF_NONCE)"
+[[ "$got" == "$NONCE" ]] && ok "placeholder shadowed by real value" \
+    || bad "placeholder shadowed by real value" "got '$got'"
+
+got="$(env_value MASTER_PASSWORD)"
+[[ "$got" == "$PASS" ]] && ok "surrounding quotes stripped" \
+    || bad "surrounding quotes stripped" "got '$got'"
+
+got="$(env_value NOT_A_REAL_KEY)"
+[[ -z "$got" ]] && ok "missing key yields empty" || bad "missing key yields empty" "got '$got'"
+
+echo "== refresh_self_token =="
+rm -f "$SELF_TOKEN_FILE"
+if refresh_self_token >/dev/null 2>&1 && [[ "$(cat "$SELF_TOKEN_FILE")" == "$py_tok" ]]; then
+    ok "writes the .env-derived token"
+else
+    bad "writes the .env-derived token" "got '$(cat "$SELF_TOKEN_FILE" 2>/dev/null)'"
+fi
+
+perms="$(ls -l "$SELF_TOKEN_FILE" | cut -c1-10)"
+[[ "$perms" == "-rw-------" ]] && ok "written 0600" || bad "written 0600" "got $perms"
+
+# The rotation script calls us with the NEW password before .env carries it.
+new_tok="$(derive_self_token "$NONCE" "brand-new-password")"
+if refresh_self_token "brand-new-password" >/dev/null 2>&1 \
+        && [[ "$(cat "$SELF_TOKEN_FILE")" == "$new_tok" ]]; then
+    ok "password argument overrides .env"
+else
+    bad "password argument overrides .env" "got '$(cat "$SELF_TOKEN_FILE" 2>/dev/null)'"
+fi
+
+# umask must not leak out of the subshell and clamp files the caller writes
+# afterwards (a rotation continues on to other steps).
+before="$(umask)"
+refresh_self_token >/dev/null 2>&1
+[[ "$(umask)" == "$before" ]] && ok "umask does not leak to the caller" \
+    || bad "umask does not leak to the caller" "$before -> $(umask)"
+
+# A box without OpenClaw has no ~/.openclaw: succeed and do nothing.
+mv "$TMP_ROOT/home/.openclaw" "$TMP_ROOT/home/.openclaw-gone"
+if refresh_self_token >/dev/null 2>&1; then
+    ok "no-OpenClaw box is a no-op, not a failure"
+else
+    bad "no-OpenClaw box is a no-op, not a failure" "returned non-zero"
+fi
+mv "$TMP_ROOT/home/.openclaw-gone" "$TMP_ROOT/home/.openclaw"
+
+# Missing nonce must fail loudly rather than write a bogus token.
+printf "MASTER_PASSWORD='%s'\n" "$PASS" > "$ENV_FILE"
+cp "$SELF_TOKEN_FILE" "$TMP_ROOT/before.tok"
+if refresh_self_token >/dev/null 2>&1; then
+    bad "missing nonce fails" "returned success"
+else
+    cmp -s "$SELF_TOKEN_FILE" "$TMP_ROOT/before.tok" \
+        && ok "missing nonce fails without clobbering the token" \
+        || bad "missing nonce fails without clobbering the token" "token was overwritten"
+fi
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -1480,9 +1480,30 @@ def register_integrations(app, limiter) -> None:  # noqa: C901
     threading.Thread(target=_startup_wire_if_needed, daemon=True).start()
 
 
+def _startup_sync_self_token() -> None:
+    """Repair a stale ~/.openclaw/homebrain.token on boot.
+
+    That file caches HMAC(nonce, MASTER_PASSWORD); the dashboard recomputes the
+    same value on every request. Anything that rotates the master password
+    without rewriting the file — or a restore that drops in another box's copy
+    — leaves the agent 401ing on every homebrain-self__* call. The wiring check
+    below cannot see this, because a stale token is still a wired token, so
+    compare the value itself. Only ever repairs a file that already exists;
+    creating it is reconcile_all_mcp()'s job."""
+    try:
+        if not os.path.exists(SELF_TOKEN_FILE):
+            return
+        if _self_token() and _read_secret(SELF_TOKEN_FILE) != _self_token():
+            _ensure_self_token()
+            logging.info("startup self-heal: refreshed stale self-MCP token")
+    except Exception as e:
+        logging.warning("self-MCP token sync failed: %s", e)
+
+
 def _startup_wire_if_needed() -> None:
     if not _has_openclaw():
         return
+    _startup_sync_self_token()
     try:
         if _self_token() and _wired_in_openclaw(MCP_NAMES["self"]):
             return


### PR DESCRIPTION
## The bug

Reported as: the agent answering *"the `homebrain-self__*` tools all go through the dashboard, which is currently 401ing."*

The dashboard was fine. The **agent's credential was stale**.

`homebrain-self` authenticates with `HMAC-SHA256(key=HOMEBRAIN_SELF_NONCE, msg=MASTER_PASSWORD)`. The dashboard recomputes it from `.env` on every request (`_self_token`, checked in `_check_bearer`); the MCP server reads a cached copy from `~/.openclaw/homebrain.token`. Nothing kept the two in step:

1. **`rotate_master_password.sh`** re-derives the Vaultwarden admin token (step 5) and the OpenClaw *gateway* token (step 6) — but never this one. So every master-password rotation silently broke all `homebrain-self__*` tools until someone happened to click **Apply** on the Connections card (`reconcile_all_mcp` → `_ensure_self_token` is the only writer). On the berlin box the token file was **5 weeks stale** after the 2026-06-15 recovery-phrase rotation; every self endpoint returned 401.
2. **`restore.sh`** copies the *source* box's `homebrain.token` out of the archive, while the destination keeps its own `MASTER_PASSWORD` (only the nonce is portable — see the instance-secret merge). Every cross-box restore lands the same skew. Relevant now that miami→berlin replication is live.
3. The existing boot-time self-heal (`_startup_wire_if_needed`) only asked whether a token *could be derived*. A stale file is still a wired file, so it never noticed.

## The fix

- `common.sh`: `derive_self_token` (pure) + `refresh_self_token` (rewrites the file 0600, owned by `homebrain`).
- Called from `rotate_master_password.sh` as step 7 (with the *new* password, which `.env` may not carry yet) and from `restore.sh` after the integration-credential restore.
- `_startup_sync_self_token()` compares the on-disk value against the derivation on boot and repairs it — so a box that took a rotation from older code heals itself on the next manager restart.
- `env_value` reads the **last** match in `.env` on purpose: `.env.template` ships an empty `HOMEBRAIN_SELF_NONCE=` placeholder that the dashboard appends the real value after. A first-match read derives from an empty nonce. Real boxes genuinely have two lines for that key.

## Tests

`scripts/tests/test_self_token.sh` (12 cases, wired into CI) pins the bash derivation against the Python one so the two implementations cannot drift, plus the placeholder-shadowing, 0600, umask-containment, no-OpenClaw-box, and don't-clobber-on-missing-nonce cases. Verified it fails when the derivation is mutated.

## Live E2E (berlin, 192.168.178.58, stable v2026.07.21)

| Check | Result |
|---|---|
| Repro: on-disk token vs derived | 401 vs 200 |
| Corrupt token → restart manager → boot self-heal | repaired, `0600 homebrain:homebrain`, 200 |
| `refresh_self_token` as root vs real `.env` (2 nonce lines, root-owned clobber) | correct value, ownership restored, umask not leaked |
| Full `rotate_master_password.sh` run (same password, so no credential moved) | rc=0, step 7 logged, token repaired, all 6 self endpoints 200, dashboard login 200, all 7 containers healthy |
| `homebrain.service_status` / `homebrain.version` over real MCP stdio | full health payload returned |

Restore path is covered by unit tests only — not exercised against a live restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
