### PR TITLE
fix(update): apply the agent sudoers rule on update, not just provision

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -300,6 +300,14 @@ fi
 systemctl enable --now homebrain-health.timer 2>/dev/null || true
 # Same for the off-site resume timer on boxes provisioned before it existed.
 systemctl enable --now homebrain-offsite.timer 2>/dev/null || true
+# Passwordless sudo for the agent. Only ensure_homebrain_user installs this,
+# and update.sh never calls it — it runs `docker compose up` directly rather
+# than deploy.sh. Without this an updated box gets the openclaw side of the
+# change (tools.exec=full, applied by refresh_openclaw above, so the agent
+# stops asking for approval) while sudo still demands a password — every
+# privileged command the agent tries then fails. Half-applied is worse than
+# either end state. Idempotent; validates with visudo before installing.
+ensure_homebrain_sudo || log_warn "Could not configure passwordless sudo for ${HOMEBRAIN_USER}."
 command -v smartctl >/dev/null 2>&1 || apt-get install -y -qq smartmontools 2>/dev/null \
     || log_warn "smartmontools install failed — SMART monitoring disabled until next update."
 


### PR DESCRIPTION
Follow-up to #139, found while preparing the release.

`/etc/sudoers.d/homebrain` is installed only by `ensure_homebrain_user`, which `update.sh` never calls — it runs `docker compose up` directly rather than going through `deploy.sh`. An existing box updating to #139 would therefore get **half** the agent change:

- `refresh_openclaw` applies `tools.exec = full`, so the agent stops pausing for approval
- but `sudo` still demands a password, so every privileged command it then attempts fails with `sudo-rs: interactive authentication is required`

That is worse than either end state: the approval gate is gone and the capability it was gating never arrives.

Fixed by calling `ensure_homebrain_sudo` from the same idempotent catch-up block that enables the health and off-site timers for boxes provisioned before those existed.

## Verification on .58

Reproduced the update path exactly:

```
before -> fragment absent, "sudo-rs: interactive authentication is required"
after  -> /etc/sudoers.d/homebrain 0440 root:root, visudo -c parsed OK,
          agent sudo -> root
re-run -> rc=0, still parses (idempotent)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)