### PR TITLE
Phase 5: data-recovery integrity and the agent trust boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         run: bash scripts/tests/test_backup_encryption.sh
       - name: update guard
         run: bash scripts/tests/test_update_guard.sh
+      - name: backup dir guard (internal-storage restore)
+        run: bash scripts/tests/test_restore_internal.sh
       - name: self-MCP token derivation
         run: bash scripts/tests/test_self_token.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: bash scripts/tests/test_update_guard.sh
       - name: backup dir guard (internal-storage restore)
         run: bash scripts/tests/test_restore_internal.sh
-      - name: backup retention (local prune + off-site copy semantics)
+      - name: backup retention, off-site copy + resume semantics
         run: |
           # rclone drives the off-site half against a temp-dir alias remote.
           # Without it that half skips and the deletion-mirroring regression

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
         run: bash scripts/tests/test_update_guard.sh
       - name: backup dir guard (internal-storage restore)
         run: bash scripts/tests/test_restore_internal.sh
+      - name: backup retention (local prune + off-site copy semantics)
+        run: |
+          # rclone drives the off-site half against a temp-dir alias remote.
+          # Without it that half skips and the deletion-mirroring regression
+          # goes unguarded.
+          sudo apt-get install -y -qq rclone
+          bash scripts/tests/test_backup_retention.sh
       - name: self-MCP token derivation
         run: bash scripts/tests/test_self_token.sh
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,31 @@ Transform tasks into verifiable goals:
 ## Project
 HomeBrain is a self-hosted home automation system targeting x86_64 Ubuntu servers with AMD GPUs. It combines an OpenClaw AI assistant (backed by llama.cpp/llama-server), Nextcloud, Home Assistant, and optional Pangolin tunnel for remote access. All services run in Docker; the user interacts exclusively through a Flask dashboard — no SSH required.
 
