### PR TITLE
feat(dashboard): off-site status line + ☁️ marker fix, and three defects found reviewing it

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1144,9 +1144,15 @@ offsite_sync() {
     # Leading / anchors the patterns to the drive's top level and --max-depth
     # stops recursion — same scope as local retention's `find -maxdepth 1`.
     # Without both, archives inside subdirectories would get mirrored too.
+    # nextcloud_backup* is the legacy full-archive name, and backup.sh's local
+    # retention counts it in the same keep-N pool as homebrain_backup* — so it
+    # is a full backup here too. Leaving it out of this selection (and out of
+    # the prune below, as an earlier revision did) copies legacy archives
+    # off-site and then never prunes them: the remote grows without bound.
     local newest_full
     newest_full=$(find "$BACKUP_MOUNTDIR" -maxdepth 1 -type f \
-        -name 'homebrain_backup*.tar.gz*' ! -name 'homebrain_backup_system_*' \
+        \( -name 'homebrain_backup*.tar.gz*' -o -name 'nextcloud_backup*.tar.gz*' \) \
+        ! -name 'homebrain_backup_system_*' \
         -printf '%T@ %f\n' 2>/dev/null | sort -n | tail -1 | cut -d' ' -f2-)
     # --no-update-modtime: without it, a file that is still sitting locally
     # gets its remote ModTime silently bumped to "now" on every sync even
@@ -1160,14 +1166,22 @@ offsite_sync() {
     fi
     rclone copy "$BACKUP_MOUNTDIR" "$remote" --no-update-modtime \
         --max-depth 1 \
-        --include '/homebrain_backup_system_*.tar.gz*' \
-        --include '/nextcloud_backup*.tar.gz*' || return 1
+        --include '/homebrain_backup_system_*.tar.gz*' || return 1
 
     # Off-site only ever needs the latest full archive — restore.sh always
     # offers the newest available — so this prunes down to one instead of
     # tracking an age window (a superseded archive could otherwise sit
     # off-site, having cost upload bandwidth, until OFFSITE_KEEP_DAYS passed).
-    offsite_prune_full "$remote"
+    #
+    # Gated on there BEING a local full archive. With none, the copy above was
+    # a no-op and the newest remote archive is the only copy of the user's data
+    # left anywhere — pruning then would delete good older archives at exactly
+    # the moment the local drive is gone, i.e. a local failure propagating into
+    # a remote deletion. That is the class of bug the copy-not-sync rule above
+    # exists to prevent, and it must not sneak back in through retention.
+    if [[ -n "$newest_full" ]]; then
+        offsite_prune_full "$remote"
+    fi
 
     # Bound system snapshots on their own schedule instead of tracking local
     # state, so a local deletion can never propagate. Never touch anything on
@@ -1193,6 +1207,7 @@ offsite_prune_full() {
     listing=$(rclone lsjson "$remote" --files-only --max-depth 1 \
         --filter '- /homebrain_backup_system_*.tar.gz*' \
         --filter '+ /homebrain_backup*.tar.gz*' \
+        --filter '+ /nextcloud_backup*.tar.gz*' \
         --filter '- *' 2>/dev/null) || return 0
     jq -r 'sort_by(.ModTime) | reverse | .[1:][].Path' <<<"$listing" 2>/dev/null \
         | while IFS= read -r old; do
@@ -1268,6 +1283,16 @@ ensure_rclone() {
 
 OFFSITE_STATE_FILE="/var/lib/homebrain/offsite.json"
 OFFSITE_LOCK_FILE="/var/run/homebrain-offsite.lock"
+# Holds the PID of the running mirror, for readers that want to report "a
+# mirror is in progress" (the dashboard's Off-site status line).
+#
+# Deliberately NOT the lock file: probing that with a real flock means briefly
+# holding it, and a mirror starting in that window sees it taken, logs "already
+# running" and returns success — a silently skipped off-site copy caused by
+# looking at it. This file is only ever written by the mirror and read by
+# everyone else. Lives in /var/run (tmpfs), so a reboot mid-mirror clears it
+# instead of leaving a permanent phantom "syncing".
+OFFSITE_RUN_FILE="/var/run/homebrain-offsite.running"
 
 # Run the mirror under the off-site lock and record the outcome.
 #
@@ -1286,12 +1311,15 @@ offsite_mirror() {
         return 0
     fi
     log_info "Mirroring backups off-site (${OFFSITE_TYPE:-unset})..."
+    printf '%d\n' "$$" > "$OFFSITE_RUN_FILE" 2>/dev/null || true
     if offsite_sync; then
+        rm -f "$OFFSITE_RUN_FILE" 2>/dev/null || true
         printf '{"ts": %d, "ok": true}\n' "$(date +%s)" > "${OFFSITE_STATE_FILE}.tmp" \
             && mv "${OFFSITE_STATE_FILE}.tmp" "$OFFSITE_STATE_FILE"
         log_info "Off-site mirror complete."
         return 0
     fi
+    rm -f "$OFFSITE_RUN_FILE" 2>/dev/null || true
     printf '{"ts": %d, "ok": false}\n' "$(date +%s)" > "${OFFSITE_STATE_FILE}.tmp" \
         && mv "${OFFSITE_STATE_FILE}.tmp" "$OFFSITE_STATE_FILE"
     log_warn "OFF-SITE COPY FAILED — the local backup is fine; check the off-site settings on the Backup page."

--- a/scripts/tests/test_backup_retention.sh
+++ b/scripts/tests/test_backup_retention.sh
@@ -290,6 +290,70 @@ else
     ok "common.sh uses copy, not sync"
 fi
 
+# ── Retention edge cases (these reshape the remote, so they run last) ───────
+
+echo "== legacy nextcloud_backup* archives are pruned like full backups =="
+# backup.sh's local retention counts nextcloud_backup* in the same keep-N pool
+# as homebrain_backup*, so off-site must treat it as a full backup too. An
+# earlier revision copied it off-site but excluded it from every prune path,
+# which grew the remote without bound.
+rm -f "$TMP"/local/*.tar.gz.gpg "$REMOTE"/*.tar.gz.gpg
+echo "payload-legacy" > "$TMP/local/nextcloud_backup_2026-06-01.tar.gz.gpg"
+offsite_sync >/dev/null 2>&1
+if [ -f "$REMOTE/nextcloud_backup_2026-06-01.tar.gz.gpg" ]; then
+    ok "legacy archive copied off-site"
+else
+    bad "legacy archive copied off-site (missing on remote)"
+fi
+sleep 1; echo "payload-2026-07-10" > "$TMP/local/homebrain_backup_2026-07-10.tar.gz.gpg"
+offsite_sync >/dev/null 2>&1
+if [ ! -f "$REMOTE/nextcloud_backup_2026-06-01.tar.gz.gpg" ]; then
+    ok "superseded legacy archive pruned (not left to grow forever)"
+else
+    bad "superseded legacy archive pruned (still on the remote)"
+fi
+
+echo "== a dead local drive never triggers a remote prune =="
+# The copy-not-sync rule exists so a local failure cannot propagate into a
+# remote deletion. Retention must not sneak that back in: with no local full
+# archive the newest remote one is the only copy of the user's data left, and
+# the older ones beside it are the only redundancy.
+cp "$TMP/local/homebrain_backup_2026-07-10.tar.gz.gpg" \
+   "$REMOTE/homebrain_backup_2026-07-09.tar.gz.gpg"
+before=$(find "$REMOTE" -name 'homebrain_backup_*.tar.gz.gpg' | wc -l | tr -d ' ')
+rm -f "$TMP"/local/*.tar.gz.gpg          # the drive dies
+offsite_sync >/dev/null 2>&1
+after=$(find "$REMOTE" -name 'homebrain_backup_*.tar.gz.gpg' | wc -l | tr -d ' ')
+if [ "$before" = "$after" ] && [ "$after" -gt 1 ]; then
+    ok "no local full archive means no remote prune (kept $after)"
+else
+    bad "no local full archive means no remote prune (went $before -> $after)"
+fi
+
+echo "== the mirror publishes a run-file readers can poll without interfering =="
+# The dashboard's status line must never probe the mirror's LOCK: taking it,
+# even briefly, makes a mirror starting in that window see it held, log
+# "already running" and return success — displaying status would silently skip
+# an off-site copy. The mirror publishes its PID instead; readers only read.
+export OFFSITE_RUN_FILE="$TMP/offsite.running"
+rm -f "$OFFSITE_LOCK_FILE"
+if grep -q 'OFFSITE_RUN_FILE' "$COMMON"; then
+    ok "common.sh publishes a run-file"
+else
+    bad "common.sh publishes a run-file"
+fi
+( offsite_mirror ) >/dev/null 2>&1
+if [ ! -f "$OFFSITE_RUN_FILE" ]; then
+    ok "run-file cleared once the mirror finishes"
+else
+    bad "run-file cleared once the mirror finishes (left behind -> phantom 'syncing')"
+fi
+if grep -q 'homebrain-offsite.lock' "$SCRIPT_DIR/../../src/app.py" 2>/dev/null; then
+    bad "app.py still probes the mirror's lock file (can cancel a mirror)"
+else
+    ok "app.py does not touch the mirror's lock file"
+fi
+
 echo
 echo "passed: $pass   failed: $fail"
 [ "$fail" -eq 0 ]

--- a/src/app.py
+++ b/src/app.py
@@ -1645,6 +1645,49 @@ def backup_offsite_test():
     return jsonify({"status": "success"})
 
 
+def offsite_is_syncing():
+    """True if a mirror (scheduled, resumed, or just-triggered) currently
+    holds the off-site lock. Same lock file and non-blocking-flock semantics
+    as common.sh:offsite_mirror, so this can never disagree with what
+    actually has the remote busy.
+    """
+    try:
+        with open("/var/run/homebrain-offsite.lock", "a") as f:
+            try:
+                fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                fcntl.flock(f, fcntl.LOCK_UN)
+                return False
+            except OSError:
+                return True
+    except OSError:
+        return False
+
+
+@app.route("/api/backup/offsite/status")
+@limiter.limit("30 per minute")
+def backup_offsite_status():
+    """Last-mirror outcome + whether one is running right now, for the
+    dashboard's Off-site Copy status line. Cheap: a lock probe and a read of
+    the small state file offsite_mirror already writes on every run — no
+    rclone invocation, so this is safe to poll.
+    """
+    env = get_env_config()
+    if env.get("OFFSITE_ENABLED", "false") != "true":
+        return jsonify({"configured": False})
+    state = {}
+    try:
+        with open("/var/lib/homebrain/offsite.json") as f:
+            state = json.load(f)
+    except (OSError, ValueError):
+        pass
+    return jsonify({
+        "configured": True,
+        "syncing": offsite_is_syncing(),
+        "last_sync_ts": state.get("ts"),
+        "last_sync_ok": state.get("ok"),
+    })
+
+
 @app.route("/api/backup/replica", methods=["GET", "POST"])
 @limiter.limit("10 per minute")
 def backup_replica():

--- a/src/app.py
+++ b/src/app.py
@@ -1646,21 +1646,25 @@ def backup_offsite_test():
 
 
 def offsite_is_syncing():
-    """True if a mirror (scheduled, resumed, or just-triggered) currently
-    holds the off-site lock. Same lock file and non-blocking-flock semantics
-    as common.sh:offsite_mirror, so this can never disagree with what
-    actually has the remote busy.
+    """True if a mirror (scheduled, resumed, or just-triggered) is running.
+
+    Reads the PID file common.sh:offsite_mirror publishes. Deliberately does
+    NOT probe the mirror's lock file: testing that with a real flock means
+    briefly holding it, and a mirror starting inside that window would find it
+    taken, log "already running" and return success — the act of displaying
+    status would silently skip an off-site copy. Read-only here, so a status
+    poll can never influence a backup.
+
+    The PID is checked for liveness because a killed mirror cannot clean up
+    after itself. Its /var/run home is tmpfs, so a reboot mid-mirror clears
+    the file rather than leaving a permanent phantom "syncing".
     """
     try:
-        with open("/var/run/homebrain-offsite.lock", "a") as f:
-            try:
-                fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                fcntl.flock(f, fcntl.LOCK_UN)
-                return False
-            except OSError:
-                return True
-    except OSError:
+        with open("/var/run/homebrain-offsite.running") as f:
+            pid = int(f.read().strip())
+    except (OSError, ValueError):
         return False
+    return os.path.isdir(f"/proc/{pid}")
 
 
 @app.route("/api/backup/offsite/status")

--- a/src/static/dashboard.js
+++ b/src/static/dashboard.js
@@ -302,6 +302,7 @@ const POLLERS = [
     [connRefresh, 15000],
     [channelRefresh, 15000],
     [pollLogsIfVisible, 3000],
+    [pollOffsiteStatusIfVisible, 15000],
 ];
 let pollTimers = [];
 
@@ -339,6 +340,7 @@ function openTab(id) {
         loadBackups();
         loadBackupConfig();
         loadOffsiteConfig();
+        loadOffsiteStatus();
         loadReplicaStatus();
         loadDiskStats();
         loadOpenClawBackupStatus();
@@ -1855,6 +1857,36 @@ async function loadOffsiteConfig() {
     } catch (e) { /* silent */ }
 }
 
+async function loadOffsiteStatus() {
+    const el = document.getElementById('os-sync-status');
+    if (!el) return;
+    try {
+        const res = await fetch('/api/backup/offsite/status', { credentials: 'include' });
+        const d = await res.json();
+        if (!d.configured) { el.style.display = 'none'; return; }
+        el.style.display = '';
+        el.style.color = '';
+        if (d.syncing) {
+            el.innerText = '🔄 Off-site sync in progress…';
+        } else if (d.last_sync_ts) {
+            const when = new Date(d.last_sync_ts * 1000).toLocaleString();
+            if (d.last_sync_ok) {
+                el.innerText = `✅ Last synced ${when}`;
+            } else {
+                el.style.color = 'var(--danger)';
+                el.innerText = `⚠️ Last sync failed (${when}) — check the backup log`;
+            }
+        } else {
+            el.innerText = 'Not yet synced.';
+        }
+    } catch (e) { el.style.display = 'none'; }
+}
+
+function pollOffsiteStatusIfVisible() {
+    const backupTab = document.getElementById('backup');
+    if (backupTab && backupTab.classList.contains('active')) loadOffsiteStatus();
+}
+
 function updateOffsiteUI() {
     const labels = {
         sftp:   ['Host (host or host:port)', 'backup.example.com', 'Username', 'Password'],
@@ -1976,18 +2008,25 @@ async function loadBackups() {
     try {
         const res = await fetch('/api/backups/list', { credentials: 'include' });
         const list = await res.json();
+        const localNames = new Set(list.map(b => b.name));
 
-        // Archives that exist only off-site — the drive-is-dead case. Fetched
-        // separately because the remote can be slow or down, and that must not
-        // stop the local list from rendering.
-        let remote = [];
+        // Archives on the off-site remote. Fetched separately because the
+        // remote can be slow or down, and that must not stop the local list
+        // from rendering. An archive already present locally is annotated
+        // with offsite:true rather than skipped — the ☁️ marker below means
+        // "this is off-site protected", not just "not on this drive". The
+        // `remote` flag keeps its narrower original meaning (no local copy,
+        // so restoring it means a download first) for confirmRestore below.
+        let offsiteOnly = [];
         try {
             const rres = await fetch('/api/backups/offsite/list', { credentials: 'include' });
             if (rres.ok) {
                 const rlist = await rres.json();
                 if (Array.isArray(rlist)) {
-                    const localNames = new Set(list.map(b => b.name));
-                    remote = rlist.filter(b => !localNames.has(b.name));
+                    const offsiteNames = new Set(rlist.map(b => b.name));
+                    list.forEach(b => { b.offsite = offsiteNames.has(b.name); });
+                    offsiteOnly = rlist.filter(b => !localNames.has(b.name))
+                        .map(b => ({ ...b, remote: true, offsite: true }));
                 }
             }
         } catch (e) { /* off-site listing is best-effort */ }
@@ -1995,7 +2034,7 @@ async function loadBackups() {
         const sel = document.getElementById('backup-list');
         sel.innerHTML = '';
         backupIndex = {};
-        list.concat(remote).forEach(b => {
+        list.concat(offsiteOnly).forEach(b => {
             backupIndex[b.name] = b;
             const opt = document.createElement('option');
             opt.value = b.name;
@@ -2003,7 +2042,7 @@ async function loadBackups() {
             // old password — say so in the list rather than letting the user
             // discover it at the passphrase prompt.
             const stale = b.needs_old_passphrase ? ' — needs previous password' : '';
-            const where = b.remote ? '☁️ ' : '';
+            const where = b.offsite ? '☁️ ' : '';
             opt.innerText = `${where}${b.encrypted ? '🔒 ' : ''}${b.name} (${b.type}, ${b.size})${stale}`;
             sel.appendChild(opt);
         });

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -233,6 +233,7 @@
             <section class="section">
                 <h3>Off-site Copy</h3>
                 <p class="lede">Mirror the encrypted archives to another machine or cloud storage after each backup.</p>
+                <p id="os-sync-status" class="small mono" style="display:none; margin-bottom:10px;"></p>
                 <form onsubmit="saveOffsiteConfig(event)">
                     <label class="check" style="margin-bottom:14px;">
                         <input type="checkbox" id="os-enabled">


### PR DESCRIPTION
## Summary

**Visibility (original scope)**
- Adds `GET /api/backup/offsite/status` → status line under **Off-site Copy**: syncing / last synced / last sync failed / not yet synced.
- Fixes `loadBackups()`: the off-site listing was filtered to names *not* already local before merging, so an archive present both locally and off-site — the common case for the newest full backup now that off-site keeps only the newest — rendered with **no** ☁️ marker, indistinguishable from a purely-local archive. Every entry now gets an `offsite` display flag, independent of the narrower `remote` flag `confirmRestore()` uses to pick the restore path.

**Three defects found reviewing the above and the merged #142.** Each has a regression test verified to fail on the pre-fix code.

1. **Legacy archives grew off-site without bound.** `nextcloud_backup*` is the legacy full-archive name; `backup.sh:451` counts it in the same keep-N pool as `homebrain_backup*`. #142 copied it off-site but excluded it from `newest_full` selection *and* from every prune path. Now treated as a full backup on both sides.
2. **A dead local drive could delete a remote archive.** #142 pruned unconditionally, so with no local full archive the copy was a no-op and the prune still deleted every remote archive but the newest — destroying redundancy at the one moment it matters. Exactly the local-failure-propagates-to-remote class the copy-not-sync rule exists to prevent, arriving via retention rather than via `sync`. Prune is now gated on a local full archive existing.
3. **Reading the status could cancel a backup.** `offsite_is_syncing()` took a real `LOCK_EX` on the mirror's own lock to test it; a mirror starting in that window would find it held, log "already running" and return **success** — a silently skipped off-site copy caused by displaying status. The mirror now publishes its PID to a run-file readers only read. It lives in `/var/run` (tmpfs) so a reboot mid-mirror clears it instead of leaving a phantom "syncing"; readers check PID liveness for the killed case.

## Test plan
- [x] 35/35 assertions in `test_backup_retention.sh` pass against a **live rclone remote** on `.58`
- [x] **Each new assertion proven non-vacuous** by reverting its fix and confirming failure: legacy archive left on the remote; remote going `2 -> 1` archives on local drive death; `app.py` touching the lock path
- [x] Status endpoint exercised through all four states on `.58` (not-configured / idle-ok / failed / syncing) against the real `.env` and backup set, via a throwaway gunicorn on an alternate port — live dashboard never touched, `.env` restored byte-for-byte
- [x] `loadBackups()` merge logic exercised under Node with the box's actual backup set (local-only / local+off-site / off-site-only)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)