+## Security invariant: the AI agent is root
+
+The OpenClaw agent runs as the `homebrain` OS user, which is in the `docker`
+group. Any member of that group can `docker run -v /:/host` and read or write
+anything on the box, so **the agent is root-equivalent and always has been.**
+As of Phase 5 that is explicit rather than accidental: `tools.exec` is set to
+`mode: full` / `ask: off` and `homebrain` has a passwordless sudoers rule,
+because "the owner never needs a shell" requires an agent that can actually
+run privileged commands.
+
+What this means when reasoning about agent risk:
+
+- **The security boundary is the Telegram `allowFrom` pairing and the
+  loopback-bound gateway**, not the tool policy. Anything that lets an
+  untrusted party put text in front of the agent is a privilege escalation.
+- The agent ingests email and browses the web. Both are prompt-injection
+  surfaces that reach a root shell. Treat any change that widens what the
+  agent will read as a security change.
+- Do not add a filesystem deny-list and call it containment — the agent can
+  sudo around it. `tools.deny` (tool names, not paths) is schema-valid and is
+  the right tool for disabling a *capability*, not for protecting a *file*.
+- `.env` is still asserted `root:root 0600` on every write and at manager
+  start. That does not stop the agent; it stops a container escape landing as
+  `www-data`.
+
 ## Repo Layout
 
 ```

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ AI model selection lives in the dashboard under **Settings → Personal AI Assis
 | Doc | What's in it |
 |-----|-------------|
 | [BENCHMARKS.md](docs/BENCHMARKS.md) | Inference throughput, quantization comparisons, tuning notes |
+| [DISASTER_RECOVERY.md](docs/DISASTER_RECOVERY.md) | Getting your data back onto new hardware after the box is gone |
 | [ROADMAP.md](docs/ROADMAP.md) | Shipped features and what's next |
 | [TESTING.md](docs/TESTING.md) | E2E verification checklist |
 | [AGENTS.md](AGENTS.md) | Contributor conventions for AI-assisted development |

--- a/config/.env.template
+++ b/config/.env.template
@@ -48,12 +48,16 @@ BACKUP_INTERNAL=false
 # OFFSITE_HOST: sftp host[:port], WebDAV base URL, or S3 endpoint URL
 # OFFSITE_USER / OFFSITE_PASS: login / app password (S3: access key / secret)
 # OFFSITE_PATH: remote directory (S3: bucket[/prefix])
+# OFFSITE_KEEP_DAYS: age at which remote archives are pruned. Deliberately
+#   independent of local retention — the remote is not a mirror, so a local
+#   deletion must never propagate to it.
 OFFSITE_ENABLED=false
 OFFSITE_TYPE=
 OFFSITE_HOST=
 OFFSITE_USER=
 OFFSITE_PASS=
 OFFSITE_PATH=
+OFFSITE_KEEP_DAYS=90
 # Optional Cloudflare Tokens (alternative to Pangolin)
 CF_TUNNEL_ID=
 TRUSTED_PROXIES_0=172.18.0.1

--- a/config/homebrain-offsite.service
+++ b/config/homebrain-offsite.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=HomeBrain off-site copy (resume interrupted mirrors)
+# rclone needs the uplink up, or the first run after boot burns its retry
+# budget on DNS failures.
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash /opt/homebrain/scripts/utilities.sh offsite_resume
+# A full archive can upload for tens of hours; a start timeout must not kill it.
+TimeoutStartSec=0
+StandardOutput=append:/var/log/homebrain/backup.log
+StandardError=append:/var/log/homebrain/backup.log

--- a/config/homebrain-offsite.timer
+++ b/config/homebrain-offsite.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Resume an interrupted HomeBrain off-site copy
+
+[Timer]
+# After boot: pick up a mirror that a restart cut short.
+OnBootSec=10min
+# Then hourly, so an interruption costs an hour rather than waiting for the
+# next scheduled backup — which on a weekly schedule could be six days away.
+# Each firing is a no-op when the remote is already current, and the off-site
+# lock means a firing during a long upload does nothing.
+OnUnitActiveSec=1h
+RandomizedDelaySec=5min
+
+[Install]
+WantedBy=timers.target

--- a/config/llama-server.service
+++ b/config/llama-server.service
@@ -2,7 +2,12 @@
 Description=llama.cpp inference server
 After=network.target multi-user.target
 Wants=multi-user.target
+# Both keys belong in [Unit]; systemd ignores them under [Service] and warns
+# on every daemon-reload. Burst was previously only in [Service], so the
+# intended 5 was silently supplied by systemd's default of the same value —
+# right behaviour, unreadable config. State it explicitly.
 StartLimitIntervalSec=600
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -37,8 +42,6 @@ ExecStart=__LLAMA_BIN__ \
 Restart=always
 RestartSec=10
 TimeoutStopSec=30
-StartLimitIntervalSec=600
-StartLimitBurst=5
 TimeoutStartSec=600
 OOMScoreAdjust=-500
 StandardOutput=journal

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -64,6 +64,9 @@
     ]
   },
   "tools": {
+    "exec": {
+      "mode": "full"
+    },
     "media": {
       "audio": {
         "enabled": true,
@@ -84,8 +87,7 @@
   },
   "approvals": {
     "exec": {
-      "enabled": true,
-      "mode": "session"
+      "enabled": false
     },
     "plugin": {
       "enabled": true,

--- a/config/versions.json
+++ b/config/versions.json
@@ -11,5 +11,8 @@
   },
   "vaultwarden": {
     "tag": "1.36.0"
+  },
+  "proton_bridge": {
+    "tag": "3.19.0-1"
   }
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -14,5 +14,8 @@
   },
   "proton_bridge": {
     "tag": "3.19.0-1"
+  },
+  "rclone": {
+    "version": "1.74.4"
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,7 +159,10 @@ services:
     # and SMTP on :12025 on localhost; the email MCP server connects there.
     profiles:
       - proton-bridge
-    image: shenxn/protonmail-bridge:latest
+    # Pinned like every other image in this stack. This one handles mail
+    # credentials and was the only :latest left, so an upstream push could
+    # swap it under a running box on the next pull.
+    image: shenxn/protonmail-bridge:${PROTON_BRIDGE_TAG:-3.19.0-1}
     restart: unless-stopped
     ports:
       - "127.0.0.1:12143:143"

--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -105,9 +105,13 @@ The usual cause was a too-old rclone: versions before 1.64 cannot split a large
 upload into chunks, so a multi-gigabyte archive is sent as a single request and
 the receiving server rejects it with *413 Request Entity Too Large*, while the
 small system snapshots go through fine. HomeBrain now installs a current rclone
-when you enable the off-site copy. If your remote is missing full archives from
-before that fix, run a backup once to seed one — allow plenty of time, since a
-full archive can take many hours to upload.
+before every off-site copy. If your remote is missing full archives from before
+that fix, they upload on the next copy — allow plenty of time, since a full
+archive can take many hours.
+
+An upload interrupted by a restart is picked up again within the hour, and
+after a reboot, by the off-site resume timer. Archives already at the remote are
+skipped, so only the one that was in flight repeats.
 
 ## Known limitation
 

--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -1,0 +1,105 @@
+# Disaster recovery
+
+Getting your data back when the box is gone — stolen, burned, drowned, or the
+disk simply died. This is the procedure the off-site copy exists for.
+
+If the **box still runs** and only the backup drive failed, you do not need this
+page: open the dashboard, go to **Backup**, pick an archive marked ☁️ and press
+Restore. That path is fully dashboard-driven.
+
+---
+
+## What you need before you start
+
+1. **The off-site details** — type (SFTP / WebDAV / S3), host or URL, username,
+   password, and remote folder. Same values you entered when you set the
+   off-site copy up.
+2. **The master password that was current when the backup was made.** This is
+   the one thing that cannot be recovered from anywhere. Archives are encrypted
+   with the master password as it stood at backup time; nothing on the new box,
+   and nothing at the off-site remote, can open an archive without it.
+   - If you changed your master password after that backup, you need the *old*
+     one. The dashboard marks such archives "needs previous password".
+   - If you reset your password with the recovery phrase, every archive from
+     before that reset needs the password you had before it.
+3. **Somewhere to put it.** The archive is downloaded before it is unpacked, so
+   the new box needs free space of roughly the archive's size. A full-system
+   archive can be tens of gigabytes.
+
+---
+
+## Procedure
+
+### 1. Install HomeBrain on the new hardware, normally
+
+Provision and complete the setup wizard exactly as you would for a new box.
+Let it generate a new master password and write it down.
+
+This feels wrong — you are setting up a box you are about to overwrite — but
+the restore needs a running stack to restore *into*. The throwaway Nextcloud
+and Home Assistant it creates are replaced wholesale in step 4.
+
+The new box keeps its **own** master password afterwards. It does not inherit
+the old one, and you do not need them to match.
+
+### 2. Give it somewhere to stage the download
+
+Dashboard → **Backup** → **Storage**.
+
+- If you have attached a backup drive, select it as usual.
+- If this box has no drive, tick **"No drive — keep backups on the internal
+  disk"**. The download needs a writable staging area either way.
+
+### 3. Point it at your off-site copy
+
+Dashboard → **Backup** → **Off-site Copy**. Enter the details from the old box
+and save, then press the connection test. You do not need to enable the
+scheduled copy yet.
+
+Once saved, archives held only at the off-site remote appear in the restore
+list marked with ☁️.
+
+### 4. Restore
+
+Dashboard → **Backup** → pick the ☁️ archive → **Restore**.
+
+- Confirm the warning. It wipes the throwaway data from step 1.
+- When prompted for a passphrase, enter **the old box's master password**.
+- The archive downloads first. On a slow connection this takes a long time and
+  the dashboard will sit on the restore log — that is normal. If there is not
+  enough free space the restore refuses up front rather than filling the disk.
+
+### 5. Afterwards
+
+- Log in with the **new** box's master password from step 1.
+- Nextcloud, Home Assistant, Vaultwarden and the AI agent's workspace come back
+  as they were.
+- Connected accounts (email, extra Home Assistant or Nextcloud logins) survive:
+  the archive carries the key those tokens are encrypted with, which is why the
+  restore works across two boxes with different master passwords.
+- Set up the off-site copy properly now (enable the schedule), and generate a
+  fresh recovery phrase under **Settings → Recovery Phrase**.
+
+---
+
+## If the restore refuses
+
+| Message | Meaning |
+| --- | --- |
+| `Decryption failed — wrong passphrase or corrupt archive` | The passphrase is not the master password that was current when this archive was made. See point 2 above. |
+| `Not enough space to fetch …: needs N MB, M MB free` | The staging area is too small. Attach a drive, or free space, and retry. Nothing was downloaded. |
+| `Failed to mount backup drive` | The box expects a drive that is not attached. Either attach it or tick the no-drive option in step 2. |
+| `Could not fetch … from the off-site remote` | Credentials, host or folder are wrong, or the remote is unreachable. Use the connection test on the Off-site Copy form. |
+
+---
+
+## Known limitation
+
+Steps 1–3 have to happen before you can restore, so recovery onto new hardware
+is a two-pass operation: install, then overwrite. Restoring directly from the
+setup wizard is not supported yet — the wizard runs before a stack exists, and
+the restore needs one.
+
+Verified on 2026-07-24: fetch from a live WebDAV remote onto a box with a
+different master password, including the cross-instance key import, up to the
+point of unpacking into the stack.

--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -93,6 +93,22 @@ Dashboard → **Backup** → pick the ☁️ archive → **Restore**.
 
 ---
 
+## Check that your files are actually off-site
+
+An off-site copy that only holds *system snapshots* will restore your settings,
+your Home Assistant config and your vault — but not your Nextcloud files. On the
+Backup page, the ☁️ entries are what you would be restoring from. If every one
+of them says "System snapshot" and none says "Full System", your files are not
+protected against losing the box.
+
+The usual cause was a too-old rclone: versions before 1.64 cannot split a large
+upload into chunks, so a multi-gigabyte archive is sent as a single request and
+the receiving server rejects it with *413 Request Entity Too Large*, while the
+small system snapshots go through fine. HomeBrain now installs a current rclone
+when you enable the off-site copy. If your remote is missing full archives from
+before that fix, run a backup once to seed one — allow plenty of time, since a
+full archive can take many hours to upload.
+
 ## Known limitation
 
 Steps 1–3 have to happen before you can restore, so recovery onto new hardware

--- a/docs/plans/PRODUCT_REVIEW_2026-07.md
+++ b/docs/plans/PRODUCT_REVIEW_2026-07.md
@@ -11,7 +11,12 @@ reboot-required health check, OpenClaw 2026.7.1-2, gunicorn 26 / gevent 26.5 /
 redis-py 8 (the held bumps, WS E2E'd), Nextcloud 33. Remaining Phase 4: G7
 URL-rewrite helper; "move NC data to another drive" flow. Phase 0 debt: misc
 secrets → Vaultwarden.
-**Date:** 2026-07-15
+**Round 2 (2026-07-24):** re-verified every finding against the tree at
+`05f9839`. Phases 1–3 hold up. Six new issues found, four of them data-loss
+paths that the original review missed — see
+[Round 2](#round-2--verification-and-new-findings-2026-07-24) and
+[Phase 5](#phase-5--data-recovery-integrity-and-the-agent-trust-boundary).
+**Date:** 2026-07-15 (Round 2: 2026-07-24)
 **Scope:** Holistic review of the product — reliability, security, engineering foundation,
 missing features — with a phased, minimalist plan. Findings verified against the working
 tree at `705129a` (post-PR #112).
@@ -139,3 +144,228 @@ Ordered by user impact. Phase 1 deliberately precedes Phase 2 because Phase 2 re
 step, no Prometheus/Grafana (the notifier covers the user need), no multi-box
 orchestration, no plugin system, no app.py rewrite — blueprints get extracted only when
 a file is being touched anyway.
+
+---
+
+## Round 2 — verification and new findings (2026-07-24)
+
+Verified against the working tree at `05f9839`.
+
+### Confirmed closed
+
+CI exists (`.github/workflows/ci.yml`); the limiter is on Redis (`app.py:441`);
+`shell=True` is down to one documented site with a CI gate that fails if the count
+drifts (`.github/check_shell_true.py`); `compare_digest` is used in all four auth
+paths; `unattended-upgrades` installs from `common.sh:501` and `update.sh:306`; the
+dead ufw 18789 rule is gone *and* actively deleted on update (`update.sh:316`); `newt`
+no longer mounts docker.sock; backups are GPG-AES256, verified by full read-back
+(`backup.sh:439`), and mirrored off-site. The notifier ships with ten checks and
+level-transition logic. This is real progress and the phase structure worked.
+
+### Stale in the docs
+
+`AGENTS.md:59` still says app.py is "~1750 lines" — it is **4,045**, and the repo
+layout block omits `recovery.py`, `integrations.py`, and `src/static/`. `ROADMAP.md`
+still lists the recovery phrase, Vault, and OpenClaw integrations as *"in progress,
+branch X"*; all three shipped. Phase 0's "refresh AGENTS.md + ROADMAP" was never done,
+and the original finding stands: every stale line is a bad prompt injected into every
+agent session. Phase 1 also promised an **app-import smoke test** — `ci.yml` runs
+`compileall` but never imports `app`, so module-level breakage still ships.
+
+### New findings
+
+**1. Restore is broken on internal-storage boxes.** `restore.sh:18` hard-requires
+`mountpoint -q "$BACKUP_MOUNTDIR"`. `BACKUP_INTERNAL` is handled in `backup.sh:93`,
+`update.sh:185`, `healthcheck.py:156`, and `app.py:645` — but not in restore.sh. PR
+#123 added no-drive mode and never taught restore about it. The dashboard lists the
+archives correctly (`backup_storage_dir()` resolves), passes a valid absolute path, and
+every restore dies at line 20. A supported configuration can back up and can never
+restore. The two mount guards drifted because each script owns its own copy.
+
+**2. A recovery-phrase reset orphans every existing backup.** Archives are encrypted
+with `MASTER_PASSWORD` as it stood at backup time (`backup.sh:167`);
+`rotate_master_password.sh` step 4 replaces it. The recovery flow's entire premise is
+that the user has forgotten the master password — so afterwards every archive, local
+and off-site, needs a passphrase they by definition do not have. `restore.sh` supports
+`RESTORE_PASSPHRASE_FILE` for exactly this, so the *mechanism* exists and only the
+*knowledge* is gone. Nothing warns before rotating and nothing takes a fresh backup
+after. The one flow designed to save a locked-out user destroys their backup history.
+
+**3. `rclone sync` makes the off-site a mirror, not a backup.** `common.sh:817` uses
+`sync`, which propagates deletions. Combined with the emergency prune loop
+(`backup.sh:136`, which deletes old archives to free space) and verification-failure
+deletion (`backup.sh:444`), a local disk problem replicates itself off-site on the next
+run. Ransomware or an accidental wipe takes both copies. Related: the prune deletes
+existing *good* archives to make room before the replacement is known-good, so a run
+whose verification fails can end with strictly fewer backups than it started with.
+
+**4. There is no off-site *restore*.** `/api/backup/offsite` writes config and
+`offsite_sync` pushes; nothing pulls. `restore.sh` only ever reads `$BACKUP_MOUNTDIR`.
+The exact scenario off-site exists for — box or drive destroyed — requires a user who by
+design never SSHes to hand-run rclone and gpg on fresh hardware. The feature shipped
+without its recovery path, which means it is currently a backup we have never proven we
+can restore.
+
+**5. The agent is already root, and the config pretends otherwise.**
+`config/openclaw.json:85` sets `approvals.exec = {enabled: true, mode: "session"}` —
+approve once, then unattended for the rest of the session — for an agent with
+`tools.profile: "full"` that ingests email and browses the web, both prompt-injection
+vectors. But the more important fact is upstream of that flag: `common.sh:136` puts
+`homebrain` in the `docker` group, and any member of `docker` can `docker run -v /:/host`
+and read or write anything on the box. **The agent is root-equivalent today.** File
+permissions on `.env` cannot contain it, and an OpenClaw-level path deny-list would be
+theater even if it were expressible — which it is not: `utilities.sh:1465` records that
+stock OpenClaw ≥2026.6 strictly validates config and refuses to load the gateway on
+unknown keys (the `mcp: Invalid input` incident). Separately, `homebrain` has a locked
+password and no NOPASSWD rule, so the agent cannot actually `sudo` at all right now —
+the approval gate is guarding a door that is already open elsewhere while the intended
+door is nailed shut.
+
+*Verified live on .58 (2026-07-24):* `groups` returns `… sudo … docker render`;
+`sudo -n true` fails with "interactive authentication is required"; the live
+`openclaw.json` carries `{"exec": {"enabled": true, "mode": "session"}}`. All three
+match the code reading. One thing did **not**: `/opt/homebrain/.env` is
+`-rw------- homebrain homebrain`, not root-owned, inside a root-owned directory and with
+no `chown` anywhere in `scripts/`. So the agent does not even need the docker escape —
+it owns the file holding `MASTER_PASSWORD` and can `cat` it. The cause is unidentified
+(no code path in the tree produces this), so it is either drift on this box or an
+unexamined write path; either way the fix is an assertion rather than a hunt. Note also
+that `HOMEBRAIN_INTEGRATIONS_KEY` — the Fernet key wrapping every stored account token —
+sits in plaintext in the homebrain-owned `openclaw.json` because the MCP servers need it
+injected. That is inherent to the design, not a defect, but it is another reason the
+filesystem is not the boundary.
+
+**6. `shenxn/protonmail-bridge:latest`** (`docker-compose.yml:162`) is the one unpinned
+image in a stack whose pinning discipline is otherwise exemplary, and it is the one
+handling mail credentials. Version pinning is a documented invariant; this is drift.
+
+### Also noted, not scheduled
+
+No log rotation for `/var/log/homebrain` (backup/restore/manager logs and
+`mcp-*-audit.log` grow forever), and five of ten compose services set no `logging:`
+limits (`redis`, `homeassistant`, `newt`, both `cloudflared`). No dead-man's switch —
+`healthcheck.py` runs on the box, so a dead box is silent, which is indistinguishable
+from healthy. The notifier is Telegram-or-nothing (`healthcheck.py:388`) despite Phase
+2a promising an email fallback, and SMTP credentials are already in the stack. `app.py`
+(4,045 lines) and `integrations.py` (1,593) still have zero tests. No `dependabot.yml`.
+No container hardening (`cap_drop`, `no-new-privileges`, memory limits) anywhere.
+Nextcloud publishes `0.0.0.0:8080` plaintext (`docker-compose.yml:44`) while Vaultwarden
+is correctly loopback-only and Caddy already terminates TLS for NC on 8444. `misc` at
+repo root still holds live production credentials including a Home Assistant long-lived
+token valid into 2036 — those should be treated as disclosed and rotated, not merely
+moved. Smaller: `backup.sh:69` removes the lock file while still holding the flock, so
+two runs can overlap during cleanup; `backup.sh:117` calls `docker compose` without
+`--env-file`, unlike every other call site; no login lockout and no failed-login
+notification through the notifier that already exists.
+
+---
+
+## Phase 5 — data recovery integrity and the agent trust boundary
+
+Scope: Round 2 findings 1–4, 5, and 6. Ordered so that each step lands on a tree where
+the previous one has already removed a way to lose data. 3 before 4 is the one hard
+dependency — there is no point building a restore path from a mirror that deletes
+itself.
+
+### 5a. Single source of truth for the backup directory (finding 1)
+
+Extract the mount guard both scripts need into `common.sh` as `ensure_backup_dir()`:
+honour `BACKUP_INTERNAL=true` by asserting the directory exists, otherwise
+`mountpoint -q` and fall back to `mount`. Call it from `backup.sh:93` and `restore.sh:18`.
+The fix is not "add the branch to restore.sh" — it is to stop having two copies that can
+drift, which is what produced the bug.
+
+*Test:* `scripts/tests/test_restore_internal.sh` — run `restore.sh` against a temp dir
+with `BACKUP_INTERNAL=true` and assert it gets past the guard to the archive-selection
+step. Wire into `ci.yml`.
+
+### 5b. Off-site copies survive local deletion (finding 3)
+
+Add `--backup-dir "offsite:${OFFSITE_PATH}/replaced/$(date +%F)"` to the `rclone sync`
+at `common.sh:817`. One flag: deletions and overwrites become moves, so a local wipe can
+no longer erase the remote copy. Prune `replaced/` on the same retention pass, keeping
+90 days. Separately, move the emergency prune (`backup.sh:136`) to run *after* the new
+archive verifies rather than before it is written, so a failed run can never leave the
+user with fewer backups than they started with.
+
+*Test:* extend `test_backup_encryption.sh` with a local-filesystem rclone remote —
+sync, delete the local archive, sync again, assert the remote copy still resolves under
+`replaced/`.
+
+### 5c. Rotation stops orphaning backups (finding 2)
+
+Three small changes, no re-encryption — re-encrypting old archives would need the old
+password, which in the recovery case is precisely what is missing:
+
+- `rotate_master_password.sh` step 4: after `MASTER_PASSWORD` lands, record the rotation
+  timestamp in `/var/lib/homebrain/backup_epoch.json`.
+- Same script, at the end: trigger a full backup so a current-password archive exists
+  before the user closes the tab.
+- Dashboard: archives older than the recorded epoch get a "needs your previous password"
+  badge in the restore list. The passphrase field in the restore modal already exists and
+  already works — this only has to tell the user *when* to use it.
+- Recovery-reset UI: state plainly, before the user commits, that existing backups will
+  need the old password and that a fresh one will be taken automatically.
+
+### 5d. Restore from off-site (finding 4)
+
+`restore.sh --from-offsite <archive-name>`: reuse `offsite_env`, `rclone copy` the single
+named archive into `$BACKUP_MOUNTDIR`, then fall through to the existing restore path
+unchanged. No new restore logic and no second code path to keep in sync. Add
+`utilities.sh offsite_list` wrapping `rclone lsjson` so the dashboard can show remote
+archives in the existing backup list with a badge, reusing `/api/restore` with a
+`source` flag.
+
+**Scoped out, deliberately:** bare-metal recovery onto a *new* box (off-site creds
+entered in the setup wizard before a stack exists) is the larger half of this problem and
+needs wizard UI. Phase 5d covers "drive died, box alive," which is the common case and
+is reachable from the dashboard. The bare-metal path gets a documented runbook in
+`docs/` now and wizard support in a later phase — but note that until that ships, the
+disaster-recovery story still has a manual step.
+
+*Test:* the round-trip that has never existed — back up, encrypt, push to a local rclone
+remote, wipe the local copy, restore from off-site, diff the tree. This is the single
+most valuable test in the repo and should gate CI.
+
+### 5e. Make the agent's trust boundary explicit (finding 5)
+
+The decision is to let the agent run privileged commands unattended — that is what "no
+SSH required" means, and `docker` group membership already grants it root equivalence, so
+the current config buys no safety while blocking the intended workflow.
+
+- `config/openclaw.json` and `utilities.sh:1470`: set `approvals.exec.enabled = false`
+  and drop `.mode`. Leave `approvals.plugin` at `session` — plugin installs are rare,
+  user-initiated, and not on the automation path.
+- Add `/etc/sudoers.d/homebrain` granting NOPASSWD, written via a temp file and validated
+  with `visudo -c` before install. This does not widen the blast radius — it makes the
+  existing docker-group equivalence explicit and usable instead of leaving the agent to
+  discover the container escape hatch.
+- Assert `root:root 0600` on `.env` — not just the mode. On .58 it is currently
+  `homebrain:homebrain 0600`, so the agent can read `MASTER_PASSWORD` with `cat` and
+  never has to reach for the docker escape. Enforce ownership and mode at manager boot
+  and at every write path (`app.py:762` sets the mode only; the bash creation sites
+  `common.sh:241` and `provision.sh:239` use the default umask). This does not contain a
+  root-equivalent agent, but it restores the intended asymmetry and still defends against
+  a container escape landing as `www-data`.
+- Document the boundary in AGENTS.md security invariants, in one sentence: **the agent is
+  root on this box; the security boundary is the Telegram `allowFrom` pairing and the
+  loopback-bound gateway, not the tool sandbox.** Anyone reasoning about agent risk needs
+  to start from that, and today the config implies the opposite.
+
+**No path deny-list.** Unknown keys brick the gateway (`utilities.sh:1465`), and a
+deny-list a root-equivalent process can walk around is theater that would make the next
+reviewer think the box is safer than it is.
+
+### 5f. Pin the Proton bridge (finding 6)
+
+Read the digest currently running on both boxes
+(`docker inspect --format '{{index .RepoDigests 0}}'`), record it under
+`versions.json` as `proton_bridge`, and reference it from compose as
+`${PROTON_BRIDGE_TAG:-<digest>}`, following the `VAULTWARDEN_TAG` precedent at
+`docker-compose.yml:120`. Pin to what is already running and verified, not to whatever
+`latest` resolves to on the day of the change.
+
+*Blocked on a digest:* .58 has no Proton account configured, so the profile is inactive
+and the image is not present (`no such object`). Take the digest from a box where the
+bridge actually runs — berlin or miami — before writing the pin. Pulling `latest` here
+just to read its digest would defeat the point of pinning to a verified build.

--- a/docs/plans/PRODUCT_REVIEW_2026-07.md
+++ b/docs/plans/PRODUCT_REVIEW_2026-07.md
@@ -262,6 +262,35 @@ notification through the notifier that already exists.
 
 ## Phase 5 — data recovery integrity and the agent trust boundary
 
+**Status: implemented and verified on .58 (2026-07-24), branch
+`feat/phase5-recovery-integrity`.** Three parts of the plan below did not
+survive contact with the hardware and shipped differently:
+
+- **5b** planned `rclone --backup-dir` and moving the emergency prune after
+  verification. rclone refuses a `--backup-dir` that overlaps the destination,
+  and the prune cannot move after the write because the space is needed *to*
+  write. Shipped `rclone copy` plus age-based remote retention
+  (`OFFSITE_KEEP_DAYS`), and a `prunable_archives` helper that excludes the
+  newest archive by construction. Simpler and strictly safer than the plan.
+- **5e** was planned on a wrong premise — mine. `approvals.exec` is not a
+  permission gate; it is approval-prompt *forwarding*, and its `mode` enum is
+  `session|targets|both`, so `"always"` was never valid and `enabled: false`
+  would not have granted unattended execution. The real policy is
+  `tools.exec`, shipped as `{"mode": "full"}`. The first attempt combined
+  `mode` with `security`/`ask` and `openclaw config validate` rejected it —
+  that config would have stopped the gateway loading on deploy.
+- **5f** could not take a digest from a running bridge: berlin *is* .58 and has
+  no Proton account, so the profile never starts, and miami is not
+  SSH-reachable. Pinned to `3.19.0-1`, which shares a digest with `:latest` and
+  has not moved since 2025-04-02.
+
+Also corrected: a path deny-list *is* expressible (`tools.deny`, tool names not
+paths), contrary to the Round 2 note — but it remains the wrong instrument,
+because a root-equivalent agent can sudo around it.
+
+Still open from this phase: bare-metal off-site recovery onto new hardware
+(needs wizard UI), and everything under "Also noted, not scheduled".
+
 Scope: Round 2 findings 1–4, 5, and 6. Ordered so that each step lands on a tree where
 the previous one has already removed a way to lose data. 3 before 4 is the one hard
 dependency — there is no point building a restore path from a mirror that deletes

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -470,6 +470,22 @@ log_info "=== Backup Complete: $ARCHIVE_PATH ==="
 if [[ "${OFFSITE_ENABLED:-false}" == "true" && "$SKIP_OFFSITE" != "true" ]]; then
     OFFSITE_STATE="/var/lib/homebrain/offsite.json"
     mkdir -p /var/lib/homebrain
+
+    # Release the BACKUP lock before uploading. The local backup is finished;
+    # everything below is a WAN transfer that can run for tens of hours on a
+    # home uplink with multi-GB archives. Holding the backup lock for that long
+    # blocks the next scheduled backup and makes update.sh's pre-update
+    # snapshot fail — which is why --skip-offsite had to exist at all.
+    #
+    # A second lock keeps two mirrors from overlapping, since backups can now
+    # start while one is still uploading.
+    flock -u 200 2>/dev/null || true
+    exec 201>"/var/run/homebrain-offsite.lock"
+    if ! flock -n 201; then
+        log_warn "An off-site mirror is already running — skipping this one."
+        exit 0
+    fi
+
     log_info "Mirroring backups off-site (${OFFSITE_TYPE:-unset})..."
     if offsite_sync; then
         printf '{"ts": %d, "ok": true}\n' "$(date +%s)" > "${OFFSITE_STATE}.tmp" \

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -84,18 +84,8 @@ esac
 # --- Main Logic ---
 log_info "=== Starting Backup [Strategy: $STRATEGY]: $(date) ==="
 
-# 1. Mount Check
-# BACKUP_INTERNAL=true (with BACKUP_MOUNTDIR pointing at a root-disk path)
-# is the no-drive mode: archives live on the internal disk purely as the
-# staging set for the off-site mirror — the mirror is the actual protection.
-# The mount check stays mandatory otherwise, so a fallen-off USB drive can
-# never silently fill the root disk.
-if [[ "${BACKUP_INTERNAL:-false}" == "true" ]]; then
-    mkdir -p "$BACKUP_MOUNTDIR"
-elif ! mountpoint -q "$BACKUP_MOUNTDIR"; then
-    log_info "Attempting to mount $BACKUP_MOUNTDIR..."
-    mount "$BACKUP_MOUNTDIR" || die "Failed to mount backup drive."
-fi
+# 1. Mount Check (shared with restore.sh — see common.sh:ensure_backup_dir)
+ensure_backup_dir
 
 # Ensure backup dir is writable
 if [ ! -w "$BACKUP_MOUNTDIR" ]; then

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -126,13 +126,16 @@ log_info "[INFO] Estimated uncompressed: $((ESTIMATED_UNCOMPRESSED_KB / 1024)) M
 while [ "$AVAILABLE_KB" -lt "$ESTIMATED_PEAK_KB" ]; do
     log_warn "Insufficient space (Avail: $((AVAILABLE_KB/1024)) MB, Need: $((ESTIMATED_PEAK_KB/1024)) MB). searching for old backups to purge..."
     
-    # Find oldest backup, sort by timestamp asc (oldest on top)
-    OLDEST_BACKUP=$(find "$BACKUP_MOUNTDIR" -maxdepth 1 -type f \( -name "homebrain_backup*.tar.gz*" -o -name "nextcloud_backup*.tar.gz*" \) -printf "%T@ %p\n" | sort -n | head -n1 | awk '{print $2}')
-    
-    if [[ -z "$OLDEST_BACKUP" ]]; then
-        die "CRITICAL: No old backups remain to delete, and space is still insufficient. Aborting."
+    # Candidates exclude the newest archive by construction — see
+    # common.sh:prunable_archives. Empty means we may not free any more space.
+    mapfile -t PRUNABLE < <(prunable_archives "$BACKUP_MOUNTDIR")
+
+    if [[ "${#PRUNABLE[@]}" -eq 0 ]]; then
+        die "CRITICAL: Space is insufficient and only one backup remains. Refusing to delete the last known-good archive — free space on $BACKUP_MOUNTDIR or fit a larger drive."
     fi
-    
+
+    OLDEST_BACKUP="${PRUNABLE[0]}"
+
     log_info "Emergency Prune: Deleting $OLDEST_BACKUP to free space."
     rm -f "$OLDEST_BACKUP"
     sync # Ensure free space is updated in kernel

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -468,33 +468,13 @@ log_info "=== Backup Complete: $ARCHIVE_PATH ==="
 # script runs — update.sh's pre-update snapshot would otherwise block the
 # whole update behind a multi-hour WAN mirror. The scheduled backup mirrors.
 if [[ "${OFFSITE_ENABLED:-false}" == "true" && "$SKIP_OFFSITE" != "true" ]]; then
-    OFFSITE_STATE="/var/lib/homebrain/offsite.json"
-    mkdir -p /var/lib/homebrain
-
     # Release the BACKUP lock before uploading. The local backup is finished;
     # everything below is a WAN transfer that can run for tens of hours on a
     # home uplink with multi-GB archives. Holding the backup lock for that long
     # blocks the next scheduled backup and makes update.sh's pre-update
     # snapshot fail — which is why --skip-offsite had to exist at all.
-    #
-    # A second lock keeps two mirrors from overlapping, since backups can now
-    # start while one is still uploading.
+    # offsite_mirror takes its own lock, so two mirrors still cannot overlap.
     flock -u 200 2>/dev/null || true
-    exec 201>"/var/run/homebrain-offsite.lock"
-    if ! flock -n 201; then
-        log_warn "An off-site mirror is already running — skipping this one."
-        exit 0
-    fi
-
-    log_info "Mirroring backups off-site (${OFFSITE_TYPE:-unset})..."
-    if offsite_sync; then
-        printf '{"ts": %d, "ok": true}\n' "$(date +%s)" > "${OFFSITE_STATE}.tmp" \
-            && mv "${OFFSITE_STATE}.tmp" "$OFFSITE_STATE"
-        log_info "Off-site mirror complete."
-    else
-        printf '{"ts": %d, "ok": false}\n' "$(date +%s)" > "${OFFSITE_STATE}.tmp" \
-            && mv "${OFFSITE_STATE}.tmp" "$OFFSITE_STATE"
-        log_warn "OFF-SITE COPY FAILED — the local backup is fine; check the off-site settings on the Backup page."
-    fi
+    offsite_mirror || true
 fi
 # Lock file removed by trap

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -894,6 +894,14 @@ offsite_env() {
 # what to keep, so a plain filtered sync gives remote retention for free.
 offsite_sync() {
     command -v rclone >/dev/null || { log_warn "rclone is not installed."; return 1; }
+    # At point of use, because that is the only place that reaches every box.
+    # app.py calls ensure_rclone when off-site settings are SAVED, which a box
+    # that already had off-site configured never does again — so the boxes most
+    # in need of the chunking fix would be exactly the ones that never got it,
+    # and their mirrors would go on failing with 413 forever. No-ops in
+    # milliseconds once rclone is current.
+    ensure_rclone "$(jq -r '.rclone.version // empty' \
+        "${INSTALL_DIR}/config/versions.json" 2>/dev/null || echo "")" || true
     offsite_env || return 1
     local remote="offsite:${OFFSITE_PATH:-homebrain-backups}"
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -775,6 +775,22 @@ configure_nextcloud_redis() {
 # They drifted — restore.sh never learned about BACKUP_INTERNAL (added in
 # #123), so no-drive boxes could back up and could never restore. One
 # definition, two callers.
+# Archives in $1 that the emergency prune may delete, oldest first.
+#
+# Deliberately excludes the newest archive, always. The prune runs *before*
+# this backup exists, and this backup can still fail — a bad dump, or a failed
+# verify, which deletes the new archive. Freeing space by deleting the only
+# known-good copy leaves the user with less protection than they started with,
+# so the last one is never a candidate. Empty output means "nothing may be
+# pruned", which the caller must treat as a hard stop, not as "nothing found".
+prunable_archives() {
+    local dir="$1"
+    find "$dir" -maxdepth 1 -type f \
+        \( -name "homebrain_backup*.tar.gz*" -o -name "nextcloud_backup*.tar.gz*" \) \
+        -printf "%T@ %p\n" 2>/dev/null \
+        | sort -n | awk '{print $2}' | sed '$d'
+}
+
 ensure_backup_dir() {
     if [[ "${BACKUP_INTERNAL:-false}" == "true" ]]; then
         mkdir -p "$BACKUP_MOUNTDIR" \
@@ -834,11 +850,30 @@ offsite_env() {
 offsite_sync() {
     command -v rclone >/dev/null || { log_warn "rclone is not installed."; return 1; }
     offsite_env || return 1
+    local remote="offsite:${OFFSITE_PATH:-homebrain-backups}"
+
+    # copy, NOT sync. sync mirrors deletions, so anything that removes a local
+    # archive — a failed drive, ransomware, the emergency prune in backup.sh —
+    # erased the off-site copy on the very next run. That is how a backup stops
+    # being a backup: the one event the off-site copy exists for was also the
+    # event that destroyed it. copy only ever adds.
+    #
     # Leading / anchors the patterns to the drive's top level and --max-depth
     # stops recursion — same scope as local retention's `find -maxdepth 1`.
     # Without both, archives inside subdirectories would get mirrored too.
-    rclone sync "$BACKUP_MOUNTDIR" "offsite:${OFFSITE_PATH:-homebrain-backups}" \
+    rclone copy "$BACKUP_MOUNTDIR" "$remote" \
         --max-depth 1 \
         --include '/homebrain_backup*.tar.gz*' \
-        --include '/nextcloud_backup*.tar.gz*'
+        --include '/nextcloud_backup*.tar.gz*' || return 1
+
+    # Bound the remote on its own schedule instead of tracking local state, so
+    # a local deletion can never propagate. Archives are encrypted at rest, so
+    # a longer window costs only space. Same include patterns: never touch
+    # anything on the remote that HomeBrain did not put there.
+    rclone delete "$remote" \
+        --min-age "${OFFSITE_KEEP_DAYS:-90}d" \
+        --max-depth 1 \
+        --include '/homebrain_backup*.tar.gz*' \
+        --include '/nextcloud_backup*.tar.gz*' 2>/dev/null \
+        || log_warn "Off-site retention pass failed (copies are safe; remote may grow)."
 }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -147,6 +147,48 @@ ensure_homebrain_user() {
             usermod -aG "$grp" "${HOMEBRAIN_USER}" 2>/dev/null || true
         fi
     done
+    ensure_homebrain_sudo
+}
+
+# Passwordless sudo for the homebrain user.
+#
+# This looks like a widening and is not one. homebrain is in the `docker` group
+# (above), and any docker group member can `docker run -v /:/host` — root, by a
+# longer route. The account had a locked password and no sudoers rule, so the
+# agent that HomeBrain's "you never need a shell" promise depends on could not
+# run a privileged command at all, while still being one container away from
+# root. That gap bought no safety and pushed the agent toward the escape hatch.
+#
+# Make it explicit instead. The real boundary is the Telegram allowFrom pairing
+# and the loopback-bound gateway — see the trust-boundary note in AGENTS.md.
+ensure_homebrain_sudo() {
+    local dest="/etc/sudoers.d/homebrain"
+    local tmp
+    tmp="$(mktemp)" || return 0
+    printf '%s ALL=(ALL) NOPASSWD:ALL\n' "${HOMEBRAIN_USER}" > "$tmp"
+    # Never install an unvalidated sudoers fragment: a malformed file in
+    # /etc/sudoers.d can lock every user out of sudo on the whole box.
+    if visudo -c -f "$tmp" >/dev/null 2>&1; then
+        install -m 0440 -o root -g root "$tmp" "$dest"
+        log_info "Passwordless sudo enabled for ${HOMEBRAIN_USER}."
+    else
+        log_warn "Generated sudoers fragment failed validation — not installed."
+    fi
+    rm -f "$tmp"
+}
+
+# .env holds MASTER_PASSWORD, every service credential, the vault admin token
+# and the off-site password. It must be root-only.
+#
+# On .58 it was found homebrain:homebrain 0600 — owned by the very account the
+# agent runs as, so reading the master password needed nothing more than `cat`.
+# No code path in the tree explains that, so assert the state rather than hunt
+# the cause. This does not contain a root-equivalent agent; it restores the
+# intended asymmetry and still stops a container escape landing as www-data.
+harden_env_file() {
+    [[ -f "$ENV_FILE" ]] || return 0
+    chown root:root "$ENV_FILE" 2>/dev/null || true
+    chmod 600 "$ENV_FILE" 2>/dev/null || true
 }
 
 # --- Admin user creation (Ubuntu x86 doesn't ship with a default user) ---
@@ -240,6 +282,9 @@ update_env_var() {
         log_warn ".env file not found, creating new one."
         echo "${key}='${value}'" > "$ENV_FILE"
     fi
+    # Every bash write path funnels through here, and the shell ones create the
+    # file under the default umask (0644). Re-assert after each write.
+    harden_env_file
 }
 
 # Read a single value out of .env. Deliberately takes the LAST match: the

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -877,3 +877,38 @@ offsite_sync() {
         --include '/nextcloud_backup*.tar.gz*' 2>/dev/null \
         || log_warn "Off-site retention pass failed (copies are safe; remote may grow)."
 }
+
+# HomeBrain archives on the remote, as rclone lsjson (Name/Size/ModTime).
+# The dashboard renders this alongside the local list so the off-site copy is
+# visible — and therefore restorable — without a shell.
+offsite_list() {
+    command -v rclone >/dev/null || { log_warn "rclone is not installed."; return 1; }
+    offsite_env || return 1
+    rclone lsjson "offsite:${OFFSITE_PATH:-homebrain-backups}" \
+        --files-only --max-depth 1 \
+        --include '/homebrain_backup*.tar.gz*' \
+        --include '/nextcloud_backup*.tar.gz*'
+}
+
+# Pull exactly one archive down into $2. $1 is a bare filename, never a path:
+# the include pattern is anchored so a crafted value cannot widen this into
+# "fetch the entire remote", and the caller (restore.sh) basenames it first.
+offsite_fetch() {
+    local name="$1" dest="$2"
+    command -v rclone >/dev/null || { log_warn "rclone is not installed."; return 1; }
+    offsite_env || return 1
+    rclone copy "offsite:${OFFSITE_PATH:-homebrain-backups}" "$dest" \
+        --max-depth 1 --include "/${name}"
+}
+
+# Size in bytes of one remote archive, or empty if it isn't there. Used to
+# refuse a fetch that would not fit — filling the root disk of a box the owner
+# cannot SSH into is exactly the failure this phase exists to prevent.
+offsite_size() {
+    local name="$1"
+    command -v rclone >/dev/null || return 1
+    offsite_env || return 1
+    rclone size "offsite:${OFFSITE_PATH:-homebrain-backups}" \
+        --max-depth 1 --include "/${name}" --json 2>/dev/null \
+        | jq -r 'select(.count > 0) | .bytes' 2>/dev/null
+}

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -762,6 +762,29 @@ configure_nextcloud_redis() {
     log_info "Redis configuration applied successfully."
 }
 
+# --- Backup storage ---------------------------------------------------------
+# Make $BACKUP_MOUNTDIR usable, honouring the no-drive mode.
+#
+# BACKUP_INTERNAL=true means BACKUP_MOUNTDIR is a path on the root disk (the
+# archives are the staging set for the off-site mirror, which is the actual
+# protection there), so "not a mountpoint" is the normal state. Otherwise the
+# mount check is mandatory: a USB drive that fell off must never silently
+# degrade into filling the root disk.
+#
+# backup.sh and restore.sh both need this and used to carry separate copies.
+# They drifted — restore.sh never learned about BACKUP_INTERNAL (added in
+# #123), so no-drive boxes could back up and could never restore. One
+# definition, two callers.
+ensure_backup_dir() {
+    if [[ "${BACKUP_INTERNAL:-false}" == "true" ]]; then
+        mkdir -p "$BACKUP_MOUNTDIR" \
+            || die "Cannot create backup directory $BACKUP_MOUNTDIR."
+    elif ! mountpoint -q "$BACKUP_MOUNTDIR"; then
+        log_info "Attempting to mount $BACKUP_MOUNTDIR..."
+        mount "$BACKUP_MOUNTDIR" || die "Failed to mount backup drive."
+    fi
+}
+
 # --- Off-site backup copy ---------------------------------------------------
 # One rclone remote named "offsite", defined entirely by the OFFSITE_* vars
 # from .env — no rclone.conf to manage. Credentials travel via rclone's

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -958,6 +958,13 @@ ensure_rclone() {
         log_warn "rclone ${cur:-unknown} cannot chunk uploads to Nextcloud (needs >= ${RCLONE_MIN_MAJOR}.${RCLONE_MIN_MINOR}); installing a current build."
     fi
 
+    # Installing needs root. Bail before spending a download we cannot use —
+    # this also keeps the function inert for unprivileged callers and tests.
+    if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+        log_warn "rclone needs updating but this is not running as root — skipping."
+        return 1
+    fi
+
     local arch url tmp
     case "$(uname -m)" in
         x86_64)  arch=amd64 ;;
@@ -986,6 +993,38 @@ ensure_rclone() {
     rm -rf "$tmp"
     hash -r 2>/dev/null || true
     log_info "Installed rclone $(/usr/local/bin/rclone version 2>/dev/null | head -1 | awk '{print $2}') to /usr/local/bin."
+}
+
+OFFSITE_STATE_FILE="/var/lib/homebrain/offsite.json"
+OFFSITE_LOCK_FILE="/var/run/homebrain-offsite.lock"
+
+# Run the mirror under the off-site lock and record the outcome.
+#
+# Shared by backup.sh (right after a backup) and homebrain-offsite.timer (on
+# boot and hourly). Both need identical locking and identical state-writing —
+# the health check reads that state file, so two copies of this logic would
+# eventually disagree about whether the off-site copy is healthy.
+#
+# Returns non-zero only when a mirror ran and failed; a skip because another
+# mirror holds the lock is success.
+offsite_mirror() {
+    mkdir -p /var/lib/homebrain
+    exec 201>"$OFFSITE_LOCK_FILE"
+    if ! flock -n 201; then
+        log_info "An off-site mirror is already running — leaving it to finish."
+        return 0
+    fi
+    log_info "Mirroring backups off-site (${OFFSITE_TYPE:-unset})..."
+    if offsite_sync; then
+        printf '{"ts": %d, "ok": true}\n' "$(date +%s)" > "${OFFSITE_STATE_FILE}.tmp" \
+            && mv "${OFFSITE_STATE_FILE}.tmp" "$OFFSITE_STATE_FILE"
+        log_info "Off-site mirror complete."
+        return 0
+    fi
+    printf '{"ts": %d, "ok": false}\n' "$(date +%s)" > "${OFFSITE_STATE_FILE}.tmp" \
+        && mv "${OFFSITE_STATE_FILE}.tmp" "$OFFSITE_STATE_FILE"
+    log_warn "OFF-SITE COPY FAILED — the local backup is fine; check the off-site settings on the Backup page."
+    return 1
 }
 
 # HomeBrain archives on the remote, as rclone lsjson (Name/Size/ModTime).

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -923,6 +923,63 @@ offsite_sync() {
         || log_warn "Off-site retention pass failed (copies are safe; remote may grow)."
 }
 
+# Install a chunk-capable rclone, replacing the distro package if needed.
+#
+# Ubuntu ships rclone 1.60.1 (2022), which has no Nextcloud chunked-upload
+# support: it PUTs an archive as one request, and the receiving Nextcloud's
+# Apache rejects anything past its body limit with "413 Request Entity Too
+# Large". Small system snapshots (~68 MB) squeak through, multi-GB full
+# archives never do — so the off-site copy silently ends up holding everything
+# EXCEPT the user's files, which is the one thing it exists to hold.
+# Nextcloud chunking landed in rclone 1.64.
+#
+# Installs to /usr/local/bin, which precedes /usr/bin in PATH, so the distro
+# package can stay where it is.
+RCLONE_MIN_MAJOR=1
+RCLONE_MIN_MINOR=64
+ensure_rclone() {
+    local want_ver="${1:-}"
+    if command -v rclone >/dev/null 2>&1; then
+        local cur major minor
+        cur=$(rclone version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
+        major="${cur%%.*}"; minor="${cur##*.}"
+        if [[ -n "$cur" ]] && { [[ "$major" -gt "$RCLONE_MIN_MAJOR" ]] || \
+            { [[ "$major" -eq "$RCLONE_MIN_MAJOR" ]] && [[ "$minor" -ge "$RCLONE_MIN_MINOR" ]]; }; }; then
+            return 0
+        fi
+        log_warn "rclone ${cur:-unknown} cannot chunk uploads to Nextcloud (needs >= ${RCLONE_MIN_MAJOR}.${RCLONE_MIN_MINOR}); installing a current build."
+    fi
+
+    local arch url tmp
+    case "$(uname -m)" in
+        x86_64)  arch=amd64 ;;
+        aarch64) arch=arm64 ;;
+        *) log_warn "No rclone build for $(uname -m)."; return 1 ;;
+    esac
+    if [[ -n "$want_ver" ]]; then
+        url="https://downloads.rclone.org/v${want_ver}/rclone-v${want_ver}-linux-${arch}.zip"
+    else
+        url="https://downloads.rclone.org/rclone-current-linux-${arch}.zip"
+    fi
+
+    tmp=$(mktemp -d) || return 1
+    if ! curl -fsSL --retry 3 -o "$tmp/rclone.zip" "$url"; then
+        rm -rf "$tmp"; log_warn "Could not download rclone from $url"; return 1
+    fi
+    if ! unzip -q -o "$tmp/rclone.zip" -d "$tmp"; then
+        rm -rf "$tmp"; log_warn "Could not unpack the rclone download."; return 1
+    fi
+    local bin
+    bin=$(find "$tmp" -type f -name rclone | head -1)
+    if [[ -z "$bin" ]]; then
+        rm -rf "$tmp"; log_warn "No rclone binary in the download."; return 1
+    fi
+    install -m 0755 -o root -g root "$bin" /usr/local/bin/rclone
+    rm -rf "$tmp"
+    hash -r 2>/dev/null || true
+    log_info "Installed rclone $(/usr/local/bin/rclone version 2>/dev/null | head -1 | awk '{print $2}') to /usr/local/bin."
+}
+
 # HomeBrain archives on the remote, as rclone lsjson (Name/Size/ModTime).
 # The dashboard renders this alongside the local list so the off-site copy is
 # visible — and therefore restorable — without a shell.

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -289,6 +289,15 @@ systemctl enable --now homebrain-health.timer 2>/dev/null \
     && log_info "Health check timer enabled." \
     || log_warn "Failed to enable health check timer."
 
+# Resume timer for interrupted off-site copies. Harmless when off-site is not
+# configured — offsite_resume exits immediately on OFFSITE_ENABLED=false.
+cp "${SCRIPT_DIR}/../config/homebrain-offsite.service" /etc/systemd/system/
+cp "${SCRIPT_DIR}/../config/homebrain-offsite.timer" /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable --now homebrain-offsite.timer 2>/dev/null \
+    && log_info "Off-site resume timer enabled." \
+    || log_warn "Failed to enable off-site resume timer."
+
 # --- 6. OpenClaw integration scaffold ---
 # Make sure /home/homebrain/.openclaw/ exists with the right ownership before
 # the dashboard starts wiring MCP servers into it. Idempotent.

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -15,13 +15,17 @@ BACKUP_FILE="${1:-}"
 ARG_FLAG="${2:-}"
 
 # --- Prerequisites ---
-if ! mountpoint -q "$BACKUP_MOUNTDIR"; then
-    mount "$BACKUP_MOUNTDIR" || die "Backup drive not mounted."
-fi
+# Shared with backup.sh so the two can't drift again: no-drive boxes
+# (BACKUP_INTERNAL=true) have no mountpoint to check. See common.sh.
+ensure_backup_dir
 
 if [[ -z "$BACKUP_FILE" ]]; then
     # Auto-select latest (plain or encrypted)
-    BACKUP_FILE="$(find "$BACKUP_MOUNTDIR" -maxdepth 1 \( -name '*backup*.tar.gz' -o -name '*backup*.tar.gz.gpg' \) -print0 | xargs -0 ls -t | head -n1)"
+    # -r matters: without it, xargs still runs `ls -t` once on empty input,
+    # which lists the CWD and hands back an unrelated filename as the archive
+    # to restore. The -f test below catches a directory, but a regular file in
+    # the CWD would sail straight through into the restore.
+    BACKUP_FILE="$(find "$BACKUP_MOUNTDIR" -maxdepth 1 \( -name '*backup*.tar.gz' -o -name '*backup*.tar.gz.gpg' \) -print0 | xargs -0 -r ls -t | head -n1)"
 fi
 
 if [[ -z "$BACKUP_FILE" || ! -f "$BACKUP_FILE" ]]; then

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -11,13 +11,60 @@ if [ -t 1 ]; then :; else exec >> "$RESTORE_LOG_FILE" 2>&1; fi
 load_env
 
 # --- Input Parsing ---
-BACKUP_FILE="${1:-}"
-ARG_FLAG="${2:-}"
+# Positional archive plus flags, in any order. --no-prompt used to be matched
+# positionally as $2; keeping it a flag means --from-offsite can be added
+# without callers caring about argument order.
+BACKUP_FILE=""
+NO_PROMPT=false
+FROM_OFFSITE=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --no-prompt)    NO_PROMPT=true ;;
+        --from-offsite) FROM_OFFSITE=true ;;
+        *)              [[ -z "$BACKUP_FILE" ]] && BACKUP_FILE="$1" ;;
+    esac
+    shift
+done
 
 # --- Prerequisites ---
 # Shared with backup.sh so the two can't drift again: no-drive boxes
 # (BACKUP_INTERNAL=true) have no mountpoint to check. See common.sh.
 ensure_backup_dir
+
+# --- Off-site fetch ---------------------------------------------------------
+# The off-site copy existed but could only be written, never read: rclone
+# pushed, nothing pulled, and restore.sh only ever looked at BACKUP_MOUNTDIR.
+# The scenario off-site backups exist for — drive dead — required a shell.
+# Pull the named archive down, then fall through to the normal path so there
+# is exactly one restore implementation.
+if [[ "$FROM_OFFSITE" == "true" ]]; then
+    [[ -n "$BACKUP_FILE" ]] || die "--from-offsite requires an archive name."
+    # Bare filename only: the caller may be passing something user-supplied.
+    OFFSITE_NAME="$(basename "$BACKUP_FILE")"
+
+    # Refuse a fetch that cannot fit. In internal-storage mode the target IS
+    # the root disk, and an appliance whose root filesystem is full is an
+    # appliance its owner cannot recover without a keyboard.
+    NEED_KB=""
+    REMOTE_BYTES="$(offsite_size "$OFFSITE_NAME" 2>/dev/null || true)"
+    if [[ "$REMOTE_BYTES" =~ ^[0-9]+$ ]] && [[ "$REMOTE_BYTES" -gt 0 ]]; then
+        NEED_KB=$(( REMOTE_BYTES / 1024 ))
+        AVAIL_KB=$(df --output=avail "$BACKUP_MOUNTDIR" | tail -n1)
+        if [[ "$AVAIL_KB" -lt "$NEED_KB" ]]; then
+            die "Not enough space to fetch $OFFSITE_NAME: needs $((NEED_KB / 1024)) MB, $((AVAIL_KB / 1024)) MB free on $BACKUP_MOUNTDIR."
+        fi
+    else
+        log_warn "Could not determine the remote size of $OFFSITE_NAME — fetching without a space check."
+    fi
+
+    log_info "Fetching $OFFSITE_NAME from the off-site remote..."
+    offsite_fetch "$OFFSITE_NAME" "$BACKUP_MOUNTDIR" \
+        || die "Could not fetch $OFFSITE_NAME from the off-site remote."
+    BACKUP_FILE="$BACKUP_MOUNTDIR/$OFFSITE_NAME"
+    [[ -f "$BACKUP_FILE" ]] \
+        || die "Off-site fetch reported success but $OFFSITE_NAME is not present locally."
+    log_info "Fetched $OFFSITE_NAME ($(du -h "$BACKUP_FILE" | cut -f1))."
+fi
 
 if [[ -z "$BACKUP_FILE" ]]; then
     # Auto-select latest (plain or encrypted)
@@ -33,7 +80,7 @@ if [[ -z "$BACKUP_FILE" || ! -f "$BACKUP_FILE" ]]; then
 fi
 
 # Interactive confirmation
-if [[ "$ARG_FLAG" != "--no-prompt" ]]; then
+if [[ "$NO_PROMPT" != "true" ]]; then
     echo "⚠️ WARNING: RESTORE PROCESS INITIATED ⚠️"
     echo "Restoring: $BACKUP_FILE"
     echo "This will WIPE ALL DATA in: ${NEXTCLOUD_DATA_DIR:-${HOMEBRAIN_HOME}/nextcloud-data}"

--- a/scripts/rotate_master_password.sh
+++ b/scripts/rotate_master_password.sh
@@ -120,6 +120,20 @@ update_env_var "MASTER_PASSWORD" "$NEW_PASS"
 update_env_var "MANAGER_PASSWORD" "$NEW_PASS"
 log_info "MASTER_PASSWORD / MANAGER_PASSWORD updated."
 
+# Backups are encrypted with the master password AS IT WAS AT BACKUP TIME
+# (backup.sh: gpg stores the s2k salt per archive), so every existing archive
+# now needs the OLD password. That is survivable for a deliberate change — the
+# user still knows it — but this script is also the recovery-phrase path, whose
+# entire premise is that they have forgotten it. Record when the boundary moved
+# so the dashboard can mark which archives predate it, instead of leaving the
+# user to guess in a passphrase prompt.
+mkdir -p /var/lib/homebrain
+EPOCH_FILE="/var/lib/homebrain/backup_epoch.json"
+printf '{"ts": %d, "rotated_at": "%s"}\n' \
+    "$(date +%s)" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "${EPOCH_FILE}.tmp" \
+    && mv "${EPOCH_FILE}.tmp" "$EPOCH_FILE"
+log_info "Backup epoch recorded — archives older than now need the previous password."
+
 # --- 5. Re-derive Vault admin token (BEST-EFFORT) --------------------------
 # ADMIN_TOKEN is an env var the vaultwarden container reads at start, so a
 # running container must be recreated to pick up the new .env value.
@@ -163,5 +177,21 @@ fi
 # dashboard only rewrites it on a Connections "Apply", so without this the
 # agent's homebrain-self__* tools 401 until someone happens to click that.
 refresh_self_token "$NEW_PASS"
+
+# --- 8. Fresh backup under the NEW password ---------------------------------
+# Without this the box can sit indefinitely with zero archives the user can
+# actually open: every existing one is sealed with the old password, and after
+# a recovery-phrase reset that password is gone for good. Detached with its own
+# session and fds so the rotation task returns immediately — a full backup can
+# run for hours, and the caller (the dashboard's background task) waits on the
+# pipe. backup.sh writes its own log and takes the backup lock, so a collision
+# with a scheduled run is handled there.
+if [[ -x "$SCRIPT_DIR/backup.sh" ]] || [[ -f "$SCRIPT_DIR/backup.sh" ]]; then
+    log_info "Starting a full backup under the new password (detached)."
+    nohup setsid bash "$SCRIPT_DIR/backup.sh" --strategy full >/dev/null 2>&1 &
+    disown 2>/dev/null || true
+else
+    log_warn "backup.sh not found — take a backup manually; existing archives need the OLD password."
+fi
 
 log_info "=== Master password rotation complete ==="

--- a/scripts/tests/test_backup_retention.sh
+++ b/scripts/tests/test_backup_retention.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#
+# Regression tests for what HomeBrain is allowed to delete — locally
+# (common.sh:prunable_archives) and off-site (common.sh:offsite_sync).
+#
+# The bugs this pins:
+#   * offsite_sync used `rclone sync`, which mirrors deletions. Anything that
+#     removed a local archive — a failed drive, ransomware, the emergency prune
+#     in backup.sh — erased the off-site copy on the next run. The one event the
+#     off-site copy exists for was also the event that destroyed it.
+#   * the emergency prune deleted archives down to zero to free space for a
+#     backup that had not been written yet, let alone verified.
+#
+# The off-site half uses rclone's `alias` backend pointed at a temp directory,
+# so the round-trip runs with no network and no credentials. offsite_env is
+# redefined after sourcing common.sh to supply that remote in place of
+# sftp/webdav/s3.
+#
+#   bash scripts/tests/test_backup_retention.sh
+#
+# Linux-only: prunable_archives uses `find -printf` and `head -n -1`, matching
+# the GNU coreutils the product already targets. Exit status: 0 if every case
+# passes, 1 otherwise. Skips cleanly without rclone.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON="$SCRIPT_DIR/../common.sh"
+
+# shellcheck source=../common.sh disable=SC1091
+source "$COMMON" 2>/dev/null
+
+pass=0
+fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail + 1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/local" "$TMP/remote"
+
+# Point the "offsite:" remote at a local directory.
+offsite_env() {
+    export RCLONE_CONFIG_OFFSITE_TYPE=alias
+    export RCLONE_CONFIG_OFFSITE_REMOTE="$TMP/remote"
+}
+
+export BACKUP_MOUNTDIR="$TMP/local"
+export OFFSITE_PATH="backups"
+REMOTE="$TMP/remote/backups"
+
+archive() { echo "payload-$1" > "$TMP/local/homebrain_backup_$1.tar.gz.gpg"; }
+
+# ── Local prune guard (no rclone needed) ────────────────────────────────────
+
+# prunable_archives needs GNU `find -printf`. Without it the helper returns
+# nothing and every assertion below would pass vacuously — which is worse than
+# skipping, because it reports green on a host that proved nothing.
+if find "$TMP" -maxdepth 0 -printf '' 2>/dev/null; then
+    HAVE_GNU_FIND=true
+else
+    HAVE_GNU_FIND=false
+fi
+
+echo "== the emergency prune never eats the last archive =="
+# common.sh:prunable_archives — the guard is in what it refuses to return.
+PR="$TMP/prune"; mkdir -p "$PR"
+if [ "$HAVE_GNU_FIND" != true ]; then
+    printf '  skip  prune guard (needs GNU find -printf)\n'
+else
+count_prunable() { prunable_archives "$PR" | grep -c . ; }
+if [ "$(count_prunable)" -eq 0 ]; then ok "empty dir yields no candidates"; else bad "empty dir yields no candidates"; fi
+: > "$PR/homebrain_backup_a.tar.gz.gpg"
+if [ "$(count_prunable)" -eq 0 ]; then
+    ok "one archive yields no candidates (the last one is never prunable)"
+else
+    bad "one archive yields no candidates (offered the only backup for deletion)"
+fi
+sleep 1; : > "$PR/homebrain_backup_b.tar.gz.gpg"
+sleep 1; : > "$PR/homebrain_backup_c.tar.gz.gpg"
+if [ "$(count_prunable)" -eq 2 ]; then ok "three archives yield two candidates"; else bad "three archives yield two candidates (got $(count_prunable))"; fi
+if [ "$(prunable_archives "$PR" | head -n1)" = "$PR/homebrain_backup_a.tar.gz.gpg" ]; then
+    ok "candidates are oldest-first"
+else
+    bad "candidates are oldest-first"
+fi
+if prunable_archives "$PR" | grep -q "homebrain_backup_c"; then
+    bad "newest archive excluded from candidates (it was offered)"
+else
+    ok "newest archive excluded from candidates"
+fi
+fi
+
+echo "== backup.sh consumes the guarded helper =="
+if grep -q 'prunable_archives "\$BACKUP_MOUNTDIR"' "$SCRIPT_DIR/../backup.sh"; then
+    ok "backup.sh prunes via prunable_archives"
+else
+    bad "backup.sh prunes via prunable_archives (rolled its own find again)"
+fi
+
+# ── Off-site copy semantics (needs rclone) ──────────────────────────────────
+
+if ! command -v rclone >/dev/null 2>&1; then
+    echo
+    echo "rclone not installed — skipping the off-site half."
+    echo "passed: $pass   failed: $fail"
+    [ "$fail" -eq 0 ]
+    exit $?
+fi
+
+echo "== the copy reaches the remote =="
+archive 2026-07-01
+archive 2026-07-02
+if offsite_sync >/dev/null 2>&1; then
+    ok "offsite_sync succeeds"
+else
+    bad "offsite_sync succeeds (returned non-zero)"
+fi
+if [ -f "$REMOTE/homebrain_backup_2026-07-01.tar.gz.gpg" ] &&
+   [ -f "$REMOTE/homebrain_backup_2026-07-02.tar.gz.gpg" ]; then
+    ok "both archives copied"
+else
+    bad "both archives copied (missing on remote)"
+fi
+
+echo "== a local wipe does NOT delete the remote copy =="
+# The regression. Under `sync` the remote emptied out with the local drive.
+rm -f "$TMP"/local/*.tar.gz.gpg
+if offsite_sync >/dev/null 2>&1; then
+    ok "offsite_sync succeeds after local wipe"
+else
+    bad "offsite_sync succeeds after local wipe (returned non-zero)"
+fi
+remaining=$(find "$REMOTE" -name '*.tar.gz.gpg' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$remaining" = "2" ]; then
+    ok "remote still holds both archives after the local drive emptied"
+else
+    bad "remote still holds both archives (found $remaining, expected 2)"
+fi
+
+echo "== age-based retention prunes the remote =="
+# Backdate one remote archive past the window; it should go, the other stay.
+touch -d '200 days ago' "$REMOTE/homebrain_backup_2026-07-01.tar.gz.gpg" 2>/dev/null \
+    || touch -A -2000000 "$REMOTE/homebrain_backup_2026-07-01.tar.gz.gpg" 2>/dev/null
+archive 2026-07-03
+OFFSITE_KEEP_DAYS=90 offsite_sync >/dev/null 2>&1
+if [ ! -f "$REMOTE/homebrain_backup_2026-07-01.tar.gz.gpg" ]; then
+    ok "archive older than OFFSITE_KEEP_DAYS pruned"
+else
+    bad "archive older than OFFSITE_KEEP_DAYS pruned (still present)"
+fi
+if [ -f "$REMOTE/homebrain_backup_2026-07-02.tar.gz.gpg" ]; then
+    ok "archive inside the window kept"
+else
+    bad "archive inside the window kept (was deleted)"
+fi
+
+echo "== retention ignores files HomeBrain did not put there =="
+echo "someone elses data" > "$REMOTE/not-ours.txt"
+touch -d '200 days ago' "$REMOTE/not-ours.txt" 2>/dev/null \
+    || touch -A -2000000 "$REMOTE/not-ours.txt" 2>/dev/null
+OFFSITE_KEEP_DAYS=90 offsite_sync >/dev/null 2>&1
+if [ -f "$REMOTE/not-ours.txt" ]; then
+    ok "unrelated remote file untouched by retention"
+else
+    bad "unrelated remote file untouched by retention (deleted it)"
+fi
+
+echo "== offsite_sync no longer uses a deletion-mirroring sync =="
+if grep -qE '^\s*rclone sync ' "$COMMON"; then
+    bad "common.sh has an rclone sync again"
+else
+    ok "common.sh uses copy, not sync"
+fi
+
+echo
+echo "passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ]

--- a/scripts/tests/test_backup_retention.sh
+++ b/scripts/tests/test_backup_retention.sh
@@ -217,6 +217,32 @@ else
     ok "restore.sh parses flags positionally-independently"
 fi
 
+echo "== offsite_mirror serialises, so a resume can't race a running mirror =="
+# homebrain-offsite.timer fires hourly and on boot. Without the lock, a firing
+# during a multi-hour upload would start a second concurrent mirror.
+export OFFSITE_LOCK_FILE="$TMP/offsite.lock"
+export OFFSITE_STATE_FILE="$TMP/offsite.json"
+if ( offsite_mirror ) >/dev/null 2>&1; then
+    ok "offsite_mirror succeeds when the lock is free"
+else
+    bad "offsite_mirror succeeds when the lock is free"
+fi
+if grep -q '"ok": true' "$OFFSITE_STATE_FILE" 2>/dev/null; then
+    ok "records success in the state file the health check reads"
+else
+    bad "records success in the state file the health check reads"
+fi
+# Hold the lock the way a long upload does, then fire again.
+( exec 202>"$OFFSITE_LOCK_FILE"; flock -n 202 || exit 1; sleep 4 ) &
+HOLDER=$!
+sleep 1
+if ( offsite_mirror ) 2>&1 | grep -q "already running"; then
+    ok "a second mirror stands down while one holds the lock"
+else
+    bad "a second mirror stands down while one holds the lock"
+fi
+wait "$HOLDER" 2>/dev/null
+
 echo "== offsite_sync no longer uses a deletion-mirroring sync =="
 if grep -qE '^\s*rclone sync ' "$COMMON"; then
     bad "common.sh has an rclone sync again"

--- a/scripts/tests/test_backup_retention.sh
+++ b/scripts/tests/test_backup_retention.sh
@@ -164,6 +164,59 @@ else
     bad "unrelated remote file untouched by retention (deleted it)"
 fi
 
+echo "== the off-site copy can be listed and fetched back =="
+# The gap this closes: rclone pushed and nothing pulled, so the one scenario
+# off-site backups exist for (local drive dead) needed a shell.
+listing="$(offsite_list 2>/dev/null)"
+if echo "$listing" | grep -q 'homebrain_backup_2026-07-02.tar.gz.gpg'; then
+    ok "offsite_list reports a remote archive"
+else
+    bad "offsite_list reports a remote archive (got: ${listing:0:120})"
+fi
+if echo "$listing" | grep -q 'not-ours.txt'; then
+    bad "offsite_list excludes foreign files (it listed one)"
+else
+    ok "offsite_list excludes foreign files"
+fi
+
+# Local drive dead: wipe local, fetch one named archive back, compare content.
+rm -f "$TMP"/local/*.tar.gz.gpg
+if offsite_fetch "homebrain_backup_2026-07-02.tar.gz.gpg" "$TMP/local" >/dev/null 2>&1; then
+    ok "offsite_fetch succeeds"
+else
+    bad "offsite_fetch succeeds (returned non-zero)"
+fi
+if [ "$(cat "$TMP/local/homebrain_backup_2026-07-02.tar.gz.gpg" 2>/dev/null)" = "payload-2026-07-02" ]; then
+    ok "fetched archive is byte-identical to what was backed up"
+else
+    bad "fetched archive is byte-identical to what was backed up"
+fi
+# Exactly one archive, not the whole remote.
+fetched=$(find "$TMP/local" -name '*.tar.gz.gpg' | wc -l | tr -d ' ')
+if [ "$fetched" = "1" ]; then
+    ok "fetch pulls only the named archive"
+else
+    bad "fetch pulls only the named archive (got $fetched)"
+fi
+
+if [ "$(offsite_size 'homebrain_backup_2026-07-02.tar.gz.gpg' 2>/dev/null)" = "19" ]; then
+    ok "offsite_size reports the remote byte count"
+else
+    bad "offsite_size reports the remote byte count (got '$(offsite_size 'homebrain_backup_2026-07-02.tar.gz.gpg' 2>/dev/null)', expected 19)"
+fi
+
+echo "== restore.sh accepts --from-offsite in any argument order =="
+if grep -q -- '--from-offsite' "$SCRIPT_DIR/../restore.sh"; then
+    ok "restore.sh handles --from-offsite"
+else
+    bad "restore.sh handles --from-offsite (flag not found)"
+fi
+if grep -q 'ARG_FLAG' "$SCRIPT_DIR/../restore.sh"; then
+    bad "restore.sh still matches --no-prompt positionally as \$2"
+else
+    ok "restore.sh parses flags positionally-independently"
+fi
+
 echo "== offsite_sync no longer uses a deletion-mirroring sync =="
 if grep -qE '^\s*rclone sync ' "$COMMON"; then
     bad "common.sh has an rclone sync again"

--- a/scripts/tests/test_restore_internal.sh
+++ b/scripts/tests/test_restore_internal.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Regression tests for common.sh:ensure_backup_dir — the shared mount guard for
+# backup.sh and restore.sh.
+#
+# The bug this pins: restore.sh carried its own copy of the guard and never
+# learned about BACKUP_INTERNAL (no-drive mode, added in #123). On a box with
+# no backup drive the dashboard listed archives correctly and every restore
+# died at "Backup drive not mounted." Back up, never restore.
+#
+# Same convention as test_update_guard.sh: the logic lives in common.sh so it
+# can be exercised with no Docker, no network and no root.
+#
+#   bash scripts/tests/test_restore_internal.sh
+#
+# Exit status: 0 if every case passes, 1 otherwise.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON="$SCRIPT_DIR/../common.sh"
+
+# shellcheck source=../common.sh disable=SC1091
+source "$COMMON" 2>/dev/null
+
+pass=0
+fail=0
+ok()  { printf '  ok    %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf '  FAIL  %s\n' "$1"; fail=$((fail + 1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "== BACKUP_INTERNAL=true: no mountpoint required =="
+
+# The regression. A path on the root disk that is not a mountpoint must be
+# accepted, and created if absent.
+target="$TMP/internal/backups"
+if ( BACKUP_INTERNAL=true BACKUP_MOUNTDIR="$target" ensure_backup_dir ) 2>/dev/null; then
+    ok "accepts a non-mountpoint path"
+else
+    bad "accepts a non-mountpoint path (expected success)"
+fi
+if [ -d "$target" ]; then
+    ok "creates the directory when absent"
+else
+    bad "creates the directory when absent (not created)"
+fi
+
+# Idempotent: a second call on an existing directory is still fine.
+if ( BACKUP_INTERNAL=true BACKUP_MOUNTDIR="$target" ensure_backup_dir ) 2>/dev/null; then
+    ok "idempotent on an existing directory"
+else
+    bad "idempotent on an existing directory (expected success)"
+fi
+
+# An uncreatable path must fail loudly rather than let the caller write into
+# nowhere. Skipped as root, which can create anything.
+if [ "$(id -u)" -eq 0 ]; then
+    printf '  skip  fails when the directory cannot be created (running as root)\n'
+else
+    blocked="$TMP/blocked"
+    mkdir -p "$blocked"
+    chmod 500 "$blocked"
+    if ( BACKUP_INTERNAL=true BACKUP_MOUNTDIR="$blocked/sub" ensure_backup_dir ) 2>/dev/null; then
+        bad "fails when the directory cannot be created (expected failure)"
+    else
+        ok "fails when the directory cannot be created"
+    fi
+    chmod 700 "$blocked"
+fi
+
+echo "== BACKUP_INTERNAL unset/false: mount check stays mandatory =="
+
+# The invariant the guard exists to protect: a drive that fell off must never
+# silently degrade into writing onto the root disk. An ordinary directory is
+# not a mountpoint and is not in fstab, so the mount attempt must fail.
+if ! command -v mountpoint >/dev/null 2>&1; then
+    printf '  skip  rejects a non-mountpoint (no mountpoint(8) on this host)\n'
+else
+    plain="$TMP/plain"
+    mkdir -p "$plain"
+    if ( BACKUP_MOUNTDIR="$plain" ensure_backup_dir ) >/dev/null 2>&1; then
+        bad "rejects a non-mountpoint when BACKUP_INTERNAL is unset (expected failure)"
+    else
+        ok "rejects a non-mountpoint when BACKUP_INTERNAL is unset"
+    fi
+    if ( BACKUP_INTERNAL=false BACKUP_MOUNTDIR="$plain" ensure_backup_dir ) >/dev/null 2>&1; then
+        bad "rejects a non-mountpoint when BACKUP_INTERNAL=false (expected failure)"
+    else
+        ok "rejects a non-mountpoint when BACKUP_INTERNAL=false"
+    fi
+fi
+
+echo "== both callers use the shared guard =="
+
+# Cheap structural check: if either script grows its own copy of the mount
+# logic again, this fails and points at why.
+for script in backup.sh restore.sh; do
+    if grep -q 'ensure_backup_dir' "$SCRIPT_DIR/../$script"; then
+        ok "$script calls ensure_backup_dir"
+    else
+        bad "$script calls ensure_backup_dir (not found)"
+    fi
+    if grep -q 'mountpoint -q "\$BACKUP_MOUNTDIR"' "$SCRIPT_DIR/../$script"; then
+        bad "$script has its own mount check again"
+    else
+        ok "$script has no private mount check"
+    fi
+done
+
+echo
+echo "passed: $pass   failed: $fail"
+[ "$fail" -eq 0 ]

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -270,7 +270,8 @@ install_python_venv_deps
 # This generalized block handles ALL service file updates (Gunicorn, Venv, or future changes).
 # It ensures the active systemd units match the repository versions exactly.
 UNITS_CHANGED=false
-for UNIT in homebrain-manager.service homebrain-health.service homebrain-health.timer; do
+for UNIT in homebrain-manager.service homebrain-health.service homebrain-health.timer \
+            homebrain-offsite.service homebrain-offsite.timer; do
     INSTALLED_SVC="/etc/systemd/system/$UNIT"
     REPO_SVC="$INSTALL_DIR/config/$UNIT"
 
@@ -297,6 +298,8 @@ fi
 # enable it (idempotent). smartmontools is a provision-time dep; install it
 # here once so pre-existing boxes get SMART monitoring too (best-effort).
 systemctl enable --now homebrain-health.timer 2>/dev/null || true
+# Same for the off-site resume timer on boxes provisioned before it existed.
+systemctl enable --now homebrain-offsite.timer 2>/dev/null || true
 command -v smartctl >/dev/null 2>&1 || apt-get install -y -qq smartmontools 2>/dev/null \
     || log_warn "smartmontools install failed — SMART monitoring disabled until next update."
 

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -2269,6 +2269,10 @@ case "${1:-}" in
         load_env
         offsite_list
         ;;
+    ensure_rclone)
+        ensure_rclone "$(jq -r '.rclone.version // empty' \
+            "${INSTALL_DIR}/config/versions.json" 2>/dev/null || echo "")"
+        ;;
     replica_enable)
         replica_target_enable
         ;;

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -2273,6 +2273,17 @@ case "${1:-}" in
         ensure_rclone "$(jq -r '.rclone.version // empty' \
             "${INSTALL_DIR}/config/versions.json" 2>/dev/null || echo "")"
         ;;
+    offsite_resume)
+        # Driven by homebrain-offsite.timer (on boot, then hourly). A reboot
+        # part-way through a multi-hour upload used to mean the archive was not
+        # retried until the NEXT scheduled backup — up to a week away on a
+        # weekly schedule, with the off-site copy silently stale in between.
+        # rclone copy is idempotent: when everything is already at the remote
+        # this is a listing and nothing more.
+        load_env
+        [[ "${OFFSITE_ENABLED:-false}" == "true" ]] || exit 0
+        offsite_mirror
+        ;;
     replica_enable)
         replica_target_enable
         ;;

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -2248,6 +2248,11 @@ case "${1:-}" in
     offsite_test)
         offsite_test
         ;;
+    offsite_list)
+        # Raw rclone lsjson on stdout for the dashboard's remote backup list.
+        load_env
+        offsite_list
+        ;;
     replica_enable)
         replica_target_enable
         ;;

--- a/scripts/utilities.sh
+++ b/scripts/utilities.sh
@@ -1467,8 +1467,24 @@ patch_openclaw_config() {
         # strictly validates the mcp section and rejects unknown keys
         # (`mcp: Invalid input`), which blocks the gateway from loading. The
         # top-level .approvals.* below is the native, schema-valid config.
-        .approvals.exec.enabled = true |
-        .approvals.exec.mode = "session" |
+        #
+        # tools.exec is the actual execution policy — NOT .approvals, which
+        # only routes approval prompts. HomeBrain promises the owner never
+        # needs a shell, so the agent must be able to run privileged commands
+        # unattended; "full" is the schema’s "trusted local operation" setting.
+        # A deliberate widening, but not a new capability: homebrain is in the
+        # docker group, which is already root-equivalent. See the trust-boundary
+        # note in AGENTS.md.
+        #
+        # Assign the whole object: .mode is a normalized selector that the
+        # validator REFUSES to see combined with .security/.ask ("cannot be
+        # combined"), and a stale granular key left behind by an older config
+        # would fail validation and stop the gateway loading.
+        .tools.exec = {"mode": "full"} |
+        # .approvals.* only controls where approval PROMPTS get delivered. With
+        # ask=off nothing ever prompts, so forwarding has nothing to forward.
+        .approvals.exec.enabled = false |
+        del(.approvals.exec.mode) |
         .approvals.plugin.enabled = true |
         .approvals.plugin.mode = "session" |
         .tools.media.audio.enabled = true |

--- a/src/app.py
+++ b/src/app.py
@@ -15,7 +15,7 @@ import tempfile
 import platform
 import requests
 import fcntl
-from datetime import timedelta
+from datetime import datetime, timedelta
 from flask import Flask, render_template, jsonify, request, Response, session, abort, stream_with_context
 import migration
 import integrations
@@ -1652,6 +1652,63 @@ def list_backups():
     return jsonify(backups)
 
 
+@app.route("/api/backups/offsite/list")
+@limiter.limit("10 per minute")
+def list_offsite_backups():
+    """Archives sitting on the off-site remote.
+
+    Without this the off-site copy is write-only from the dashboard's point of
+    view: rclone pushed, nothing listed it, and the one scenario it exists for
+    (local drive dead) needed a shell to recover from.
+    """
+    env = get_env_config()
+    if env.get("OFFSITE_ENABLED", "false") != "true":
+        return jsonify([])
+    try:
+        result = subprocess.run(
+            ["bash", SCRIPT_UTILITIES, "offsite_list"],
+            capture_output=True, text=True, timeout=60,
+        )
+    except subprocess.TimeoutExpired:
+        return jsonify({"error": "The off-site remote did not respond."}), 504
+    if result.returncode != 0:
+        return jsonify({"error": "Could not list the off-site remote."}), 502
+
+    epoch = backup_epoch()
+    out = []
+    try:
+        for entry in json.loads(result.stdout or "[]"):
+            name = entry.get("Name", "")
+            if not name.endswith((".tar.gz", ".tar.gz.gpg")):
+                continue
+            size = entry.get("Size", 0) / (1024 * 1024)
+            if "data_only" in name:
+                btype = "Data Only"
+            elif "_system_" in name:
+                btype = "System snapshot"
+            else:
+                btype = "Full System"
+            encrypted = name.endswith(".gpg")
+            # ModTime is RFC3339; compare against the rotation epoch the same
+            # way the local list does.
+            stale = False
+            if encrypted and epoch:
+                try:
+                    mod = datetime.fromisoformat(
+                        entry.get("ModTime", "").replace("Z", "+00:00"))
+                    stale = mod.timestamp() < epoch
+                except Exception:
+                    stale = False
+            out.append({"name": name, "size": f"{size:.2f} MB", "type": btype,
+                        "encrypted": encrypted, "needs_old_passphrase": stale,
+                        "remote": True})
+    except Exception as e:
+        logging.warning(f"Could not parse off-site listing: {e}")
+        return jsonify({"error": "Could not read the off-site listing."}), 502
+    out.sort(key=lambda x: x["name"], reverse=True)
+    return jsonify(out)
+
+
 @app.route("/api/restore", methods=["POST"])
 @limiter.limit("3 per minute")
 def trigger_restore():
@@ -1662,7 +1719,18 @@ def trigger_restore():
     if not filename or "/" in filename:
         return jsonify({"error": "Invalid filename"}), 400
 
-    full_path = os.path.join(backup_storage_dir(), filename)
+    source = (request.json.get("source") or "local").lower()
+    if source not in ("local", "offsite"):
+        return jsonify({"error": "Invalid source"}), 400
+
+    # For an off-site restore restore.sh fetches the archive itself and then
+    # runs the ordinary path, so the only difference here is what we hand it.
+    if source == "offsite":
+        target = filename
+        offsite_flag = " --from-offsite"
+    else:
+        target = os.path.join(backup_storage_dir(), filename)
+        offsite_flag = ""
 
     # Optional passphrase for encrypted archives made under a DIFFERENT master
     # password (pre-rotation or from another box). Passed via a root-only temp
@@ -1679,8 +1747,8 @@ def trigger_restore():
 
     # restore.sh handles auto-detection of content (HA vs NC vs DB)
     # Quote full path
-    cmd = f"{pass_env}bash {SCRIPT_RESTORE} {shlex.quote(full_path)} --no-prompt >> {LOG_FILES['restore']} 2>&1"
-    task_name = "System Restore"
+    cmd = f"{pass_env}bash {SCRIPT_RESTORE} {shlex.quote(target)} --no-prompt{offsite_flag} >> {LOG_FILES['restore']} 2>&1"
+    task_name = "Off-site Restore" if source == "offsite" else "System Restore"
 
     threading.Thread(
         target=run_background_task, args=(task_name, cmd, "restore")

--- a/src/app.py
+++ b/src/app.py
@@ -1527,12 +1527,19 @@ def backup_offsite():
         update_env_var("OFFSITE_PASS", password)
     update_env_var("OFFSITE_PATH", path)
 
-    if enabled and not shutil.which("rclone"):
+    if enabled:
+        # Not apt: Ubuntu ships rclone 1.60 (2022), which cannot chunk uploads
+        # to Nextcloud and so fails every multi-GB archive with a 413 from the
+        # receiving Apache — leaving an off-site copy that holds the small
+        # system snapshots and none of the user's files. ensure_rclone installs
+        # a pinned current build only when the present one is too old.
         try:
-            subprocess.run(
-                ["apt-get", "install", "-y", "rclone"],
-                check=True, capture_output=True, text=True, timeout=300,
+            r = subprocess.run(
+                ["bash", SCRIPT_UTILITIES, "ensure_rclone"],
+                capture_output=True, text=True, timeout=300,
             )
+            if r.returncode != 0 and not shutil.which("rclone"):
+                return jsonify({"error": "Could not install rclone"}), 500
         except Exception:
             return jsonify({"error": "Could not install rclone"}), 500
     return jsonify({"status": "success"})

--- a/src/app.py
+++ b/src/app.py
@@ -219,6 +219,27 @@ log_file = LOG_FILES["manager"]
 # --- Security: Factory Auth ---
 SECRET_KEY_FILE = f"{INSTALL_DIR}/.secret_key"
 
+
+def harden_env_file():
+    """Assert .env is root-only at every manager start.
+
+    It holds MASTER_PASSWORD, every service credential, the vault admin token
+    and the off-site password. On .58 it was found owned by `homebrain` — the
+    account the AI agent runs as — so reading the master password took nothing
+    more than `cat`. No code path in the tree explains that, so assert the end
+    state rather than hunt the cause. Mirrors common.sh:harden_env_file for the
+    bash side.
+    """
+    try:
+        if os.path.exists(ENV_FILE):
+            os.chown(ENV_FILE, 0, 0)
+            os.chmod(ENV_FILE, 0o600)
+    except Exception as e:
+        logging.warning(f"Could not harden {ENV_FILE}: {e}")
+
+
+harden_env_file()
+
 def load_persistent_secret_key():
     """Ensures sessions remain valid across service restarts."""
     try:

--- a/src/app.py
+++ b/src/app.py
@@ -1604,10 +1604,26 @@ def trigger_backup():
     return jsonify({"status": "started"})
 
 
+def backup_epoch():
+    """Epoch of the last master-password rotation, or 0.
+
+    Archives are encrypted with the master password as it was at backup time,
+    so anything older than this needs the PREVIOUS password. Written by
+    rotate_master_password.sh — which is also the recovery-phrase path, where
+    the user by definition no longer has that password.
+    """
+    try:
+        with open("/var/lib/homebrain/backup_epoch.json") as f:
+            return float(json.load(f).get("ts", 0))
+    except Exception:
+        return 0
+
+
 @app.route("/api/backups/list")
 def list_backups():
     backups = []
     storage = backup_storage_dir()
+    epoch = backup_epoch()
     if os.path.exists(storage):
         for f in os.listdir(storage):
             if f.endswith(".tar.gz") or f.endswith(".tar.gz.gpg"):
@@ -1621,9 +1637,15 @@ def list_backups():
                         btype = "System snapshot"
                     else:
                         btype = "Full System"
+                    encrypted = f.endswith(".gpg")
                     backups.append({"name": f, "size": f"{size:.2f} MB",
                                     "type": btype,
-                                    "encrypted": f.endswith(".gpg")})
+                                    "encrypted": encrypted,
+                                    # Only meaningful for encrypted archives:
+                                    # a plaintext one opens regardless.
+                                    "needs_old_passphrase": bool(
+                                        encrypted and epoch
+                                        and os.path.getmtime(path) < epoch)})
                 except:
                     pass
     backups.sort(key=lambda x: x["name"], reverse=True)
@@ -3928,6 +3950,7 @@ def custom_401(e):
       <div id="recovery-view" class="hidden">
         <h1>Recover Access</h1>
         <p class="hint">Enter your recovery phrase and choose a new master password. This resets access to the Dashboard, Nextcloud and Home Assistant — it cannot decrypt individual vault items.</p>
+        <p class="hint"><strong>About your existing backups:</strong> they are sealed with the master password that was in use when each one was made, so they will still need that old password to restore. A fresh backup is taken automatically under your new password as soon as the reset finishes.</p>
         <form id="rf" autocomplete="off">
           <label class="field-label" for="rec-phrase">Recovery phrase</label>
           <textarea id="rec-phrase" name="phrase" placeholder="six words separated by spaces" required autocomplete="off" spellcheck="false"></textarea>

--- a/src/static/dashboard.js
+++ b/src/static/dashboard.js
@@ -1975,10 +1975,26 @@ async function loadBackups() {
     try {
         const res = await fetch('/api/backups/list', { credentials: 'include' });
         const list = await res.json();
+
+        // Archives that exist only off-site — the drive-is-dead case. Fetched
+        // separately because the remote can be slow or down, and that must not
+        // stop the local list from rendering.
+        let remote = [];
+        try {
+            const rres = await fetch('/api/backups/offsite/list', { credentials: 'include' });
+            if (rres.ok) {
+                const rlist = await rres.json();
+                if (Array.isArray(rlist)) {
+                    const localNames = new Set(list.map(b => b.name));
+                    remote = rlist.filter(b => !localNames.has(b.name));
+                }
+            }
+        } catch (e) { /* off-site listing is best-effort */ }
+
         const sel = document.getElementById('backup-list');
         sel.innerHTML = '';
         backupIndex = {};
-        list.forEach(b => {
+        list.concat(remote).forEach(b => {
             backupIndex[b.name] = b;
             const opt = document.createElement('option');
             opt.value = b.name;
@@ -1986,7 +2002,8 @@ async function loadBackups() {
             // old password — say so in the list rather than letting the user
             // discover it at the passphrase prompt.
             const stale = b.needs_old_passphrase ? ' — needs previous password' : '';
-            opt.innerText = `${b.encrypted ? '🔒 ' : ''}${b.name} (${b.type}, ${b.size})${stale}`;
+            const where = b.remote ? '☁️ ' : '';
+            opt.innerText = `${where}${b.encrypted ? '🔒 ' : ''}${b.name} (${b.type}, ${b.size})${stale}`;
             sel.appendChild(opt);
         });
     } catch (e) { /* silent */ }
@@ -1995,14 +2012,18 @@ async function loadBackups() {
 async function confirmRestore() {
     const file = document.getElementById('backup-list').value;
     if (!file) return;
+    const isRemote = !!(backupIndex[file] && backupIndex[file].remote);
     if (!await hbConfirm({
         title: 'Restore this snapshot?',
         body: `All current data is wiped and replaced with ${file}.`,
-        detail: 'This cannot be undone.',
+        detail: isRemote
+            ? 'This archive lives only on your off-site remote. It is downloaded first, which can take a long time on a slow connection. This cannot be undone.'
+            : 'This cannot be undone.',
         confirm: 'Restore', danger: true, requireText: 'RESTORE',
     })) return;
 
     const payload = { filename: file };
+    if (isRemote) payload.source = 'offsite';
     if (backupIndex[file] && backupIndex[file].encrypted) {
         // Normally decrypts with the current master password. A passphrase is
         // only needed when the archive predates a password change — and we

--- a/src/static/dashboard.js
+++ b/src/static/dashboard.js
@@ -1982,7 +1982,11 @@ async function loadBackups() {
             backupIndex[b.name] = b;
             const opt = document.createElement('option');
             opt.value = b.name;
-            opt.innerText = `${b.encrypted ? '🔒 ' : ''}${b.name} (${b.type}, ${b.size})`;
+            // Archives made before the last master-password change need that
+            // old password — say so in the list rather than letting the user
+            // discover it at the passphrase prompt.
+            const stale = b.needs_old_passphrase ? ' — needs previous password' : '';
+            opt.innerText = `${b.encrypted ? '🔒 ' : ''}${b.name} (${b.type}, ${b.size})${stale}`;
             sel.appendChild(opt);
         });
     } catch (e) { /* silent */ }
@@ -2001,11 +2005,15 @@ async function confirmRestore() {
     const payload = { filename: file };
     if (backupIndex[file] && backupIndex[file].encrypted) {
         // Normally decrypts with the current master password. A passphrase is
-        // only needed when the archive predates a password change.
+        // only needed when the archive predates a password change — and we
+        // know which archives those are, so don't make the user guess.
+        const stale = backupIndex[file].needs_old_passphrase;
         const pw = await hbPrompt({
             title: 'Archive passphrase',
-            body: 'Leave this empty to use the current master password. Only enter a passphrase if this backup was made before a master-password change.',
-            label: 'Passphrase (optional)',
+            body: stale
+                ? 'This backup was made before your master password changed, so it needs the password that was in use back then — not your current one.'
+                : 'Leave this empty to use the current master password. Only enter a passphrase if this backup was made before a master-password change.',
+            label: stale ? 'Previous master password' : 'Passphrase (optional)',
             type: 'password',
             confirm: 'Restore',
             allowEmpty: true,


### PR DESCRIPTION
Implements Phase 5 of `docs/plans/PRODUCT_REVIEW_2026-07.md`. Every item verified on real hardware (.58) against the live off-site remote, not just in tests.

## Data-recovery integrity

- **Restore works on boxes with no backup drive.** `restore.sh` carried its own copy of the mount guard and never learned about `BACKUP_INTERNAL` (added in #123), so no-drive boxes could back up and could never restore. The guard now lives once in `common.sh:ensure_backup_dir`.
- **The off-site copy survives a local wipe.** `offsite_sync` used `rclone sync`, which mirrors deletions — a dead drive or the emergency prune erased the off-site copy on the next run. Now `copy` plus age-based remote retention (`OFFSITE_KEEP_DAYS`).
- **The emergency prune can't eat the last archive.** It previously deleted down to zero to free space for a backup not yet written, let alone verified.
- **Restore from off-site, from the dashboard.** rclone pushed and nothing pulled; the scenario off-site exists for needed a shell. `restore.sh --from-offsite` fetches the named archive and falls through to the ordinary path, refusing a fetch that won't fit.
- **Rotation stops orphaning backups.** Archives are sealed with the master password of the day, so a recovery-phrase reset — whose premise is that the password is forgotten — silently locked the whole backup history. The dashboard now marks which archives need the previous password, and a rotation takes a fresh backup.
- **An off-site copy interrupted by a reboot resumes** within the hour instead of waiting for the next scheduled backup.
- **The mirror no longer holds the backup lock**, which used to block backups and pre-update snapshots for the duration of a multi-hour upload.

## The bug that made off-site backups useless

Ubuntu ships rclone 1.60 (2022); Nextcloud chunked upload landed in 1.64. So a multi-GB archive went as one request and the receiving Apache rejected it with `413 Request Entity Too Large`, while small system snapshots passed. The off-site copy ended up holding everything **except** the user's files. This was the default path — `app.py` installed rclone with apt, and HomeBrain-to-HomeBrain replication targets Nextcloud by design.

Found on .58, whose remote held four system snapshots and no full archive. Fixed by pinning rclone 1.74.4 and installing it at point of use, so existing boxes get it too — the first version of this fix only ran when off-site settings were *saved*, which the affected boxes never do again.

## Agent trust boundary

`homebrain` is in the `docker` group and so has always been root-equivalent, yet had no sudoers rule — one container away from root while the documented path was closed. Now explicit: `tools.exec = {"mode": "full"}` and a `visudo`-validated NOPASSWD fragment, with the boundary documented in AGENTS.md.

Note `approvals.exec` is *not* a permission gate — it is approval-prompt forwarding (`session|targets|both`). The first attempt combined `mode` with `security`/`ask`, which `openclaw config validate` rejects; that config would have stopped the gateway loading on deploy.

`.env` is asserted `root:root 0600` — on .58 it was owned by `homebrain`, so the agent could read `MASTER_PASSWORD` with `cat`.

## Verification highlights

| | Result |
|---|---|
| off-site restore | fetched 68M from live WebDAV, decrypted, valid tar, 2788 entries |
| bare-metal | fresh box with its own master password imported the archive's instance keys and kept its own |
| deletion safety | old `sync` wiped the remote: `found 0, expected 2` |
| agent exec | agent turn ran `sudo -n id -un` unattended, returned `root` |
| chunked upload | `Update will use the chunked upload strategy` against real Nextcloud |
| lock | a backup now starts during a mirror; a second mirror stands down |

Three new test files, wired into CI (which gains rclone). `docs/DISASTER_RECOVERY.md` documents the bare-metal runbook.

## Known limitations

- Restoring directly from the setup wizard is unsupported — the wizard runs before a stack exists and the restore needs one. Recovery onto new hardware is install-then-overwrite.
- Unpacking into a genuinely fresh stack is unproven on real hardware; it is the same code path as the local restore, which is verified.
- Off-site resume is per-file, not per-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)